### PR TITLE
Persist linear memo text across reloads

### DIFF
--- a/beta/src/browser/viewer.globals.d.ts
+++ b/beta/src/browser/viewer.globals.d.ts
@@ -45,6 +45,7 @@ interface AppState {
   rootId: string;
   nodes: Record<string, TreeNode>;
   links?: Record<string, GraphLink>;
+  linearNotesByScope?: Record<string, string>;
 }
 
 interface SavedDoc {

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -250,6 +250,37 @@ function createEmptyDoc(): SavedDoc {
   };
 }
 
+function sanitizeLinearNotesByScope(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+  const sanitized: Record<string, string> = {};
+  Object.entries(raw as Record<string, unknown>).forEach(([scopeId, memo]) => {
+    if (!scopeId) {
+      return;
+    }
+    sanitized[scopeId] = String(memo ?? "");
+  });
+  return sanitized;
+}
+
+function hydrateLinearNotesFromDocState(): void {
+  Object.keys(linearNotesByScope).forEach((scopeId) => {
+    delete linearNotesByScope[scopeId];
+  });
+  if (!doc) {
+    return;
+  }
+  Object.assign(linearNotesByScope, sanitizeLinearNotesByScope(doc.state.linearNotesByScope));
+}
+
+function syncLinearNotesToDocState(): void {
+  if (!doc) {
+    return;
+  }
+  doc.state.linearNotesByScope = { ...linearNotesByScope };
+}
+
 function ensureDocShape(payload: unknown): SavedDoc {
   const p = payload as Record<string, unknown>;
   const candidate = (p && p["state"])
@@ -293,6 +324,7 @@ function ensureDocShape(payload: unknown): SavedDoc {
       style: record.style || "default",
     };
   });
+  candidate.state.linearNotesByScope = sanitizeLinearNotesByScope(candidate.state.linearNotesByScope);
   return candidate as SavedDoc;
 }
 
@@ -1551,6 +1583,7 @@ function renderLinearPanel(): void {
   const templateText = buildLinearFromScope().text;
   if (!(scopeRootId in linearNotesByScope)) {
     linearNotesByScope[scopeRootId] = templateText;
+    syncLinearNotesToDocState();
   }
   const scopeMemo = linearNotesByScope[scopeRootId] || "";
   linearDirty = scopeMemo !== templateText;
@@ -3072,6 +3105,7 @@ function downloadJson(): void {
 }
 
 function currentDocSnapshot(): SavedDoc {
+  syncLinearNotesToDocState();
   return {
     version: 1,
     savedAt: nowIso(),
@@ -3454,6 +3488,7 @@ function extendSelectionBreadth(direction: -1 | 1): void {
 function loadPayload(payload: unknown): void {
   try {
     doc = ensureDocShape(payload);
+    hydrateLinearNotesFromDocState();
     undoStack = [];
     redoStack = [];
     linearDirty = false;
@@ -4052,6 +4087,8 @@ linearTextEl?.addEventListener("input", () => {
   }
   const scopeRootId = currentLinearMemoScopeId();
   linearNotesByScope[scopeRootId] = linearTextEl.value;
+  syncLinearNotesToDocState();
+  scheduleAutosave();
   const templateText = buildLinearFromScope().text;
   linearDirty = linearTextEl.value !== templateText;
   if (linearMetaEl) {
@@ -4069,12 +4106,16 @@ linearTextEl?.addEventListener("keydown", (event: KeyboardEvent) => {
   if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
     event.preventDefault();
     linearNotesByScope[currentLinearMemoScopeId()] = linearTextEl.value;
+    syncLinearNotesToDocState();
+    scheduleAutosave();
     setStatus("Linear memo saved in current scope.");
     return;
   }
   if (event.key === "Escape") {
     event.preventDefault();
     linearNotesByScope[currentLinearMemoScopeId()] = buildLinearFromScope().text;
+    syncLinearNotesToDocState();
+    scheduleAutosave();
     renderLinearPanel();
     setStatus("Linear memo reset to outline template.");
   }

--- a/beta/src/shared/types.ts
+++ b/beta/src/shared/types.ts
@@ -36,6 +36,7 @@ export interface AppState {
   rootId: string;
   nodes: Record<string, TreeNode>;
   links?: Record<string, GraphLink>;
+  linearNotesByScope?: Record<string, string>;
 }
 
 export interface SavedDoc {

--- a/beta/tests/unit/persistence_db_behavior.test.js
+++ b/beta/tests/unit/persistence_db_behavior.test.js
@@ -106,6 +106,10 @@ test("saveToSqlite and loadFromSqlite round-trip", () => {
   model.editNode(child, "Child Updated");
   model.addAlias(rootId, child, { aliasLabel: "Child Alias", access: "write" });
   model.addLink(child, sibling, { direction: "forward", style: "soft" });
+  model.state.linearNotesByScope = {
+    [rootId]: "Root memo",
+    [child]: "Child memo",
+  };
 
   const { base, filePath } = makeTempPath("nested", "rapid.sqlite");
   model.saveToSqlite(filePath, "doc-a");

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -98,6 +98,24 @@
 - `.gitignore`
   - M3E開発向けの除外パターンを整理・更新
 
+## 追加実施（Beta: Linear Text のリロード時リセット修正）
+
+- `beta/src/browser/viewer.ts`
+  - `linearNotesByScope` を `doc.state.linearNotesByScope` へ同期する処理を追加
+  - ドキュメント読込時に保存済み linear memo を復元する処理を追加
+  - Linear Text 入力時に autosave をスケジュールするよう更新
+  - 初回スコープ表示時に生成されるテンプレートも state 側へ同期するよう更新
+- `beta/src/shared/types.ts`
+  - `AppState` に `linearNotesByScope?: Record<string, string>` を追加
+- `beta/src/browser/viewer.globals.d.ts`
+  - browser 側 `AppState` 宣言へ `linearNotesByScope` を追加
+- `beta/tests/unit/persistence_db_behavior.test.js`
+  - SQLite round-trip テストに `linearNotesByScope` を追加し、永続化維持を検証
+
+## 確認（Beta: Linear Text のリロード時リセット修正）
+
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし


### PR DESCRIPTION
## Summary
- persist Linear Text memos per scope in state.linearNotesByScope
- restore memo state on load instead of falling back to auto-format template
- trigger autosave on Linear Text edits and keep snapshot sync with memo state
- add SQLite round-trip coverage for linearNotesByScope

## Verification
- npm --prefix beta run test:unit