### PR TITLE
feat: LaTeX rendering and visual fixes

### DIFF
--- a/beta/src/browser/viewer.globals.d.ts
+++ b/beta/src/browser/viewer.globals.d.ts
@@ -230,6 +230,7 @@ interface ViewState {
   cameraY: number;
   panState: PanState | null;
   clipboardState: ClipboardState;
+  linkSourceNodeId: string;
   reparentSourceIds: Set<string>;
   dragState: DragState | null;
   collapsedIds: Set<string>;

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -1930,18 +1930,22 @@ function render(): void {
       return;
     }
 
-    const sourceX = sourcePos.x + sourcePos.w * 0.5;
+    const forward = targetPos.x >= sourcePos.x;
+    const sourceX = forward
+      ? sourcePos.x + sourcePos.w + VIEWER_TUNING.layout.edgeStartPad
+      : sourcePos.x - VIEWER_TUNING.layout.edgeEndPad;
     const sourceY = sourcePos.y;
-    const targetX = targetPos.x + targetPos.w * 0.5;
+    const targetX = forward
+      ? targetPos.x - VIEWER_TUNING.layout.edgeEndPad
+      : targetPos.x + targetPos.w + VIEWER_TUNING.layout.edgeStartPad;
     const targetY = targetPos.y;
-    const dx = targetX - sourceX;
-    const dy = targetY - sourceY;
-    const distance = Math.max(1, Math.hypot(dx, dy));
-    const normalX = -dy / distance;
-    const normalY = dx / distance;
-    const bend = Math.min(96, Math.max(34, distance * 0.18));
-    const controlX = (sourceX + targetX) / 2 + normalX * bend;
-    const controlY = (sourceY + targetY) / 2 + normalY * bend;
+    const curve = Math.max(48, Math.abs(targetX - sourceX) * 0.45);
+    const c1x = forward ? sourceX + curve : sourceX - curve;
+    const c1y = sourceY;
+    const c2x = forward ? targetX - curve : targetX + curve;
+    const c2y = targetY;
+    const controlX = (c1x + c2x) / 2;
+    const controlY = (sourceY + targetY) / 2;
     const styleClass = link.style === "default" ? "" : ` graph-link-${link.style}`;
     const stroke = VIEWER_TUNING.palette.edgeColors[Math.abs(controlX + controlY) % VIEWER_TUNING.palette.edgeColors.length];
     const markerEndId = `graph-link-arrow-end-${link.id}`;
@@ -1962,7 +1966,7 @@ function render(): void {
         <path d="M 10 1 L 0 6 L 10 11 z" fill="${stroke}" />
       </marker>`;
 
-    graphLinks += `<path class="graph-link${styleClass}" data-link-id="${link.id}" stroke="${stroke}" d="M ${sourceX} ${sourceY} Q ${controlX} ${controlY}, ${targetX} ${targetY}"${markerStart}${markerEnd} />`;
+    graphLinks += `<path class="graph-link${styleClass}" data-link-id="${link.id}" stroke="${stroke}" d="M ${sourceX} ${sourceY} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${targetX} ${targetY}"${markerStart}${markerEnd} />`;
     if (label) {
       graphLinks += `<text class="graph-link-label" data-link-id="${link.id}" x="${controlX}" y="${controlY - 8}" text-anchor="middle">${escapeXml(label)}</text>`;
     }

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -1911,12 +1911,6 @@ function render(): void {
   );
   let defs = `
     <defs>
-      <marker id="graph-link-arrow-end" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto">
-        <path d="M 0 1 L 10 6 L 0 11 z" fill="#2a7188" />
-      </marker>
-      <marker id="graph-link-arrow-start" viewBox="0 0 12 12" refX="2" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-        <path d="M 10 1 L 0 6 L 10 11 z" fill="#2a7188" />
-      </marker>
     </defs>`;
   let edges = "";
   let graphLinks = "";
@@ -1949,15 +1943,26 @@ function render(): void {
     const controlX = (sourceX + targetX) / 2 + normalX * bend;
     const controlY = (sourceY + targetY) / 2 + normalY * bend;
     const styleClass = link.style === "default" ? "" : ` graph-link-${link.style}`;
+    const stroke = VIEWER_TUNING.palette.edgeColors[Math.abs(controlX + controlY) % VIEWER_TUNING.palette.edgeColors.length];
+    const markerEndId = `graph-link-arrow-end-${link.id}`;
+    const markerStartId = `graph-link-arrow-start-${link.id}`;
     const markerStart = link.direction === "backward" || link.direction === "both"
-      ? ` marker-start="url(#graph-link-arrow-start)"`
+      ? ` marker-start="url(#${markerStartId})"`
       : "";
     const markerEnd = link.direction === "forward" || link.direction === "both"
-      ? ` marker-end="url(#graph-link-arrow-end)"`
+      ? ` marker-end="url(#${markerEndId})"`
       : "";
     const label = (link.label || link.relationType || "").trim();
 
-    graphLinks += `<path class="graph-link${styleClass}" data-link-id="${link.id}" d="M ${sourceX} ${sourceY} Q ${controlX} ${controlY}, ${targetX} ${targetY}"${markerStart}${markerEnd} />`;
+    defs += `
+      <marker id="${markerEndId}" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto">
+        <path d="M 0 1 L 10 6 L 0 11 z" fill="${stroke}" />
+      </marker>
+      <marker id="${markerStartId}" viewBox="0 0 12 12" refX="2" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+        <path d="M 10 1 L 0 6 L 10 11 z" fill="${stroke}" />
+      </marker>`;
+
+    graphLinks += `<path class="graph-link${styleClass}" data-link-id="${link.id}" stroke="${stroke}" d="M ${sourceX} ${sourceY} Q ${controlX} ${controlY}, ${targetX} ${targetY}"${markerStart}${markerEnd} />`;
     if (label) {
       graphLinks += `<text class="graph-link-label" data-link-id="${link.id}" x="${controlX}" y="${controlY - 8}" text-anchor="middle">${escapeXml(label)}</text>`;
     }

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -19,6 +19,8 @@ const jumpTargetBtn = document.getElementById("jump-target");
 const toggleCollapseBtn = document.getElementById("toggle-collapse");
 const aiGenerateTopicsBtn = document.getElementById("ai-generate-topics");
 const deleteNodeBtn = document.getElementById("delete-node");
+const markLinkBtn = document.getElementById("mark-link");
+const applyLinkBtn = document.getElementById("apply-link");
 const markReparentBtn = document.getElementById("mark-reparent");
 const applyReparentBtn = document.getElementById("apply-reparent");
 const importanceViewSelect = document.getElementById("importance-view") as HTMLSelectElement;
@@ -135,6 +137,7 @@ let viewState: ViewState = {
   cameraY: VIEWER_TUNING.pan.initialCameraY,
   panState: null,
   clipboardState: null,
+  linkSourceNodeId: "",
   reparentSourceIds: new Set<string>(),
   dragState: null,
   collapsedIds: new Set<string>(),
@@ -270,6 +273,25 @@ function ensureDocShape(payload: unknown): SavedDoc {
     node.access = node.nodeType === "alias" ? (node.access || "read") : undefined;
     node.targetSnapshotLabel = node.targetSnapshotLabel || undefined;
     node.isBroken = node.nodeType === "alias" ? Boolean(node.isBroken) : undefined;
+  });
+  const rawLinks = candidate.state.links && typeof candidate.state.links === "object"
+    ? candidate.state.links
+    : {};
+  candidate.state.links = {};
+  Object.entries(rawLinks).forEach(([linkId, link]) => {
+    if (!link || typeof link !== "object") {
+      return;
+    }
+    const record = link as GraphLink;
+    candidate.state.links![linkId] = {
+      id: record.id || linkId,
+      sourceNodeId: String(record.sourceNodeId || ""),
+      targetNodeId: String(record.targetNodeId || ""),
+      relationType: record.relationType || undefined,
+      label: record.label || undefined,
+      direction: record.direction || "none",
+      style: record.style || "default",
+    };
   });
   return candidate as SavedDoc;
 }
@@ -849,6 +871,16 @@ function aliasBadge(node: TreeNode): string {
     return "broken";
   }
   return aliasAccess(node) === "write" ? "write" : "read";
+}
+
+function normalizeGraphLink(link: GraphLink): GraphLink {
+  return {
+    ...link,
+    relationType: link.relationType ?? undefined,
+    label: link.label ?? undefined,
+    direction: link.direction ?? "none",
+    style: link.style ?? "default",
+  };
 }
 
 function nodeBadge(node: TreeNode): string {
@@ -1877,9 +1909,59 @@ function render(): void {
     VIEWER_TUNING.layout.minCanvasHeight,
     layout.totalHeight + VIEWER_TUNING.layout.topPad + VIEWER_TUNING.layout.canvasBottomPad
   );
+  let defs = `
+    <defs>
+      <marker id="graph-link-arrow-end" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto">
+        <path d="M 0 1 L 10 6 L 0 11 z" fill="#2a7188" />
+      </marker>
+      <marker id="graph-link-arrow-start" viewBox="0 0 12 12" refX="2" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+        <path d="M 10 1 L 0 6 L 10 11 z" fill="#2a7188" />
+      </marker>
+    </defs>`;
   let edges = "";
+  let graphLinks = "";
   let overlays = "";
   let nodes = "";
+
+  Object.values(state.links || {}).forEach((rawLink) => {
+    const link = normalizeGraphLink(rawLink);
+    const source = state.nodes[link.sourceNodeId];
+    const target = state.nodes[link.targetNodeId];
+    const sourcePos = pos[link.sourceNodeId];
+    const targetPos = pos[link.targetNodeId];
+    if (!source || !target || !sourcePos || !targetPos) {
+      return;
+    }
+    if (!isNodeInScope(source.id) || !isNodeInScope(target.id) || !isNodeVisibleByImportance(source.id) || !isNodeVisibleByImportance(target.id)) {
+      return;
+    }
+
+    const sourceX = sourcePos.x + sourcePos.w * 0.5;
+    const sourceY = sourcePos.y;
+    const targetX = targetPos.x + targetPos.w * 0.5;
+    const targetY = targetPos.y;
+    const dx = targetX - sourceX;
+    const dy = targetY - sourceY;
+    const distance = Math.max(1, Math.hypot(dx, dy));
+    const normalX = -dy / distance;
+    const normalY = dx / distance;
+    const bend = Math.min(96, Math.max(34, distance * 0.18));
+    const controlX = (sourceX + targetX) / 2 + normalX * bend;
+    const controlY = (sourceY + targetY) / 2 + normalY * bend;
+    const styleClass = link.style === "default" ? "" : ` graph-link-${link.style}`;
+    const markerStart = link.direction === "backward" || link.direction === "both"
+      ? ` marker-start="url(#graph-link-arrow-start)"`
+      : "";
+    const markerEnd = link.direction === "forward" || link.direction === "both"
+      ? ` marker-end="url(#graph-link-arrow-end)"`
+      : "";
+    const label = (link.label || link.relationType || "").trim();
+
+    graphLinks += `<path class="graph-link${styleClass}" data-link-id="${link.id}" d="M ${sourceX} ${sourceY} Q ${controlX} ${controlY}, ${targetX} ${targetY}"${markerStart}${markerEnd} />`;
+    if (label) {
+      graphLinks += `<text class="graph-link-label" data-link-id="${link.id}" x="${controlX}" y="${controlY - 8}" text-anchor="middle">${escapeXml(label)}</text>`;
+    }
+  });
 
   function drawNode(nodeId: string): void {
     const node = state.nodes[nodeId];
@@ -1926,6 +2008,9 @@ function render(): void {
     }
     if (viewState.reparentSourceIds.has(nodeId)) {
       classNames.push("reparent-source");
+    }
+    if (viewState.linkSourceNodeId === nodeId) {
+      classNames.push("link-source");
     }
     if (viewState.clipboardState?.type === "cut" && viewState.clipboardState.sourceIds.has(nodeId)) {
       classNames.push("cut-pending");
@@ -2032,13 +2117,17 @@ function render(): void {
   canvas.setAttribute("width", String(maxX));
   canvas.setAttribute("height", String(maxY));
   canvas.setAttribute("viewBox", `0 0 ${maxX} ${maxY}`);
-  (canvas as Element).innerHTML = `${edges}${overlays}${nodes}`;
+  (canvas as Element).innerHTML = `${defs}${edges}${graphLinks}${overlays}${nodes}`;
   applyZoom();
 
   const version = doc.version ?? "n/a";
   const savedAt = doc.savedAt ?? "n/a";
   const nodeCount = Object.keys(state.nodes).length;
+  const linkCount = Object.values(state.links || {}).filter((link) => pos[link.sourceNodeId] && pos[link.targetNodeId]).length;
   const selected = state.nodes[viewState.selectedNodeId];
+  const linkSourceLabel = viewState.linkSourceNodeId && state.nodes[viewState.linkSourceNodeId]
+    ? uiLabel(state.nodes[viewState.linkSourceNodeId]!)
+    : "none";
   const moveNodes = Array.from(viewState.reparentSourceIds)
     .map((nodeId) => state.nodes[nodeId])
     .filter((node): node is TreeNode => Boolean(node));
@@ -2051,7 +2140,7 @@ function render(): void {
     dropLabel = `reorder in ${parentText} @ ${dragProposal.index}`;
   }
   syncThinkingModeUi();
-  metaEl.textContent = `version: ${version} | savedAt: ${savedAt} | nodes: ${nodeCount} | scope: ${normalizedCurrentScopeId()} | importance: ${importanceViewMode} | selected: ${selected ? uiLabel(selected) : "n/a"} (${viewState.selectedNodeIds.size}) | move-node: ${moveNodes.length > 0 ? `${moveNodes.length} selected` : "none"} | drop-target: ${dropLabel}`;
+  metaEl.textContent = `version: ${version} | savedAt: ${savedAt} | nodes: ${nodeCount} | links: ${linkCount} | scope: ${normalizedCurrentScopeId()} | importance: ${importanceViewMode} | selected: ${selected ? uiLabel(selected) : "n/a"} (${viewState.selectedNodeIds.size}) | link-source: ${linkSourceLabel} | move-node: ${moveNodes.length > 0 ? `${moveNodes.length} selected` : "none"} | drop-target: ${dropLabel}`;
   updateScopeMeta();
   updateScopeSummary();
   updateDocumentTitle();
@@ -2425,6 +2514,10 @@ function normalizeSelectionState(): void {
       ? { type: "cut", sourceIds: normalizedCutSourceIds }
       : null;
   }
+
+  if (viewState.linkSourceNodeId && !doc.state.nodes[viewState.linkSourceNodeId]) {
+    viewState.linkSourceNodeId = "";
+  }
 }
 
 function setSingleSelection(nodeId: string, renderNow = true): void {
@@ -2585,6 +2678,91 @@ function addSibling(): void {
   parent.children.splice(currentIndex + 1, 0, id);
   setSingleSelection(id, false);
   touchDocument();
+  board.focus();
+}
+
+function selectedLinkableNode(): TreeNode | null {
+  if (!doc || !viewState.selectedNodeId) {
+    return null;
+  }
+  const node = doc.state.nodes[viewState.selectedNodeId];
+  if (!node || isAliasNode(node)) {
+    return null;
+  }
+  return node;
+}
+
+function findExistingGraphLink(sourceNodeId: string, targetNodeId: string): GraphLink | null {
+  if (!doc) {
+    return null;
+  }
+  const links = Object.values(doc.state.links || {});
+  return links.find((link) => link.sourceNodeId === sourceNodeId && link.targetNodeId === targetNodeId) || null;
+}
+
+function markLinkSource(): void {
+  if (!doc) {
+    return;
+  }
+  const node = selectedLinkableNode();
+  if (!node) {
+    setStatus("Select a non-alias node to mark link source.", true);
+    return;
+  }
+  if (viewState.linkSourceNodeId === node.id) {
+    viewState.linkSourceNodeId = "";
+    setStatus("Link source mark cleared.");
+    scheduleRender();
+    return;
+  }
+  viewState.linkSourceNodeId = node.id;
+  setStatus(`Marked link source: ${uiLabel(node)}`);
+  scheduleRender();
+}
+
+function applyMarkedLink(): void {
+  if (!doc) {
+    return;
+  }
+  const sourceId = viewState.linkSourceNodeId;
+  if (!sourceId) {
+    setStatus("No link source marked.", true);
+    return;
+  }
+  const source = doc.state.nodes[sourceId];
+  const target = selectedLinkableNode();
+  if (!source || !target) {
+    setStatus("Select a non-alias target node.", true);
+    return;
+  }
+  if (isAliasNode(source)) {
+    setStatus("Alias nodes cannot be graph link endpoints.", true);
+    return;
+  }
+  if (source.id === target.id) {
+    setStatus("Graph links cannot connect a node to itself.", true);
+    return;
+  }
+  if (findExistingGraphLink(source.id, target.id)) {
+    setStatus("That link already exists.");
+    return;
+  }
+
+  pushUndoSnapshot();
+  const linkId = newId();
+  if (!doc.state.links) {
+    doc.state.links = {};
+  }
+  doc.state.links[linkId] = normalizeGraphLink({
+    id: linkId,
+    sourceNodeId: source.id,
+    targetNodeId: target.id,
+    direction: "forward",
+    style: "default",
+  });
+  viewState.linkSourceNodeId = "";
+  touchDocument();
+  setStatus(`Linked ${uiLabel(source)} -> ${uiLabel(target)}.`);
   board.focus();
 }
 
@@ -3278,6 +3456,7 @@ function loadPayload(payload: unknown): void {
     viewState.currentScopeRootId = doc.state.rootId;
     viewState.thinkingMode = "rapid";
     viewState.clipboardState = null;
+    viewState.linkSourceNodeId = "";
     viewState.reparentSourceIds = new Set<string>();
     viewState.collapsedIds = new Set(
       Object.values(doc.state.nodes)
@@ -4014,6 +4193,16 @@ jumpTargetBtn?.addEventListener("click", () => {
   jumpToAliasTarget();
 });
 
+markLinkBtn?.addEventListener("click", () => {
+  if (!doc) return;
+  markLinkSource();
+});
+
+applyLinkBtn?.addEventListener("click", () => {
+  if (!doc) return;
+  applyMarkedLink();
+});
+
 toggleCollapseBtn?.addEventListener("click", () => {
   if (!doc) return;
   toggleCollapse();
@@ -4455,6 +4644,20 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     event.preventDefault();
     if (!event.repeat) {
       toggleReparentSource();
+    }
+    return;
+  }
+
+  if (!event.ctrlKey && !event.metaKey && !event.altKey && event.shiftKey && event.key.toLowerCase() === "l") {
+    event.preventDefault();
+    applyMarkedLink();
+    return;
+  }
+
+  if (!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "l") {
+    event.preventDefault();
+    if (!event.repeat) {
+      markLinkSource();
     }
     return;
   }

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -309,6 +309,39 @@ function textWidth(str: string, fontSize: number): number {
   return Math.max(80, normalized.length * fontSize * 0.62);
 }
 
+function splitLabelLines(text: string): string[] {
+  const lines = String(text || "").replaceAll("\r", "").split("\n");
+  return lines.length > 0 ? lines : [""];
+}
+
+function lineHeightForFont(fontSize: number): number {
+  return Math.ceil(fontSize * 1.2);
+}
+
+function multilineTextStartY(centerY: number, lineCount: number, fontSize: number, lineHeight: number): number {
+  const glyphHeight = Math.ceil(fontSize);
+  const blockHeight = (lineCount - 1) * lineHeight + glyphHeight;
+  const ascent = Math.ceil(fontSize * 0.8);
+  return centerY - blockHeight / 2 + ascent;
+}
+
+function multilineTspans(lines: string[], x: number, lineHeight: number): string {
+  return lines
+    .map((line, index) => `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeXml(line || " ")}</tspan>`)
+    .join("");
+}
+
+function measureNodeLabel(text: string, fontSize: number): { w: number; h: number } {
+  const lines = splitLabelLines(text);
+  const maxLineWidth = lines.reduce((max, line) => Math.max(max, textWidth(line, fontSize)), 80);
+  const lineHeight = lineHeightForFont(fontSize);
+  const verticalPadding = 24;
+  return {
+    w: maxLineWidth + 20,
+    h: Math.max(VIEWER_TUNING.layout.leafHeight, lines.length * lineHeight + verticalPadding),
+  };
+}
+
 const LATEX_DISPLAY_RE = /^\$\$([\s\S]+)\$\$$/;
 const LATEX_INLINE_RE = /^\$([^$]+)\$$/;
 
@@ -332,13 +365,30 @@ function measureLatex(text: string): { w: number; h: number } {
   if (latexMetricsCache.has(text)) return latexMetricsCache.get(text)!;
   const { latex, displayMode } = latexSource(text);
   const probe = document.createElement("div");
-  probe.style.cssText = "position:absolute;visibility:hidden;top:-9999px;left:-9999px";
+  probe.style.cssText = [
+    "position:absolute",
+    "visibility:hidden",
+    "top:-9999px",
+    "left:-9999px",
+    "display:inline-flex",
+    "align-items:center",
+    "padding:0 4px",
+    "box-sizing:border-box",
+    `font-size:${VIEWER_TUNING.typography.nodeFont}px`,
+    "line-height:1",
+    "white-space:nowrap",
+  ].join(";");
   document.body.appendChild(probe);
   try {
     katex.render(latex, probe, { displayMode, throwOnError: false });
+    const displayBlock = probe.querySelector(".katex-display") as HTMLElement | null;
+    if (displayBlock) {
+      displayBlock.style.margin = "0";
+    }
+    const rect = probe.getBoundingClientRect();
     const result = {
-      w: Math.max(80, probe.offsetWidth + 24),
-      h: Math.max(VIEWER_TUNING.layout.leafHeight, probe.offsetHeight + 16),
+      w: Math.max(80, Math.ceil(rect.width) + 8),
+      h: Math.max(VIEWER_TUNING.layout.leafHeight, Math.ceil(rect.height) + 12),
     };
     latexMetricsCache.set(text, result);
     return result;
@@ -1659,18 +1709,16 @@ function buildLayout(state: AppState): LayoutResult {
     depthOf[nodeId] = depth;
 
     if (nodeId === state.rootId) {
+      const rootLabelMeasure = measureNodeLabel(uiLabel(node), VIEWER_TUNING.typography.rootFont);
       metrics[nodeId] = {
-        w: Math.max(280, textWidth(node.text || "", VIEWER_TUNING.typography.rootFont) + 120),
-        h: VIEWER_TUNING.layout.rootHeight,
+        w: Math.max(280, rootLabelMeasure.w + 100),
+        h: Math.max(VIEWER_TUNING.layout.rootHeight, rootLabelMeasure.h + 8),
       };
     } else if (isLatexNode(node)) {
       const m = measureLatex(node.text);
       metrics[nodeId] = { w: m.w, h: m.h };
     } else {
-      metrics[nodeId] = {
-        w: textWidth(node.text || "", VIEWER_TUNING.typography.nodeFont) + 20,
-        h: 56,
-      };
+      metrics[nodeId] = measureNodeLabel(uiLabel(node), VIEWER_TUNING.typography.nodeFont);
     }
 
     depthMaxWidth[depth] = Math.max(depthMaxWidth[depth] ?? 0, metrics[nodeId]!.w);
@@ -1699,8 +1747,9 @@ function buildLayout(state: AppState): LayoutResult {
 
     const children = visibleChildren(node);
     if (children.length === 0) {
-      subtreeHeightCache[nodeId] = VIEWER_TUNING.layout.leafHeight;
-      return VIEWER_TUNING.layout.leafHeight;
+      const leafSpan = Math.max(VIEWER_TUNING.layout.leafHeight, metrics[nodeId]!.h + 12);
+      subtreeHeightCache[nodeId] = leafSpan;
+      return leafSpan;
     }
 
     let sum = 0;
@@ -1894,16 +1943,20 @@ function render(): void {
     nodes += `<rect class="${classNames.join(" ")}" data-node-id="${nodeId}" x="${hitX}" y="${hitY}" width="${hitW}" height="${hitH}" rx="12" />`;
 
     if (nodeId === displayRootId) {
-      const label = escapeXml(uiLabel(node) || "(empty)");
+      const rootLabelLines = splitLabelLines(uiLabel(node) || "(empty)");
+      const rootLineHeight = lineHeightForFont(VIEWER_TUNING.typography.rootFont);
+      const rootStartY = multilineTextStartY(p.y, rootLabelLines.length, VIEWER_TUNING.typography.rootFont, rootLineHeight);
+      const rootTspans = multilineTspans(rootLabelLines, p.x + p.w / 2, rootLineHeight);
       const w = p.w;
       const h = p.h;
       const rx = 60;
       const x = p.x;
       const y = p.y - h / 2;
       nodes += `<rect class="root-box" data-node-id="${nodeId}" x="${x}" y="${y}" width="${w}" height="${h}" rx="${rx}" />`;
-      nodes += `<text class="label-root" data-node-id="${nodeId}" x="${x + w / 2}" y="${p.y}" text-anchor="middle" dominant-baseline="middle">${label}</text>`;
+      nodes += `<text class="label-root" data-node-id="${nodeId}" x="${x + w / 2}" y="${rootStartY}" text-anchor="middle">${rootTspans}</text>`;
     } else {
-      const label = escapeXml(uiLabel(node) || "(empty)");
+      const rawLabel = uiLabel(node) || "(empty)";
+      const labelLines = splitLabelLines(rawLabel);
       const labelClasses = ["label-node"];
       if (viewState.selectedNodeIds.has(nodeId)) {
         labelClasses.push("selected");
@@ -1916,10 +1969,11 @@ function render(): void {
         labelClasses.push(isBrokenAlias(node) ? "alias-broken-label" : (aliasAccess(node) === "write" ? "alias-write-label" : "alias-read-label"));
       }
       if (isFolderNode(node)) {
+        const frameH = Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h) - 12;
         const folderFrameX = p.x - 14;
-        const folderFrameY = p.y - VIEWER_TUNING.layout.nodeHitHeight / 2 + 6;
+        const folderFrameY = p.y - frameH / 2;
         const folderFrameW = p.w + 28;
-        const folderFrameH = VIEWER_TUNING.layout.nodeHitHeight - 12;
+        const folderFrameH = frameH;
         nodes += `<rect class="folder-box" data-node-id="${nodeId}" x="${folderFrameX}" y="${folderFrameY}" width="${folderFrameW}" height="${folderFrameH}" rx="8" />`;
       }
       if (isLatexNode(node)) {
@@ -1933,7 +1987,10 @@ function render(): void {
         const foY = p.y - foH / 2;
         nodes += `<foreignObject data-node-id="${nodeId}" x="${p.x}" y="${foY}" width="${p.w}" height="${foH}"><div xmlns="http://www.w3.org/1999/xhtml" class="latex-node-content">${htmlStr}</div></foreignObject>`;
       } else {
-        nodes += `<text class="${labelClasses.join(" ")}" data-node-id="${nodeId}" x="${p.x}" y="${p.y}" text-anchor="start" dominant-baseline="middle">${label}</text>`;
+        const lineHeight = lineHeightForFont(VIEWER_TUNING.typography.nodeFont);
+        const startY = multilineTextStartY(p.y, labelLines.length, VIEWER_TUNING.typography.nodeFont, lineHeight);
+        const tspans = multilineTspans(labelLines, p.x, lineHeight);
+        nodes += `<text class="${labelClasses.join(" ")}" data-node-id="${nodeId}" x="${p.x}" y="${startY}" text-anchor="start">${tspans}</text>`;
       }
       const badge = nodeBadge(node);
       if (badge) {
@@ -2010,6 +2067,10 @@ function clientToCanvasPoint(clientX: number, clientY: number): { x: number; y: 
   };
 }
 
+function interactionHalfHeight(nodePos: NodePosition): number {
+  return Math.max(VIEWER_TUNING.layout.nodeHitHeight, nodePos.h) / 2;
+}
+
 function getNodeHitBounds(nodeId: string): { left: number; right: number; top: number; bottom: number } | null {
   if (!doc || !lastLayout) {
     return null;
@@ -2021,11 +2082,12 @@ function getNodeHitBounds(nodeId: string): { left: number; right: number; top: n
   const displayRootId = currentScopeRootId();
   const left = nodeId === displayRootId ? p.x : p.x - 8;
   const width = nodeId === displayRootId ? p.w : p.w + 36;
+  const halfH = interactionHalfHeight(p);
   return {
     left,
     right: left + width,
-    top: p.y - VIEWER_TUNING.layout.nodeHitHeight / 2,
-    bottom: p.y + VIEWER_TUNING.layout.nodeHitHeight / 2,
+    top: p.y - halfH,
+    bottom: p.y + halfH,
   };
 }
 
@@ -2114,7 +2176,7 @@ function getNextVisibleNodeTopAtDepth(nodeId: string, depth: number): number | n
     if (!nextPos || nextPos.depth !== depth) {
       continue;
     }
-    return nextPos.y - VIEWER_TUNING.layout.leafHeight / 2;
+    return nextPos.y - interactionHalfHeight(nextPos);
   }
   return null;
 }
@@ -2147,8 +2209,9 @@ function isInExplicitReparentZone(nodeId: string, x: number, y: number): boolean
   const horizontalInset = Math.min(48, Math.max(14, nodePos.w * 0.2));
   const left = nodePos.x + horizontalInset;
   const right = nodePos.x + nodePos.w - horizontalInset;
-  const topEdge = nodePos.y - VIEWER_TUNING.layout.nodeHitHeight / 2 + DRAG_EDGE_BAND;
-  const bottomEdge = nodePos.y + VIEWER_TUNING.layout.nodeHitHeight / 2 - DRAG_EDGE_BAND;
+  const halfH = interactionHalfHeight(nodePos);
+  const topEdge = nodePos.y - halfH + DRAG_EDGE_BAND;
+  const bottomEdge = nodePos.y + halfH - DRAG_EDGE_BAND;
   return x >= left && x <= right && y >= topEdge && y <= bottomEdge;
 }
 
@@ -2178,8 +2241,8 @@ function proposeReorderDrop(sourceId: string, x: number, y: number): DragDropPro
         }
         return {
           id: childId,
-          top: p.y - VIEWER_TUNING.layout.leafHeight / 2,
-          bottom: p.y + VIEWER_TUNING.layout.leafHeight / 2,
+          top: hit.top,
+          bottom: hit.bottom,
           hitLeft: hit.left,
           hitRight: hit.right,
         };
@@ -2257,14 +2320,15 @@ function proposeDrop(sourceId: string, clientX: number, clientY: number): DragDr
     const targetNode = doc?.state.nodes[targetNodeId];
     if (targetPos && targetNode?.parentId) {
       const targetIndex = getVisibleChildrenForDrop(targetNode.parentId, sourceId).indexOf(targetNodeId);
-      const topEdge = targetPos.y - VIEWER_TUNING.layout.nodeHitHeight / 2 + DRAG_EDGE_BAND;
-      const bottomEdge = targetPos.y + VIEWER_TUNING.layout.nodeHitHeight / 2 - DRAG_EDGE_BAND;
+      const targetHalfH = interactionHalfHeight(targetPos);
+      const topEdge = targetPos.y - targetHalfH + DRAG_EDGE_BAND;
+      const bottomEdge = targetPos.y + targetHalfH - DRAG_EDGE_BAND;
       if (point.y < topEdge && targetIndex >= 0 && canDropUnderParent(sourceId, targetNode.parentId)) {
         return {
           kind: "reorder",
           parentId: targetNode.parentId,
           index: targetIndex,
-          lineY: targetPos.y - VIEWER_TUNING.layout.nodeHitHeight / 2,
+          lineY: targetPos.y - targetHalfH,
         };
       }
       if (point.y > bottomEdge && targetIndex >= 0 && canDropUnderParent(sourceId, targetNode.parentId)) {
@@ -2272,7 +2336,7 @@ function proposeDrop(sourceId: string, clientX: number, clientY: number): DragDr
           kind: "reorder",
           parentId: targetNode.parentId,
           index: targetIndex + 1,
-          lineY: targetPos.y + VIEWER_TUNING.layout.nodeHitHeight / 2,
+          lineY: targetPos.y + targetHalfH,
         };
       }
     }

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -1909,9 +1909,7 @@ function render(): void {
     VIEWER_TUNING.layout.minCanvasHeight,
     layout.totalHeight + VIEWER_TUNING.layout.topPad + VIEWER_TUNING.layout.canvasBottomPad
   );
-  let defs = `
-    <defs>
-    </defs>`;
+  let defs = "<defs>";
   let edges = "";
   let graphLinks = "";
   let overlays = "";
@@ -1947,7 +1945,8 @@ function render(): void {
     const controlX = (c1x + c2x) / 2;
     const controlY = (sourceY + targetY) / 2;
     const styleClass = link.style === "default" ? "" : ` graph-link-${link.style}`;
-    const stroke = VIEWER_TUNING.palette.edgeColors[Math.abs(controlX + controlY) % VIEWER_TUNING.palette.edgeColors.length];
+    const colorSeed = Math.round(Math.abs(sourcePos.depth * 31 + targetPos.depth * 17 + sourceY + targetY));
+    const stroke = VIEWER_TUNING.palette.edgeColors[colorSeed % VIEWER_TUNING.palette.edgeColors.length]!;
     const markerEndId = `graph-link-arrow-end-${link.id}`;
     const markerStartId = `graph-link-arrow-start-${link.id}`;
     const markerStart = link.direction === "backward" || link.direction === "both"
@@ -1971,6 +1970,7 @@ function render(): void {
       graphLinks += `<text class="graph-link-label" data-link-id="${link.id}" x="${controlX}" y="${controlY - 8}" text-anchor="middle">${escapeXml(label)}</text>`;
     }
   });
+  defs += "</defs>";
 
   function drawNode(nodeId: string): void {
     const node = state.nodes[nodeId];

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -326,6 +326,7 @@ function latexSource(text: string): { latex: string; displayMode: boolean } {
 }
 
 const latexMetricsCache = new Map<string, { w: number; h: number }>();
+const latexHtmlCache = new Map<string, string>();
 
 function measureLatex(text: string): { w: number; h: number } {
   if (latexMetricsCache.has(text)) return latexMetricsCache.get(text)!;
@@ -915,10 +916,30 @@ function setVisualCheckStatus(lines: string | string[]): void {
   visualCheckEl.textContent = Array.isArray(lines) ? lines.join("\n") : String(lines || "");
 }
 
+let _appliedCanvasWidth = "";
+let _appliedCanvasHeight = "";
+let _appliedCanvasTransform = "";
+let _linearPanelLayoutDirty = true;
+let _linearPanelAnchorCanvasX = VIEWER_TUNING.layout.leftPad;
+let _linearPanelAnchorCanvasY = VIEWER_TUNING.layout.topPad;
+let _linearPanelCanvasHeight = 380;
+
 function applyZoom(): void {
-  canvas.style.width = `${contentWidth}px`;
-  canvas.style.height = `${contentHeight}px`;
-  canvas.style.transform = `translate(${viewState.cameraX}px, ${viewState.cameraY}px) scale(${viewState.zoom})`;
+  const widthValue = `${contentWidth}px`;
+  if (_appliedCanvasWidth !== widthValue) {
+    canvas.style.width = widthValue;
+    _appliedCanvasWidth = widthValue;
+  }
+  const heightValue = `${contentHeight}px`;
+  if (_appliedCanvasHeight !== heightValue) {
+    canvas.style.height = heightValue;
+    _appliedCanvasHeight = heightValue;
+  }
+  const transformValue = `translate(${viewState.cameraX}px, ${viewState.cameraY}px) scale(${viewState.zoom})`;
+  if (_appliedCanvasTransform !== transformValue) {
+    canvas.style.transform = transformValue;
+    _appliedCanvasTransform = transformValue;
+  }
   syncInlineEditorPosition();
   syncLinearPanelPosition();
 }
@@ -934,56 +955,51 @@ function syncLinearPanelPosition(): void {
     linearPanelEl.style.removeProperty("width");
     linearPanelEl.style.removeProperty("height");
     linearPanelEl.style.removeProperty("transform");
+    _linearPanelLayoutDirty = true;
     return;
   }
 
-  const layout = lastLayout;
-
-  let deepestDepth = -1;
-  let deepestRightEdge = VIEWER_TUNING.layout.leftPad;
-  let deepestTop = VIEWER_TUNING.layout.topPad;
-  visibleOrder.forEach((nodeId) => {
-    const p = layout.pos[nodeId];
-    if (!p) {
-      return;
+  if (_linearPanelLayoutDirty) {
+    const layout = lastLayout;
+    let deepestDepth = -1;
+    let deepestRightEdge = VIEWER_TUNING.layout.leftPad;
+    let treeMinY = Number.POSITIVE_INFINITY;
+    let treeMaxY = Number.NEGATIVE_INFINITY;
+    visibleOrder.forEach((nodeId) => {
+      const p = layout.pos[nodeId];
+      if (!p) {
+        return;
+      }
+      treeMinY = Math.min(treeMinY, p.y - p.h / 2);
+      treeMaxY = Math.max(treeMaxY, p.y + p.h / 2);
+      if (p.depth > deepestDepth) {
+        deepestDepth = p.depth;
+        deepestRightEdge = p.x + p.w;
+        return;
+      }
+      if (p.depth === deepestDepth) {
+        deepestRightEdge = Math.max(deepestRightEdge, p.x + p.w);
+      }
+    });
+    if (!Number.isFinite(treeMinY) || !Number.isFinite(treeMaxY)) {
+      treeMinY = VIEWER_TUNING.layout.topPad;
+      treeMaxY = treeMinY + 380;
     }
-    if (p.depth > deepestDepth) {
-      deepestDepth = p.depth;
-      deepestRightEdge = p.x + p.w;
-      deepestTop = p.y - p.h / 2;
-      return;
-    }
-    if (p.depth === deepestDepth) {
-      deepestRightEdge = Math.max(deepestRightEdge, p.x + p.w);
-      deepestTop = Math.min(deepestTop, p.y - p.h / 2);
-    }
-  });
+    const depthOffset = Math.max(56, VIEWER_TUNING.layout.columnGap * 0.45);
+    _linearPanelAnchorCanvasX = deepestRightEdge + depthOffset;
+    _linearPanelAnchorCanvasY = Math.max(VIEWER_TUNING.layout.topPad, treeMinY - 12);
+    _linearPanelCanvasHeight = Math.max(220, treeMaxY - treeMinY + 24);
+    _linearPanelLayoutDirty = false;
+  }
 
   const panelCanvasWidth = linearPanelCanvasWidth;
-  let treeMinY = Number.POSITIVE_INFINITY;
-  let treeMaxY = Number.NEGATIVE_INFINITY;
-  visibleOrder.forEach((nodeId) => {
-    const p = layout.pos[nodeId];
-    if (!p) {
-      return;
-    }
-    treeMinY = Math.min(treeMinY, p.y - p.h / 2);
-    treeMaxY = Math.max(treeMaxY, p.y + p.h / 2);
-  });
-  if (!Number.isFinite(treeMinY) || !Number.isFinite(treeMaxY)) {
-    treeMinY = VIEWER_TUNING.layout.topPad;
-    treeMaxY = treeMinY + 380;
-  }
-  const panelCanvasHeight = Math.max(220, treeMaxY - treeMinY + 24);
-  const depthOffset = Math.max(56, VIEWER_TUNING.layout.columnGap * 0.45);
-  const anchorCanvasX = deepestRightEdge + depthOffset;
-  const anchorCanvasY = Math.max(VIEWER_TUNING.layout.topPad, treeMinY - 12);
+  const panelCanvasHeight = _linearPanelCanvasHeight;
   const zoomScale = viewState.zoom;
   const panelWidth = panelCanvasWidth * zoomScale;
   const panelHeight = panelCanvasHeight * zoomScale;
 
-  const panelLeft = viewState.cameraX + anchorCanvasX * viewState.zoom;
-  const panelTop = viewState.cameraY + anchorCanvasY * viewState.zoom;
+  const panelLeft = viewState.cameraX + _linearPanelAnchorCanvasX * viewState.zoom;
+  const panelTop = viewState.cameraY + _linearPanelAnchorCanvasY * viewState.zoom;
 
   linearPanelEl.style.left = `${Math.round(panelLeft)}px`;
   linearPanelEl.style.top = `${Math.round(panelTop)}px`;
@@ -1756,6 +1772,30 @@ function updateDocumentTitle(): void {
   document.title = scopeLabel ? `${appTitle} - ${scopeLabel}` : appTitle;
 }
 
+let _renderScheduled = false;
+function scheduleRender(): void {
+  if (_renderScheduled) {
+    return;
+  }
+  _renderScheduled = true;
+  requestAnimationFrame(() => {
+    _renderScheduled = false;
+    render();
+  });
+}
+
+let _zoomApplyScheduled = false;
+function scheduleApplyZoom(): void {
+  if (_zoomApplyScheduled) {
+    return;
+  }
+  _zoomApplyScheduled = true;
+  requestAnimationFrame(() => {
+    _zoomApplyScheduled = false;
+    applyZoom();
+  });
+}
+
 function render(): void {
   if (!doc) {
     syncThinkingModeUi();
@@ -1779,6 +1819,7 @@ function render(): void {
   const layout = buildLayout(state);
   lastLayout = layout;
   visibleOrder = layout.order;
+  _linearPanelLayoutDirty = true;
   const displayRootId = currentScopeRootId();
 
   const pos = layout.pos;
@@ -1882,8 +1923,12 @@ function render(): void {
         nodes += `<rect class="folder-box" data-node-id="${nodeId}" x="${folderFrameX}" y="${folderFrameY}" width="${folderFrameW}" height="${folderFrameH}" rx="8" />`;
       }
       if (isLatexNode(node)) {
-        const { latex, displayMode } = latexSource(node.text);
-        const htmlStr = katex.renderToString(latex, { displayMode, throwOnError: false });
+        let htmlStr = latexHtmlCache.get(node.text);
+        if (!htmlStr) {
+          const { latex, displayMode } = latexSource(node.text);
+          htmlStr = katex.renderToString(latex, { displayMode, throwOnError: false });
+          latexHtmlCache.set(node.text, htmlStr);
+        }
         const foH = p.h;
         const foY = p.y - foH / 2;
         nodes += `<foreignObject data-node-id="${nodeId}" x="${p.x}" y="${foY}" width="${p.w}" height="${foH}"><div xmlns="http://www.w3.org/1999/xhtml" class="latex-node-content">${htmlStr}</div></foreignObject>`;
@@ -2327,7 +2372,7 @@ function setSingleSelection(nodeId: string, renderNow = true): void {
   viewState.selectedNodeIds = new Set([nodeId]);
   viewState.selectionAnchorId = null;
   if (renderNow) {
-    render();
+    scheduleRender();
   }
 }
 
@@ -2354,7 +2399,7 @@ function setRangeSelection(targetId: string): void {
   viewState.selectionAnchorId = anchorId;
   viewState.selectedNodeIds = getVisibleRangeSelection(anchorId, targetId);
   viewState.selectedNodeIds.add(targetId);
-  render();
+  scheduleRender();
 }
 
 function toggleNodeSelection(nodeId: string): void {
@@ -2362,20 +2407,20 @@ function toggleNodeSelection(nodeId: string): void {
   if (viewState.selectedNodeIds.has(nodeId)) {
     if (viewState.selectedNodeIds.size === 1) {
       viewState.selectedNodeId = nodeId;
-      render();
+      scheduleRender();
       return;
     }
     viewState.selectedNodeIds.delete(nodeId);
     if (viewState.selectedNodeId === nodeId) {
       viewState.selectedNodeId = viewState.selectedNodeIds.values().next().value as string;
     }
-    render();
+    scheduleRender();
     return;
   }
 
   viewState.selectedNodeIds.add(nodeId);
   viewState.selectedNodeId = nodeId;
-  render();
+  scheduleRender();
 }
 
 function selectNode(nodeId: string): void {
@@ -2498,6 +2543,7 @@ function applyNodeTextEdit(nodeId: string, nextRaw: string, mode: "node-text" | 
       }
       pushUndoSnapshot();
       latexMetricsCache.delete(target.text);
+      latexHtmlCache.delete(target.text);
       target.text = next;
       syncAliasDisplayForTarget(target.id);
       touchDocument();
@@ -2517,6 +2563,7 @@ function applyNodeTextEdit(nodeId: string, nextRaw: string, mode: "node-text" | 
   }
   pushUndoSnapshot();
   latexMetricsCache.delete(node.text);
+  latexHtmlCache.delete(node.text);
   node.text = next;
   syncAliasDisplayForTarget(node.id);
   touchDocument();
@@ -2808,7 +2855,7 @@ async function saveDocToLocalDb(showStatus = false): Promise<boolean> {
     if (showStatus) {
       setStatus("Saved locally.");
     }
-    render();
+    scheduleRender();
     return true;
   } catch (err) {
     if (showStatus) {
@@ -2886,7 +2933,7 @@ async function pushDocToCloud(showStatus = false, force = false): Promise<boolea
     if (showStatus) {
       setStatus(force ? "Cloud sync force-push completed." : "Cloud sync push completed.");
     }
-    render();
+    scheduleRender();
     return true;
   } catch (err) {
     if (showStatus) {
@@ -2984,7 +3031,7 @@ function initBroadcastSync(): void {
     }
     if (ev.data.type === "STATE_UPDATE") {
       doc.state = ev.data.state;
-      render();
+      scheduleRender();
     }
   };
   window.addEventListener("beforeunload", () => bc?.close());
@@ -3149,7 +3196,7 @@ function extendSelectionBreadth(direction: -1 | 1): void {
   const anchorId = viewState.selectionAnchorId || viewState.selectedNodeId;
   viewState.selectedNodeIds = getVisibleRangeSelection(anchorId, target);
   viewState.selectedNodeIds.add(target);
-  render();
+  scheduleRender();
   setStatus(`Selected ${viewState.selectedNodeIds.size} node(s).`);
 }
 
@@ -3343,7 +3390,7 @@ function markReparentSource(): void {
   viewState.reparentSourceIds = new Set(viewState.selectedNodeIds);
   const roots = getMovableSelectionRoots(viewState.reparentSourceIds);
   setStatus(`Marked move nodes: ${roots.length}`);
-  render();
+  scheduleRender();
 }
 
 function sameIdSet(left: Set<string>, right: Set<string>): boolean {
@@ -3369,20 +3416,20 @@ function toggleReparentSource(): void {
   if (nextRoots.size === 0) {
     viewState.reparentSourceIds.clear();
     setStatus("No move node selected.", true);
-    render();
+    scheduleRender();
     return;
   }
 
   if (sameIdSet(currentRoots, nextRoots)) {
     viewState.reparentSourceIds.clear();
     setStatus("Move node mark cleared.");
-    render();
+    scheduleRender();
     return;
   }
 
   viewState.reparentSourceIds = nextSourceIds;
   setStatus(`Marked move nodes: ${nextRoots.size}`);
-  render();
+  scheduleRender();
 }
 
 function toggleHoldReparent(): void {
@@ -3476,7 +3523,7 @@ function selectAllVisibleInScope(): void {
   viewState.selectedNodeId = firstVisibleId;
   viewState.selectedNodeIds = new Set(visibleOrder);
   viewState.selectionAnchorId = firstVisibleId;
-  render();
+  scheduleRender();
   setStatus(`Selected ${viewState.selectedNodeIds.size} node(s).`);
 }
 
@@ -3528,7 +3575,7 @@ function copySelected(): void {
     snapshots,
   };
   void copyTextToSystemClipboard(roots.map((rootId) => uiLabel(getNode(rootId))).join("\n"));
-  render();
+  scheduleRender();
   setStatus(`Copied ${roots.length} node(s).`);
 }
 
@@ -3542,7 +3589,7 @@ function cutSelected(): void {
     type: "cut",
     sourceIds: new Set(roots),
   };
-  render();
+  scheduleRender();
   setStatus(`Cut pending: ${roots.length} node(s).`);
 }
 
@@ -3584,7 +3631,7 @@ function pasteClipboard(): void {
     .filter((nodeId) => getNode(nodeId).parentId !== null);
   if (cutRoots.length === 0) {
     viewState.clipboardState = null;
-    render();
+    scheduleRender();
     setStatus("No cut nodes available.", true);
     return;
   }
@@ -3612,7 +3659,7 @@ function clearCutClipboard(): boolean {
     return false;
   }
   viewState.clipboardState = null;
-  render();
+  scheduleRender();
   setStatus("Cut pending cleared.");
   return true;
 }
@@ -3864,7 +3911,7 @@ importanceViewSelect?.addEventListener("change", () => {
   const nextMode = importanceViewSelect.value as ImportanceViewMode;
   importanceViewMode = nextMode;
   linearDirty = false;
-  render();
+  scheduleRender();
   setStatus(`Importance view: ${nextMode}`);
 });
 
@@ -3964,10 +4011,10 @@ canvas.addEventListener("pointerdown", (event: PointerEvent) => {
   const collapseNodeId = (event.target as Element | null)?.getAttribute("data-collapse-node-id");
   if (collapseNodeId && event.button === 0) {
     event.preventDefault();
-    selectNode(collapseNodeId);
+    setSingleSelection(collapseNodeId, false);
     if (viewState.collapsedIds.has(collapseNodeId)) {
       viewState.collapsedIds.delete(collapseNodeId);
-      render();
+      scheduleRender();
       setStatus("Expanded collapsed branch.");
     }
     board.focus();
@@ -4006,7 +4053,7 @@ canvas.addEventListener("pointermove", (event: PointerEvent) => {
   }
   viewState.dragState.dragged = true;
   viewState.dragState.proposal = proposeDropForSources(viewState.dragState.sourceRootIds, event.clientX, event.clientY);
-  render();
+  scheduleRender();
 });
 
 function finishNodeDrag(event: PointerEvent): void {
@@ -4045,7 +4092,6 @@ function finishNodeDrag(event: PointerEvent): void {
         setSingleSelection(proposal.parentId, false);
         touchDocument();
         setStatus(`Moved ${movedCount} node(s).`);
-        render();
         board.focus();
         return;
       }
@@ -4055,7 +4101,7 @@ function finishNodeDrag(event: PointerEvent): void {
         : applyMoveByParentAndIndex(sourceNodeId, proposal.parentId, proposal.index, false);
       if (applied) {
         setSingleSelection(sourceNodeId, false);
-        render();
+        scheduleRender();
         board.focus();
         return;
       }
@@ -4063,7 +4109,7 @@ function finishNodeDrag(event: PointerEvent): void {
   }
 
   setStatus("No valid drop target.", true);
-  render();
+  scheduleRender();
   board.focus();
 }
 
@@ -4098,7 +4144,7 @@ board.addEventListener("wheel", (event: WheelEvent) => {
   if (!event.ctrlKey && !event.metaKey) {
     viewState.cameraX -= deltaX * VIEWER_TUNING.pan.wheelFactor;
     viewState.cameraY -= deltaY * VIEWER_TUNING.pan.wheelFactor;
-    applyZoom();
+    scheduleApplyZoom();
     return;
   }
   const intensity = Math.min(
@@ -4137,7 +4183,7 @@ board.addEventListener("pointermove", (event: PointerEvent) => {
   }
   viewState.cameraX = viewState.panState.cameraX + (event.clientX - viewState.panState.startX);
   viewState.cameraY = viewState.panState.cameraY + (event.clientY - viewState.panState.startY);
-  applyZoom();
+  scheduleApplyZoom();
 });
 
 function endPan(event: PointerEvent): void {

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -4089,17 +4089,23 @@ board.addEventListener("wheel", (event: WheelEvent) => {
     return;
   }
   event.preventDefault();
+  // Normalize deltas to pixels so zoom/pan feel identical across browsers and
+  // operating systems. deltaMode=0 (pixel) is left as-is — that is the Mac
+  // trackpad baseline everything else is scaled to match.
+  const deltaScale = event.deltaMode === 1 ? 40 : event.deltaMode === 2 ? 800 : 1;
+  const deltaX = event.deltaX * deltaScale;
+  const deltaY = event.deltaY * deltaScale;
   if (!event.ctrlKey && !event.metaKey) {
-    viewState.cameraX -= event.deltaX * VIEWER_TUNING.pan.wheelFactor;
-    viewState.cameraY -= event.deltaY * VIEWER_TUNING.pan.wheelFactor;
+    viewState.cameraX -= deltaX * VIEWER_TUNING.pan.wheelFactor;
+    viewState.cameraY -= deltaY * VIEWER_TUNING.pan.wheelFactor;
     applyZoom();
     return;
   }
   const intensity = Math.min(
     VIEWER_TUNING.zoom.wheelIntensityCap,
-    Math.abs(event.deltaY) / VIEWER_TUNING.zoom.wheelIntensityDivisor
+    Math.abs(deltaY) / VIEWER_TUNING.zoom.wheelIntensityDivisor
   );
-  const factor = Math.exp(-Math.sign(event.deltaY) * intensity);
+  const factor = Math.exp(-Math.sign(deltaY) * intensity);
   setZoom(viewState.zoom * factor, event.clientX, event.clientY);
 }, { passive: false });
 

--- a/beta/tests/visual/viewer.visual.spec.js
+++ b/beta/tests/visual/viewer.visual.spec.js
@@ -28,6 +28,15 @@ async function getSelectedCount(page) {
   return Number(match[1]);
 }
 
+async function getLinkCount(page) {
+  const metaText = await page.locator("#meta").textContent();
+  const match = (metaText || "").match(/links:\s*(\d+)/);
+  if (!match) {
+    throw new Error(`Unable to parse link count from meta: ${metaText}`);
+  }
+  return Number(match[1]);
+}
+
 async function loadJsonDoc(page, doc) {
   const isolatedDocId = `rapid-visual-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
   const qs = `localDocId=${encodeURIComponent(isolatedDocId)}&cloudDocId=${encodeURIComponent(isolatedDocId)}`;
@@ -226,6 +235,55 @@ test("viewer multi reparent ignores root in marked sources", async ({ page }) =>
 
   await expect(page.locator("#status")).toContainText("Moved 2 node(s).");
   await expect(page.locator("#meta")).toContainText("selected: New Node");
+});
+
+// 目的: link source をマークして別ノードへ適用すると、graph link が作成され描画されることを確認する。
+test("viewer add graph link by toolbar flow", async ({ page }) => {
+  await loadAndStabilize(page, "#load-default");
+
+  const question = page.locator("text.label-node", { hasText: "Question" }).first();
+  const hypothesis = page.locator("text.label-node", { hasText: "Hypothesis v2" }).first();
+
+  await question.click({ force: true });
+  await page.click("#mark-link");
+  await expect(page.locator("#meta")).toContainText("link-source: Question");
+
+  await hypothesis.click({ force: true });
+  await page.click("#apply-link");
+
+  expect(await getLinkCount(page)).toBe(1);
+  await expect(page.locator("#status")).toContainText("Linked Question -> Hypothesis v2.");
+  await expect(page.locator("path.graph-link")).toHaveCount(1);
+});
+
+// 目的: 保存済み links を含む JSON を読み込んだとき、graph link が描画されることを確認する。
+test("viewer renders persisted graph link", async ({ page }) => {
+  const doc = {
+    version: 1,
+    savedAt: "2026-04-08T00:00:00.000Z",
+    state: {
+      rootId: "root",
+      nodes: {
+        root: { id: "root", parentId: null, children: ["a", "b"], nodeType: "text", text: "Root", collapsed: false, details: "", note: "", attributes: {}, link: "" },
+        a: { id: "a", parentId: "root", children: [], nodeType: "text", text: "A", collapsed: false, details: "", note: "", attributes: {}, link: "" },
+        b: { id: "b", parentId: "root", children: [], nodeType: "text", text: "B", collapsed: false, details: "", note: "", attributes: {}, link: "" },
+      },
+      links: {
+        link_1: {
+          id: "link_1",
+          sourceNodeId: "a",
+          targetNodeId: "b",
+          direction: "forward",
+          style: "default",
+        },
+      },
+    },
+  };
+
+  await loadJsonDoc(page, doc);
+
+  expect(await getLinkCount(page)).toBe(1);
+  await expect(page.locator("path.graph-link[data-link-id='link_1']")).toHaveCount(1);
 });
 
 // 目的: Shift+ArrowUp/Down で可視順に選択が拡張されることを確認する。

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -292,6 +292,38 @@
         fill: none;
         stroke-width: 4;
         stroke-linecap: round;
+        pointer-events: none;
+      }
+
+      .graph-link {
+        fill: none;
+        stroke: #2a7188;
+        stroke-width: 3;
+        stroke-linecap: round;
+        opacity: 0.95;
+        pointer-events: none;
+      }
+
+      .graph-link.graph-link-soft {
+        stroke: #7ca6b3;
+        stroke-width: 2.5;
+        opacity: 0.82;
+      }
+
+      .graph-link.graph-link-dashed {
+        stroke-dasharray: 10 7;
+      }
+
+      .graph-link.graph-link-emphasis {
+        stroke: #126e83;
+        stroke-width: 4.5;
+      }
+
+      .graph-link-label {
+        fill: #245567;
+        font-size: 12px;
+        font-weight: 700;
+        pointer-events: none;
       }
 
       .root-box {
@@ -330,6 +362,12 @@
 
 .node-hit.reparent-source {
   stroke-dasharray: 8 5;
+}
+
+.node-hit.link-source {
+  stroke: #2a7188;
+  stroke-width: 3;
+  stroke-dasharray: 5 4;
 }
 
 .node-hit.cut-pending {

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -297,7 +297,6 @@
 
       .graph-link {
         fill: none;
-        stroke: #2a7188;
         stroke-width: 3;
         stroke-linecap: round;
         opacity: 0.95;
@@ -305,9 +304,8 @@
       }
 
       .graph-link.graph-link-soft {
-        stroke: #7ca6b3;
         stroke-width: 2.5;
-        opacity: 0.82;
+        opacity: 0.72;
       }
 
       .graph-link.graph-link-dashed {
@@ -315,12 +313,11 @@
       }
 
       .graph-link.graph-link-emphasis {
-        stroke: #126e83;
         stroke-width: 4.5;
       }
 
       .graph-link-label {
-        fill: #245567;
+        fill: #555;
         font-size: 12px;
         font-weight: 700;
         pointer-events: none;
@@ -365,7 +362,7 @@
 }
 
 .node-hit.link-source {
-  stroke: #2a7188;
+  stroke: var(--accent);
   stroke-width: 3;
   stroke-dasharray: 5 4;
 }

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -165,6 +165,10 @@
         pointer-events: auto;
       }
 
+      .meta-panel[hidden] {
+        display: none;
+      }
+
       .visual-check {
         display: none;
         padding: 8px 10px;

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -498,6 +498,10 @@
         pointer-events: none;
       }
 
+      .latex-node-content .katex-display {
+        margin: 0;
+      }
+
       @media (max-width: 900px) {
         .label-root,
         .label-node {

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -33,6 +33,9 @@
           <button id="ai-generate-topics">AI topics</button>
           <button id="delete-node" class="danger">Delete</button>
           <span class="toolbar-sep">|</span>
+          <button id="mark-link">Mark link</button>
+          <button id="apply-link">Add link</button>
+          <span class="toolbar-sep">|</span>
           <button id="mark-reparent">Mark move</button>
           <button id="apply-reparent">Apply move</button>
           <span class="toolbar-sep">|</span>

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -54,11 +54,11 @@
           <button id="zoom-in">+</button>
           <button id="fit-all">Fit all</button>
           <button id="focus-selected">Focus</button>
-          <button id="toggle-meta-panel">Hide meta</button>
+          <button id="toggle-meta-panel">Show meta</button>
           <span class="toolbar-sep">|</span>
           <button id="download-btn">Download JSON</button>
         </div>
-        <div class="meta-panel" aria-label="Meta panel">
+        <div class="meta-panel" aria-label="Meta panel" hidden>
           <div id="mode-meta" class="meta">mode: Rapid</div>
           <div id="scope-meta" class="meta">scope: root</div>
           <div id="scope-summary" class="meta">outside: none</div>

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -41,6 +41,17 @@
 - `npm --prefix beta run build`: pass
 - `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
 
+## 追加実施（Beta: graph link を edge 同様のベジェ曲線に修正）
+
+- `beta/src/browser/viewer.ts`
+  - graph link の経路を center-to-center の quadratic から、ノード外周アンカーを使う cubic bezier に変更
+  - tree edge と同じ `edgeStartPad` / `edgeEndPad` / cubic 制御点ロジックへ寄せ、線本体がノードの下に埋もれにくいよう修正
+
+## 確認（Beta: graph link を edge 同様のベジェ曲線に修正）
+
+- `npm --prefix beta run build`: pass
+- `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
+
 ## 依存関係メモ
 
 - npm 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -26,6 +26,21 @@
 - `npm --prefix beta run test:unit`: pass
 - `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
 
+## 追加実施（Beta: graph link の見た目を tree edge に寄せる）
+
+- `beta/src/browser/viewer.ts`
+  - graph link の色を固定色から edge palette ベースへ変更
+  - 矢印 marker も link ごとの stroke 色に追従するよう更新
+- `beta/viewer.css`
+  - graph link の base style を edge に近い見た目へ調整
+  - label 色を中立寄りに変更
+  - source マーク色を既存 accent に寄せて統一感を改善
+
+## 確認（Beta: graph link の見た目を tree edge に寄せる）
+
+- `npm --prefix beta run build`: pass
+- `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
+
 ## 依存関係メモ
 
 - npm 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -52,6 +52,17 @@
 - `npm --prefix beta run build`: pass
 - `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
 
+## 追加実施（Beta: graph link の stroke 不在を修正）
+
+- `beta/src/browser/viewer.ts`
+  - graph link 色選択の index が小数になり得る不具合を修正し、常に palette の有効色を選ぶよう更新
+  - SVG `defs` を正しく閉じるよう整形し、marker 定義を安定化
+
+## 確認（Beta: graph link の stroke 不在を修正）
+
+- `npm --prefix beta run build`: pass
+- `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
+
 ## 依存関係メモ
 
 - npm 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -1,0 +1,35 @@
+# 2026-04-08 Daily
+
+## 追加実施（Beta: ノード間 graph link 追加）
+
+- `beta/viewer.html`
+  - ツールバーに `Mark link` / `Add link` ボタンを追加
+- `beta/src/browser/viewer.ts`
+  - 選択ノードを graph link の source としてマークする状態を追加
+  - source をマーク後、別ノード選択で link を作成する処理を追加
+  - alias ノードや自己リンクを拒否し、重複 link も抑止
+  - `state.links` を viewer 側でも正規化して読み込むよう更新
+  - graph link の SVG 描画を追加
+  - meta 表示に `links` 件数と `link-source` を追加
+  - キーボード操作として `L` で source マーク、`Shift+L` で link 作成を追加
+- `beta/viewer.css`
+  - graph link 線、ラベル、source マークのスタイルを追加
+- `beta/src/browser/viewer.globals.d.ts`
+  - `ViewState` に `linkSourceNodeId` を追加
+- `beta/tests/visual/viewer.visual.spec.js`
+  - ツールバー経由で graph link を追加できることを確認する visual テストを追加
+  - `links` を含む JSON 読み込み時に graph link が描画されることを確認する visual テストを追加
+
+## 確認（Beta: ノード間 graph link 追加）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+- `cd beta && npx playwright test -g "viewer add graph link by toolbar flow|viewer renders persisted graph link"`: pass (2 tests)
+
+## 依存関係メモ
+
+- npm 依存関係の追加なし
+
+## 次
+
+- graph link の削除・編集（ラベル、方向、style）UI を追加するか検討

--- a/final/src/browser/viewer.ts
+++ b/final/src/browser/viewer.ts
@@ -3926,17 +3926,23 @@ board.addEventListener("wheel", (event: WheelEvent) => {
     return;
   }
   event.preventDefault();
+  // Normalize deltas to pixels so zoom/pan feel identical across browsers and
+  // operating systems. deltaMode=0 (pixel) is left as-is — that is the Mac
+  // trackpad baseline everything else is scaled to match.
+  const deltaScale = event.deltaMode === 1 ? 40 : event.deltaMode === 2 ? 800 : 1;
+  const deltaX = event.deltaX * deltaScale;
+  const deltaY = event.deltaY * deltaScale;
   if (!event.ctrlKey && !event.metaKey) {
-    viewState.cameraX -= event.deltaX * VIEWER_TUNING.pan.wheelFactor;
-    viewState.cameraY -= event.deltaY * VIEWER_TUNING.pan.wheelFactor;
+    viewState.cameraX -= deltaX * VIEWER_TUNING.pan.wheelFactor;
+    viewState.cameraY -= deltaY * VIEWER_TUNING.pan.wheelFactor;
     applyZoom();
     return;
   }
   const intensity = Math.min(
     VIEWER_TUNING.zoom.wheelIntensityCap,
-    Math.abs(event.deltaY) / VIEWER_TUNING.zoom.wheelIntensityDivisor
+    Math.abs(deltaY) / VIEWER_TUNING.zoom.wheelIntensityDivisor
   );
-  const factor = Math.exp(-Math.sign(event.deltaY) * intensity);
+  const factor = Math.exp(-Math.sign(deltaY) * intensity);
   setZoom(viewState.zoom * factor, event.clientX, event.clientY);
 }, { passive: false });
 

--- a/final/viewer.css
+++ b/final/viewer.css
@@ -165,6 +165,10 @@
         pointer-events: auto;
       }
 
+      .meta-panel[hidden] {
+        display: none;
+      }
+
       .visual-check {
         display: none;
         padding: 8px 10px;

--- a/final/viewer.html
+++ b/final/viewer.html
@@ -53,11 +53,11 @@
           <button id="zoom-in">+</button>
           <button id="fit-all">Fit all</button>
           <button id="focus-selected">Focus</button>
-          <button id="toggle-meta-panel">Hide meta</button>
+          <button id="toggle-meta-panel">Show meta</button>
           <span class="toolbar-sep">|</span>
           <button id="download-btn">Download JSON</button>
         </div>
-        <div class="meta-panel" aria-label="Meta panel">
+        <div class="meta-panel" aria-label="Meta panel" hidden>
           <div id="mode-meta" class="meta">mode: Rapid</div>
           <div id="scope-meta" class="meta">scope: root</div>
           <div id="scope-summary" class="meta">outside: none</div>


### PR DESCRIPTION
## Summary

- KaTeXによるテキストノードへのLaTeXレンダリング機能を追加
- 可変高さレイアウトとLaTeXノードのサイジングを修正
- 高速パン・ズーム・メタキー操作の修正
- 中国語テキストボックス幅の修正

## Changes

- `feat: LaTeX rendering in text nodes via KaTeX` — KaTeX静的アセット追加、viewer.tsにレンダリング実装
- `Fix variable-height layout and LaTeX node sizing` — レイアウト計算の修正
- `fix: fast pan` / `fix: zoom, meta` — 操作系バグ修正
- `fix: reorder bug` / `fix: correct textbox width for Chinese characters` — その他修正

## Test plan

- [ ] LaTeXノードが正しくレンダリングされることを確認
- [ ] パン・ズーム操作が正常に動作することを確認
- [ ] ビジュアルテスト (`viewer.visual.spec.js`) がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)