### PR TITLE
Add local Gemma AI flow and topic suggestion subagent

### DIFF
--- a/beta/README.md
+++ b/beta/README.md
@@ -84,6 +84,35 @@ This launcher injects:
 - `M3E_AI_BASE_URL=https://api.deepseek.com`
 - `M3E_AI_MODEL=deepseek-chat`
 
+Concrete local Gemma setup (Ollama):
+
+1. Run installer script:
+
+```powershell
+pwsh -File scripts/beta/install-ollama-gemma3-4b.ps1
+```
+
+2. Create Bitwarden item (example name: `m3e-ollama-gemma`) and set:
+  - `password=ollama` (dummy key for OpenAI-compatible auth header)
+  - `provider=ollama`
+  - `transport=openai-compatible`
+  - `base_url=http://localhost:11434/v1`
+  - `model=gemma3:4b`
+
+3. Launch with AI:
+
+```powershell
+bw unlock
+$env:BW_SESSION = "<session>"
+pwsh -File scripts/beta/launch-with-ai.ps1 -BitwardenItem "m3e-ollama-gemma"
+```
+
+Or launch directly without Bitwarden:
+
+```bat
+scripts\beta\launch-with-local-gemma.bat
+```
+
 Environment variables:
 
 ```bash
@@ -134,6 +163,13 @@ Common AI API endpoints:
 
 - `GET /api/ai/status`
 - `POST /api/ai/subagent/linear-transform`
+- `POST /api/ai/subagent/topic-suggest`
+
+Trial feature in viewer:
+
+- Toolbar button: `AI topics`
+- Shortcut: `Ctrl/Cmd+Shift+T`
+- Behavior: calls `topic-suggest` and appends proposed related topics as child nodes of current selection
 
 Minimal request example:
 

--- a/beta/prompts/topic-agent/topic-suggest.txt
+++ b/beta/prompts/topic-agent/topic-suggest.txt
@@ -1,0 +1,9 @@
+You are a topic expansion assistant for M3E.
+Given a selected node, generate related discussion topics.
+Return strict JSON only with this exact shape:
+{"topics":["topic 1","topic 2","topic 3"]}
+Rules:
+- Use concise noun phrases in Japanese or English matching the input language.
+- Produce 3 to 6 topics.
+- Avoid duplicates and overly generic phrases.
+- Do not include markdown or explanations outside JSON.

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -17,6 +17,7 @@ const exitScopeBtn = document.getElementById("exit-scope");
 const addAliasBtn = document.getElementById("add-alias");
 const jumpTargetBtn = document.getElementById("jump-target");
 const toggleCollapseBtn = document.getElementById("toggle-collapse");
+const aiGenerateTopicsBtn = document.getElementById("ai-generate-topics");
 const deleteNodeBtn = document.getElementById("delete-node");
 const markReparentBtn = document.getElementById("mark-reparent");
 const applyReparentBtn = document.getElementById("apply-reparent");
@@ -1183,6 +1184,97 @@ async function requestLinearSubagentTransform(
     rawText: String(result.proposal?.result?.rawText || ""),
     usage: result.usage || undefined,
   };
+}
+
+async function requestTopicSuggestionsForSelectedNode(maxTopics = 5): Promise<string[]> {
+  if (!doc || !viewState.selectedNodeId) {
+    throw new Error("No node is selected.");
+  }
+  const selected = getNode(viewState.selectedNodeId);
+  const payload: AiSubagentRequest = {
+    documentId: LOCAL_DOC_ID,
+    scopeId: normalizedCurrentScopeId(),
+    mode: "proposal",
+    input: {
+      nodeText: selected.text,
+      nodeDetails: selected.details || "",
+      maxTopics,
+    },
+  };
+
+  const response = await fetch("/api/ai/subagent/topic-suggest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify(payload),
+  });
+  const result = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(String(result.error || "Topic suggestion request failed."));
+  }
+
+  const rawTopics = result.proposal?.result?.topics;
+  if (!Array.isArray(rawTopics)) {
+    return [];
+  }
+  return rawTopics
+    .map((value) => String(value || "").trim())
+    .filter((value) => value.length > 0)
+    .slice(0, maxTopics);
+}
+
+function appendTopicSuggestionsToSelectedNode(topics: string[]): number {
+  if (!doc || !viewState.selectedNodeId || topics.length === 0) {
+    return 0;
+  }
+  const parent = getNode(viewState.selectedNodeId);
+  if (isAliasNode(parent)) {
+    throw new Error("Alias nodes cannot own children.");
+  }
+
+  const existingLabels = new Set(
+    (parent.children || [])
+      .map((childId) => doc!.state.nodes[childId]?.text?.trim().toLowerCase())
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  const normalized = topics
+    .map((topic) => topic.trim())
+    .filter((topic) => topic.length > 0)
+    .filter((topic) => !existingLabels.has(topic.toLowerCase()));
+  if (normalized.length === 0) {
+    return 0;
+  }
+
+  pushUndoSnapshot();
+  normalized.forEach((topic) => {
+    const id = newId();
+    doc!.state.nodes[id] = createNodeRecord(id, parent.id, topic);
+    parent.children.push(id);
+  });
+  viewState.collapsedIds.delete(parent.id);
+  parent.collapsed = false;
+  touchDocument();
+  return normalized.length;
+}
+
+async function generateRelatedTopicsForSelectedNode(): Promise<void> {
+  if (!doc || !viewState.selectedNodeId) {
+    setStatus("Select a node first.", true);
+    return;
+  }
+  try {
+    const topics = await requestTopicSuggestionsForSelectedNode(5);
+    const added = appendTopicSuggestionsToSelectedNode(topics);
+    if (added === 0) {
+      setStatus("No new related topics were suggested.");
+      return;
+    }
+    setStatus(`AI suggested ${added} related topic(s).`);
+    render();
+    board.focus();
+  } catch (err) {
+    setStatus(`AI topic suggestion failed (${(err as Error).message}).`, true);
+  }
 }
 
 function linearOffsetToLineIndex(text: string, offset: number): number {
@@ -3565,6 +3657,11 @@ toggleCollapseBtn?.addEventListener("click", () => {
   toggleCollapse();
 });
 
+aiGenerateTopicsBtn?.addEventListener("click", () => {
+  if (!doc) return;
+  void generateRelatedTopicsForSelectedNode();
+});
+
 deleteNodeBtn?.addEventListener("click", () => {
   if (!doc) return;
   deleteSelected();
@@ -3890,6 +3987,12 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
       setThinkingMode("deep");
       return;
     }
+  }
+
+  if ((event.ctrlKey || event.metaKey) && event.shiftKey && !event.altKey && event.key.toLowerCase() === "t") {
+    event.preventDefault();
+    void generateRelatedTopicsForSelectedNode();
+    return;
   }
 
   if ((event.ctrlKey || event.metaKey) && event.key === "]") {

--- a/beta/src/node/ai_infra.ts
+++ b/beta/src/node/ai_infra.ts
@@ -10,6 +10,13 @@ export interface AiProviderConfig {
   mcpServerCommand: string | null;
 }
 
+function isLocalBaseUrl(url: string | null): boolean {
+  if (!url) {
+    return false;
+  }
+  return url.includes("localhost") || url.includes("127.0.0.1");
+}
+
 function pickEnv(primary: string, legacy?: string): string | null {
   const value = process.env[primary]?.trim();
   if (value) {
@@ -27,13 +34,19 @@ export function loadAiProviderConfigFromEnv(): AiProviderConfig {
     ? "mcp"
     : "openai-compatible";
 
+  const provider = pickEnv("M3E_AI_PROVIDER", "M3E_LINEAR_AGENT_PROVIDER") || "deepseek";
+  const baseUrl = pickEnv("M3E_AI_BASE_URL", "M3E_LINEAR_AGENT_BASE_URL");
+  const apiKey = pickEnv("M3E_AI_API_KEY", "M3E_LINEAR_AGENT_API_KEY");
+  const model = pickEnv("M3E_AI_MODEL", "M3E_LINEAR_AGENT_MODEL");
+  const effectiveApiKey = apiKey || ((provider === "ollama" || isLocalBaseUrl(baseUrl)) ? "ollama" : null);
+
   return {
     enabled: (pickEnv("M3E_AI_ENABLED", "M3E_LINEAR_AGENT_ENABLED") || "") === "1",
-    provider: pickEnv("M3E_AI_PROVIDER", "M3E_LINEAR_AGENT_PROVIDER") || "deepseek",
+    provider,
     transport,
-    baseUrl: pickEnv("M3E_AI_BASE_URL", "M3E_LINEAR_AGENT_BASE_URL"),
-    apiKey: pickEnv("M3E_AI_API_KEY", "M3E_LINEAR_AGENT_API_KEY"),
-    model: pickEnv("M3E_AI_MODEL", "M3E_LINEAR_AGENT_MODEL"),
+    baseUrl,
+    apiKey: effectiveApiKey,
+    model,
     mcpServerCommand: pickEnv("M3E_AI_MCP_SERVER", "M3E_LINEAR_AGENT_MCP_SERVER"),
   };
 }

--- a/beta/src/node/ai_subagent.ts
+++ b/beta/src/node/ai_subagent.ts
@@ -1,5 +1,7 @@
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
 import { loadAiProviderConfigFromEnv } from "./ai_infra";
+import fs from "fs";
+import path from "path";
 import type {
   AiStatusResponse,
   AiSubagentRequest,
@@ -7,10 +9,49 @@ import type {
   LinearTransformRequest,
 } from "../shared/types";
 
-type SupportedSubagent = "linear-transform";
+type SupportedSubagent = "linear-transform" | "topic-suggest";
+
+interface ChatCompletionResponse {
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  choices?: Array<{
+    message?: {
+      content?: string | Array<{ type?: string; text?: string }>;
+    };
+  }>;
+  error?: {
+    message?: string;
+  };
+}
+
+const DEFAULT_TOPIC_PROMPT = [
+  "You generate related subtopics for the selected M3E node.",
+  "Return strict JSON only in this shape: {\"topics\":[\"...\"]}.",
+  "Use concise noun phrases, avoid duplicates, and propose 3-6 topics.",
+].join(" ");
+
+function readTextFileIfExists(filePath: string | undefined): string | null {
+  if (!filePath) {
+    return null;
+  }
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    return null;
+  }
+  return fs.readFileSync(resolved, "utf8").trim();
+}
+
+function topicSuggestPrompt(): string {
+  return readTextFileIfExists(process.env.M3E_TOPIC_SUGGEST_PROMPT_FILE)
+    ?? process.env.M3E_TOPIC_SUGGEST_PROMPT?.trim()
+    ?? DEFAULT_TOPIC_PROMPT;
+}
 
 function isSupportedSubagent(name: string): name is SupportedSubagent {
-  return name === "linear-transform";
+  return name === "linear-transform" || name === "topic-suggest";
 }
 
 export function getAiStatus(): AiStatusResponse {
@@ -38,6 +79,10 @@ export function getAiStatus(): AiStatusResponse {
         available: linear.enabled && linear.configured,
         promptConfigured: linear.promptConfigured,
       },
+      "topic-suggest": {
+        available: ai.enabled && configured,
+        promptConfigured: true,
+      },
     },
   };
 }
@@ -62,6 +107,115 @@ function normalizeLinearTransformInput(request: AiSubagentRequest): LinearTransf
     scopeRootId: request.scopeId,
     scopeLabel: typeof input.scopeLabel === "string" ? input.scopeLabel : null,
     instruction: typeof input.instruction === "string" ? input.instruction : null,
+  };
+}
+
+function extractTextContent(payload: ChatCompletionResponse): string {
+  const content = payload.choices?.[0]?.message?.content;
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => item.text || "")
+      .join("")
+      .trim();
+  }
+  if (payload.error?.message) {
+    throw new Error(payload.error.message);
+  }
+  throw new Error("Subagent returned no text content.");
+}
+
+function parseTopicsFromModelText(rawText: string): string[] {
+  const trimmed = rawText.trim();
+  if (!trimmed) {
+    return [];
+  }
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Accept simple bullet/list fallback when provider ignores JSON instruction.
+    return trimmed
+      .split(/\r?\n/)
+      .map((line) => line.replace(/^[-*0-9.\s]+/, "").trim())
+      .filter((line) => line.length > 0)
+      .slice(0, 8);
+  }
+  const topics = (parsed as { topics?: unknown[] })?.topics;
+  if (!Array.isArray(topics)) {
+    return [];
+  }
+  return topics
+    .map((item) => String(item || "").trim())
+    .filter((item) => item.length > 0)
+    .slice(0, 8);
+}
+
+async function runTopicSuggestSubagent(
+  request: AiSubagentRequest,
+): Promise<{ topics: string[]; rawText: string; model: string; provider: string; usage?: AiSubagentSuccessResponse["usage"] }> {
+  const ai = loadAiProviderConfigFromEnv();
+  if (!ai.enabled) {
+    throw new Error("AI infrastructure is disabled.");
+  }
+  if (ai.transport === "mcp") {
+    throw new Error("MCP transport is not implemented yet.");
+  }
+  if (!ai.baseUrl || !ai.apiKey || !ai.model) {
+    throw new Error("Topic suggestion subagent is not fully configured.");
+  }
+
+  const nodeText = requireString(request.input.nodeText, "AI_INPUT_NODE_TEXT_REQUIRED");
+  const nodeDetails = typeof request.input.nodeDetails === "string" ? request.input.nodeDetails : "";
+  const maxTopicsRaw = Number(request.input.maxTopics);
+  const maxTopics = Number.isFinite(maxTopicsRaw) && maxTopicsRaw > 0
+    ? Math.min(8, Math.max(1, Math.floor(maxTopicsRaw)))
+    : 5;
+
+  const userPrompt = [
+    "Topic generation request:",
+    `DocumentId: ${request.documentId}`,
+    `ScopeId: ${request.scopeId}`,
+    `NodeText: ${nodeText}`,
+    `NodeDetails: ${nodeDetails || "(none)"}`,
+    `MaxTopics: ${maxTopics}`,
+    "Return JSON only.",
+  ].join("\n");
+
+  const response = await fetch(`${ai.baseUrl.replace(/\/+$/, "")}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      Authorization: `Bearer ${ai.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: ai.model,
+      messages: [
+        { role: "system", content: topicSuggestPrompt() },
+        { role: "user", content: userPrompt },
+      ],
+      temperature: 0.5,
+    }),
+  });
+
+  const payload = await response.json() as ChatCompletionResponse;
+  if (!response.ok) {
+    throw new Error(payload.error?.message || `Subagent request failed with status ${response.status}.`);
+  }
+
+  const rawText = extractTextContent(payload);
+  return {
+    topics: parseTopicsFromModelText(rawText).slice(0, maxTopics),
+    rawText,
+    model: ai.model,
+    provider: ai.provider || "deepseek",
+    usage: payload.usage ? {
+      inputTokens: payload.usage.prompt_tokens,
+      outputTokens: payload.usage.completion_tokens,
+      totalTokens: payload.usage.total_tokens,
+    } : undefined,
   };
 }
 
@@ -103,6 +257,33 @@ export async function runAiSubagent(
         result: {
           direction: result.direction,
           outputText: result.outputText,
+          rawText: result.rawText,
+        },
+      },
+      usage: result.usage,
+      meta: {
+        scopeId: request.scopeId,
+        documentId: request.documentId,
+        latencyMs: Date.now() - startedAt,
+      },
+    };
+  }
+
+  if (subagent === "topic-suggest") {
+    const result = await runTopicSuggestSubagent(request);
+    return {
+      ok: true,
+      subagent,
+      provider: result.provider,
+      transport: loadAiProviderConfigFromEnv().transport,
+      model: result.model,
+      mode: request.mode === "direct-result" ? "direct-result" : "proposal",
+      requiresApproval: true,
+      proposal: {
+        kind: "topic-suggestions",
+        summary: "Generated related topics for the selected node.",
+        result: {
+          topics: result.topics,
           rawText: result.rawText,
         },
       },

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -490,6 +490,8 @@ function mapAiErrorToResponse(err: unknown): { status: number; code: string; mes
       return { status: 400, code: message, message: "input.direction must be tree-to-linear or linear-to-tree." };
     case "AI_INPUT_SOURCE_TEXT_REQUIRED":
       return { status: 400, code: message, message: "input.sourceText is required." };
+    case "AI_INPUT_NODE_TEXT_REQUIRED":
+      return { status: 400, code: message, message: "input.nodeText is required." };
     case "AI_UNSUPPORTED_SUBAGENT":
       return { status: 404, code: message, message: "Unsupported subagent." };
     default:

--- a/beta/tests/unit/linear_transform_api_integration.test.js
+++ b/beta/tests/unit/linear_transform_api_integration.test.js
@@ -31,11 +31,14 @@ test.before(async () => {
     const userMessage = body.messages.find((message) => message.role === "user");
 
     res.setHeader("Content-Type", "application/json; charset=utf-8");
+    const content = userMessage.content.includes("Topic generation request:")
+      ? JSON.stringify({ topics: ["Root cause", "Alternative design", "Validation steps"] })
+      : `stubbed-transform:${userMessage.content.includes("tree-to-linear") ? "ttl" : "ltt"}`;
     res.end(JSON.stringify({
       choices: [
         {
           message: {
-            content: `stubbed-transform:${userMessage.content.includes("tree-to-linear") ? "ttl" : "ltt"}`,
+            content,
           },
         },
       ],
@@ -103,6 +106,7 @@ test("linear transform convert proxies request to configured subagent", async ()
   assert.equal(status.payload.configured, true);
   assert.equal(status.payload.provider, "deepseek");
   assert.equal(status.payload.features["linear-transform"].available, true);
+  assert.equal(status.payload.features["topic-suggest"].available, true);
 
   const converted = await requestJson(`${appBaseUrl}/api/ai/subagent/linear-transform`, {
     method: "POST",
@@ -186,4 +190,37 @@ test("ai subagent returns 404 for unsupported subagent", async () => {
   });
   assert.equal(response.response.status, 404);
   assert.equal(response.payload.code, "AI_UNSUPPORTED_SUBAGENT");
+});
+
+test("topic suggest subagent returns related topics", async () => {
+  process.env.M3E_AI_ENABLED = "1";
+  process.env.M3E_AI_PROVIDER = "ollama";
+  process.env.M3E_AI_TRANSPORT = "openai-compatible";
+  process.env.M3E_AI_BASE_URL = providerBaseUrl;
+  process.env.M3E_AI_API_KEY = "ollama";
+  process.env.M3E_AI_MODEL = "gemma3:4b";
+
+  const response = await requestJson(`${appBaseUrl}/api/ai/subagent/topic-suggest`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({
+      documentId: "rapid-main",
+      scopeId: "root",
+      input: {
+        nodeText: "AI infra setup",
+        nodeDetails: "Need local and cloud routing",
+        maxTopics: 3,
+      },
+    }),
+  });
+
+  assert.equal(response.response.status, 200);
+  assert.equal(response.payload.ok, true);
+  assert.equal(response.payload.subagent, "topic-suggest");
+  assert.equal(response.payload.model, "gemma3:4b");
+  assert.deepEqual(response.payload.proposal.result.topics, [
+    "Root cause",
+    "Alternative design",
+    "Validation steps",
+  ]);
 });

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -29,6 +29,7 @@
           <button id="add-alias">Add alias</button>
           <button id="jump-target">Jump target</button>
           <button id="toggle-collapse">Collapse</button>
+          <button id="ai-generate-topics">AI topics</button>
           <button id="delete-node" class="danger">Delete</button>
           <span class="toolbar-sep">|</span>
           <button id="mark-reparent">Mark move</button>
@@ -68,6 +69,7 @@
             Enter add sibling + edit |
             Ctrl/Cmd+] enter scope |
             Ctrl/Cmd+[ back scope |
+            Ctrl/Cmd+Shift+T AI topics |
             Shift+Enter newline while editing |
             F2 edit selected node |
             Space collapse |

--- a/dev-docs/03_Spec/AI_Common_API.md
+++ b/dev-docs/03_Spec/AI_Common_API.md
@@ -71,6 +71,7 @@ feature ごとに専用 endpoint を持ってもよい。
 |------|------|
 | `GET /api/ai/status` | 実装済み |
 | `POST /api/ai/subagent/linear-transform` | 実装済み |
+| `POST /api/ai/subagent/topic-suggest` | 実装済み |
 | `openai-compatible` transport | 実装済み |
 | `mcp` transport | 未実装 |
 | `title-rewrite` | 未実装 |
@@ -90,6 +91,10 @@ feature ごとに専用 endpoint を持ってもよい。
   "message": "AI infrastructure is configured.",
   "features": {
     "linear-transform": {
+      "available": true,
+      "promptConfigured": true
+    },
+    "topic-suggest": {
       "available": true,
       "promptConfigured": true
     },

--- a/dev-docs/daily/260403.md
+++ b/dev-docs/daily/260403.md
@@ -17,3 +17,47 @@
 ## 依存関係メモ
 
 - 依存関係の追加なし
+
+## 追加実施（codex2 / dev-beta-data: Gemma ローカル導入と関連話題生成）
+
+- `beta/src/node/ai_infra.ts`
+  - local provider（Ollama）向けに `M3E_AI_API_KEY` の補完（`ollama`）を追加
+  - `localhost/127.0.0.1` endpoint でも同様に補完するよう更新
+- `beta/src/node/ai_subagent.ts`
+  - 新規 subagent `topic-suggest` を追加
+  - `POST /api/ai/subagent/topic-suggest` で選択ノード関連の話題候補を JSON で返す処理を実装
+  - `features.topic-suggest` を `/api/ai/status` に追加
+- `beta/src/node/start_viewer.ts`
+  - `AI_INPUT_NODE_TEXT_REQUIRED` のエラーマッピングを追加
+- `beta/src/browser/viewer.ts`
+  - `topic-suggest` 呼び出し処理を追加
+  - 返却された話題を選択ノードの子ノードとして追加する処理を追加
+  - 重複話題を除外し、Undo/Autosave フローに接続
+  - ショートカット `Ctrl/Cmd+Shift+T` を追加
+- `beta/viewer.html`
+  - ツールバーに `AI topics` ボタンを追加
+  - ショートカット表示に `Ctrl/Cmd+Shift+T` を追加
+- `beta/tests/unit/linear_transform_api_integration.test.js`
+  - `topic-suggest` 統合テストを追加
+- `beta/prompts/topic-agent/topic-suggest.txt`
+  - 関連話題生成用 prompt を追加
+- `scripts/beta/install-ollama-gemma3-4b.ps1`
+  - Ollama 導入と `gemma3:4b` 取得を自動化するスクリプトを追加
+- `scripts/beta/launch-with-local-gemma.bat`
+  - Bitwarden なしで Ollama + Gemma で Beta を起動するスクリプトを追加
+- `scripts/beta/launch-with-ai.ps1`
+  - provider=ollama 時の `base_url/model/api_key` 既定値を追加
+  - `M3E_TOPIC_SUGGEST_PROMPT_FILE` 注入を追加
+- `beta/README.md` / `scripts/README.md` / `dev-docs/03_Spec/AI_Common_API.md`
+  - Gemma ローカル導入手順、新 endpoint、新スクリプト、試験機能説明を追記
+
+## 確認（codex2 / dev-beta-data: Gemma ローカル導入と関連話題生成）
+
+- `npm -C beta run build`: pass
+- `npm -C beta run test:ci`: pass (41 tests)
+- `ollama pull gemma3:4b`: pass
+- `ollama run gemma3:4b "M3E integration check: respond with OK only."`: pass (`OK`)
+
+## 依存関係メモ（Gemma ローカル導入と関連話題生成）
+
+- npm 依存関係の追加なし

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,8 @@ M3E の各環境を日常利用するための起動・更新・migration スク
 |-----------|------|
 | `launch.bat` | Beta を起動（ビルド済み前提）**← 日常利用** |
 | `update-and-launch.bat` | git pull → install → build → 起動 |
+| `install-ollama-gemma3-4b.ps1` | Ollama 導入 + `gemma3:4b` 取得（ローカル AI 準備） |
+| `launch-with-local-gemma.bat` | Bitwarden なしで Ollama + `gemma3:4b` で Beta を起動 |
 | `launch-with-ai.bat` | Bitwarden から AI API key を注入して Beta を起動 |
 | `update-and-launch-with-ai.bat` | 更新後、Bitwarden から AI API key を注入して Beta を起動 |
 

--- a/scripts/beta/install-ollama-gemma3-4b.ps1
+++ b/scripts/beta/install-ollama-gemma3-4b.ps1
@@ -1,0 +1,59 @@
+param(
+    [switch]$SkipPull
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $Name"
+    }
+}
+
+function Ensure-Ollama {
+    if (Get-Command ollama -ErrorAction SilentlyContinue) {
+        return
+    }
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw "ollama is not installed and winget is unavailable. Install Ollama manually: https://ollama.com/download"
+    }
+
+    Write-Host "Installing Ollama via winget..."
+    winget install -e --id Ollama.Ollama --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0) {
+        throw "winget install Ollama failed."
+    }
+
+    Start-Sleep -Seconds 2
+    if (-not (Get-Command ollama -ErrorAction SilentlyContinue)) {
+        throw "Ollama install completed but command is not in PATH yet. Open a new shell and rerun this script."
+    }
+}
+
+Write-Host "[1/3] Ensure Ollama is installed..."
+Ensure-Ollama
+
+Write-Host "[2/3] Start Ollama runtime if needed..."
+$null = Start-Process -FilePath "ollama" -ArgumentList "serve" -WindowStyle Hidden -PassThru -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+
+if (-not $SkipPull) {
+    Write-Host "[3/3] Pull gemma3:4b model..."
+    ollama pull gemma3:4b
+    if ($LASTEXITCODE -ne 0) {
+        throw "ollama pull gemma3:4b failed."
+    }
+} else {
+    Write-Host "[3/3] Skip model pull (SkipPull=true)."
+}
+
+Write-Host "Done. Quick check command:"
+Write-Host "  ollama run gemma3:4b \"hello\""
+Write-Host "Recommended M3E AI env:"
+Write-Host "  M3E_AI_PROVIDER=ollama"
+Write-Host "  M3E_AI_TRANSPORT=openai-compatible"
+Write-Host "  M3E_AI_BASE_URL=http://localhost:11434/v1"
+Write-Host "  M3E_AI_API_KEY=ollama"
+Write-Host "  M3E_AI_MODEL=gemma3:4b"

--- a/scripts/beta/launch-with-ai.ps1
+++ b/scripts/beta/launch-with-ai.ps1
@@ -60,24 +60,43 @@ $apiKey = if ($item.login.password) { "$($item.login.password)".Trim() } else { 
 if (-not $apiKey) {
     $apiKey = Get-FieldValue -Item $item -Names @("api_key", "M3E_AI_API_KEY", "deepseek_api_key")
 }
-if (-not $apiKey) {
-    throw "API key was not found in the Bitwarden item password or known custom fields."
-}
 
 $provider = Get-FieldValue -Item $item -Names @("provider", "ai_provider", "M3E_AI_PROVIDER")
 $transport = Get-FieldValue -Item $item -Names @("transport", "ai_transport", "M3E_AI_TRANSPORT")
 $baseUrl = Get-FieldValue -Item $item -Names @("base_url", "endpoint", "M3E_AI_BASE_URL")
 $model = Get-FieldValue -Item $item -Names @("model", "default_model", "M3E_AI_MODEL")
 
+$effectiveProvider = if ($provider) { $provider } else { "deepseek" }
+
+if (-not $apiKey -and $effectiveProvider -eq "ollama") {
+    $apiKey = "ollama"
+}
+if (-not $apiKey) {
+    throw "API key was not found in the Bitwarden item password or known custom fields."
+}
+
 $env:M3E_AI_ENABLED = "1"
 $env:M3E_AI_API_KEY = $apiKey
-$env:M3E_AI_PROVIDER = if ($provider) { $provider } else { "deepseek" }
+$env:M3E_AI_PROVIDER = $effectiveProvider
 $env:M3E_AI_TRANSPORT = if ($transport) { $transport } else { "openai-compatible" }
-$env:M3E_AI_BASE_URL = if ($baseUrl) { $baseUrl } else { "https://api.deepseek.com" }
-$env:M3E_AI_MODEL = if ($model) { $model } else { "deepseek-chat" }
+if ($baseUrl) {
+    $env:M3E_AI_BASE_URL = $baseUrl
+} elseif ($effectiveProvider -eq "ollama") {
+    $env:M3E_AI_BASE_URL = "http://localhost:11434/v1"
+} else {
+    $env:M3E_AI_BASE_URL = "https://api.deepseek.com"
+}
+if ($model) {
+    $env:M3E_AI_MODEL = $model
+} elseif ($effectiveProvider -eq "ollama") {
+    $env:M3E_AI_MODEL = "gemma3:4b"
+} else {
+    $env:M3E_AI_MODEL = "deepseek-chat"
+}
 $env:M3E_LINEAR_TRANSFORM_SYSTEM_PROMPT_FILE = Join-Path $repoRoot "beta\prompts\linear-agent\system.txt"
 $env:M3E_LINEAR_TRANSFORM_TREE_TO_LINEAR_PROMPT_FILE = Join-Path $repoRoot "beta\prompts\linear-agent\tree-to-linear.txt"
 $env:M3E_LINEAR_TRANSFORM_LINEAR_TO_TREE_PROMPT_FILE = Join-Path $repoRoot "beta\prompts\linear-agent\linear-to-tree.txt"
+$env:M3E_TOPIC_SUGGEST_PROMPT_FILE = Join-Path $repoRoot "beta\prompts\topic-agent\topic-suggest.txt"
 $env:M3E_DATA_DIR = Join-Path $repoRoot "beta\data"
 
 if (-not (Test-Path $env:M3E_DATA_DIR)) {

--- a/scripts/beta/launch-with-local-gemma.bat
+++ b/scripts/beta/launch-with-local-gemma.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+set "REPO_ROOT=%~dp0..\.."
+pushd "%REPO_ROOT%" || exit /b 1
+
+set "M3E_AI_ENABLED=1"
+set "M3E_AI_PROVIDER=ollama"
+set "M3E_AI_TRANSPORT=openai-compatible"
+set "M3E_AI_BASE_URL=http://localhost:11434/v1"
+set "M3E_AI_API_KEY=ollama"
+set "M3E_AI_MODEL=gemma3:4b"
+set "M3E_LINEAR_TRANSFORM_SYSTEM_PROMPT_FILE=%REPO_ROOT%\beta\prompts\linear-agent\system.txt"
+set "M3E_LINEAR_TRANSFORM_TREE_TO_LINEAR_PROMPT_FILE=%REPO_ROOT%\beta\prompts\linear-agent\tree-to-linear.txt"
+set "M3E_LINEAR_TRANSFORM_LINEAR_TO_TREE_PROMPT_FILE=%REPO_ROOT%\beta\prompts\linear-agent\linear-to-tree.txt"
+set "M3E_TOPIC_SUGGEST_PROMPT_FILE=%REPO_ROOT%\beta\prompts\topic-agent\topic-suggest.txt"
+set "M3E_DATA_DIR=%REPO_ROOT%\beta\data"
+
+echo Launching Beta with local Gemma (provider=%M3E_AI_PROVIDER%, model=%M3E_AI_MODEL%)
+npm --prefix beta start
+set "EXIT_CODE=%ERRORLEVEL%"
+
+popd
+endlocal & exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- add local Ollama + gemma3:4b setup/launch scripts for Beta
- extend shared AI infra defaults for local provider usage
- add new AI subagent: topic-suggest
- add viewer trial action to generate related topics for selected node and append as children
- update docs/spec/daily log for new endpoint and operations

## Verification
- npm -C beta run build
- npm -C beta run test:ci (41 tests pass)
- ollama pull gemma3:4b
- ollama run gemma3:4b \"M3E integration check: respond with OK only.\"