### PR TITLE
Stabilize linear text persistence and input UX on Beta

### DIFF
--- a/beta/src/browser/viewer.globals.d.ts
+++ b/beta/src/browser/viewer.globals.d.ts
@@ -46,6 +46,7 @@ interface AppState {
   nodes: Record<string, TreeNode>;
   links?: Record<string, GraphLink>;
   linearNotesByScope?: Record<string, string>;
+  linearTextFontScale?: number;
 }
 
 interface SavedDoc {

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -64,6 +64,7 @@ const CLOUD_DOC_ID = normalizeDocId(queryParams.get("cloudDocId"), LOCAL_DOC_ID)
 const AUTOSAVE_DELAY_MS = 700;
 const MAX_UNDO_STEPS = 200;
 const TAB_ID = crypto.randomUUID();
+document.documentElement.style.setProperty("--linear-text-font-size", `${VIEWER_TUNING.typography.nodeFont}px`);
 
 interface BcStateMessage {
   type: "STATE_UPDATE";

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -73,6 +73,8 @@ const TAB_ID = crypto.randomUUID();
 const LINEAR_TEXT_FONT_SCALE_MIN = 0.6;
 const LINEAR_TEXT_FONT_SCALE_MAX = 1.4;
 const LINEAR_TEXT_FONT_SCALE_STEP = 0.1;
+const LINEAR_PANEL_WIDTH_MIN = 220;
+const LINEAR_PANEL_WIDTH_MAX = 2200;
 
 interface BcStateMessage {
   type: "STATE_UPDATE";
@@ -328,6 +330,45 @@ function syncLinearAdjustMenuUi(): void {
   if (linearMenuToggleBtn) {
     linearMenuToggleBtn.setAttribute("aria-expanded", linearAdjustMenuOpen ? "true" : "false");
   }
+}
+
+function isMarkdownFilename(fileName: string): boolean {
+  const lower = fileName.toLowerCase();
+  return lower.endsWith(".md") || lower.endsWith(".markdown");
+}
+
+function markdownToLinearText(markdown: string): string {
+  const lines = String(markdown || "").replaceAll("\r", "").split("\n");
+  const converted: string[] = [];
+  lines.forEach((rawLine) => {
+    const line = rawLine.replace(/\t/g, "  ").trimEnd();
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    const heading = trimmed.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      const depth = Math.max(0, heading[1]!.length - 1);
+      converted.push(`${"  ".repeat(depth)}${heading[2]!.trim()}`);
+      return;
+    }
+    const list = line.match(/^(\s*)(?:[-*+]|\d+\.)\s+(.+)$/);
+    if (list) {
+      const leadingSpaces = list[1]?.length ?? 0;
+      const depth = Math.floor(leadingSpaces / 2);
+      converted.push(`${"  ".repeat(depth)}${list[2]!.trim()}`);
+      return;
+    }
+    const quote = line.match(/^(\s*)>\s*(.+)$/);
+    if (quote) {
+      const leadingSpaces = quote[1]?.length ?? 0;
+      const depth = Math.floor(leadingSpaces / 2);
+      converted.push(`${"  ".repeat(depth)}${quote[2]!.trim()}`);
+      return;
+    }
+    converted.push(trimmed);
+  });
+  return converted.join("\n");
 }
 
 function setLinearTextFontScale(nextScale: number, showStatus = true): void {
@@ -1195,7 +1236,7 @@ function captureManualLinearPanelWidth(): void {
     return;
   }
   const canvasWidth = renderedWidth / viewState.zoom;
-  linearPanelCanvasWidth = Math.max(220, Math.min(1200, canvasWidth));
+  linearPanelCanvasWidth = Math.max(LINEAR_PANEL_WIDTH_MIN, Math.min(LINEAR_PANEL_WIDTH_MAX, canvasWidth));
 }
 
 function syncInlineEditorPosition(): void {
@@ -4161,6 +4202,19 @@ fileInput.addEventListener("change", (event: Event) => {
     try {
       const text = String(reader.result || "");
       const isMm = file.name.toLowerCase().endsWith(".mm");
+      const isMd = isMarkdownFilename(file.name);
+      if (isMd) {
+        if (!doc) {
+          loadPayload(createEmptyDoc());
+        }
+        const scopeRootId = currentLinearMemoScopeId();
+        linearNotesByScope[scopeRootId] = markdownToLinearText(text);
+        syncLinearNotesToDocState();
+        scheduleAutosave();
+        renderLinearPanel();
+        setStatus(`Imported .md file to Linear Text: ${file.name}`);
+        return;
+      }
       const payload = isMm ? parseMmText(text) : JSON.parse(text);
       loadPayload(payload);
       if (isMm) {
@@ -4261,7 +4315,7 @@ linearResizeHandleEl?.addEventListener("pointermove", (event: PointerEvent) => {
   const dx = event.clientX - linearResizeState.startClientX;
   const zoom = Math.max(0.0001, viewState.zoom);
   const nextWidth = linearResizeState.startCanvasWidth + dx / zoom;
-  linearPanelCanvasWidth = Math.max(220, Math.min(1200, nextWidth));
+  linearPanelCanvasWidth = Math.max(LINEAR_PANEL_WIDTH_MIN, Math.min(LINEAR_PANEL_WIDTH_MAX, nextWidth));
   syncLinearPanelPosition();
 });
 

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -133,6 +133,7 @@ let cloudConflictPending = false;
 let linearTransformStatus: LinearTransformStatus | null = null;
 let linearTextFontScale = 1;
 let linearAdjustMenuOpen = false;
+let linearMenuVisible = false;
 const DRAG_CENTER_BAND_HALF = 20;
 const DRAG_EDGE_BAND = 14;
 const DRAG_REORDER_TAIL = 28;
@@ -324,6 +325,9 @@ function hydrateLinearTextFontScaleFromDocState(): void {
 }
 
 function syncLinearAdjustMenuUi(): void {
+  if (linearPanelEl) {
+    linearPanelEl.classList.toggle("menu-visible", linearMenuVisible || linearAdjustMenuOpen);
+  }
   if (linearAdjustControlsEl) {
     linearAdjustControlsEl.hidden = !linearAdjustMenuOpen;
   }
@@ -4229,6 +4233,7 @@ fileInput.addEventListener("change", (event: Event) => {
 
 linearMenuToggleBtn?.addEventListener("click", (event: MouseEvent) => {
   event.preventDefault();
+  linearMenuVisible = true;
   linearAdjustMenuOpen = !linearAdjustMenuOpen;
   syncLinearAdjustMenuUi();
 });
@@ -4246,6 +4251,16 @@ linearFontIncBtn?.addEventListener("click", (event: MouseEvent) => {
 linearFontResetBtn?.addEventListener("click", (event: MouseEvent) => {
   event.preventDefault();
   setLinearTextFontScale(1);
+});
+
+linearTextEl?.addEventListener("pointerdown", () => {
+  linearMenuVisible = true;
+  syncLinearAdjustMenuUi();
+});
+
+linearTextEl?.addEventListener("focus", () => {
+  linearMenuVisible = true;
+  syncLinearAdjustMenuUi();
 });
 
 linearTextEl?.addEventListener("input", () => {
@@ -4669,13 +4684,11 @@ board.addEventListener("pointerup", endPan);
 board.addEventListener("pointercancel", endPan);
 
 document.addEventListener("pointerdown", (event: PointerEvent) => {
-  if (!linearAdjustMenuOpen) {
-    return;
-  }
   const target = event.target as HTMLElement | null;
-  if (target?.closest("#linear-menu")) {
+  if (target?.closest(".linear-panel")) {
     return;
   }
+  linearMenuVisible = false;
   linearAdjustMenuOpen = false;
   syncLinearAdjustMenuUi();
 });
@@ -4686,6 +4699,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
   }
 
   if (linearAdjustMenuOpen && event.key === "Escape") {
+    linearMenuVisible = false;
     linearAdjustMenuOpen = false;
     syncLinearAdjustMenuUi();
     event.preventDefault();

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -281,6 +281,10 @@ function syncLinearNotesToDocState(): void {
   doc.state.linearNotesByScope = { ...linearNotesByScope };
 }
 
+function hasLinearNotes(notes: Record<string, string> | undefined): boolean {
+  return Boolean(notes && Object.keys(notes).length > 0);
+}
+
 function ensureDocShape(payload: unknown): SavedDoc {
   const p = payload as Record<string, unknown>;
   const candidate = (p && p["state"])
@@ -3296,6 +3300,32 @@ async function loadDocFromLocalDb(showStatus = false): Promise<boolean> {
   }
 }
 
+async function loadLinearNotesFromLocalDbFallback(): Promise<void> {
+  if (!doc || hasLinearNotes(sanitizeLinearNotesByScope(doc.state.linearNotesByScope))) {
+    return;
+  }
+  try {
+    const response = await fetch(`/api/docs/${encodeURIComponent(LOCAL_DOC_ID)}`, { cache: "no-store" });
+    if (response.status === 404 || !response.ok) {
+      return;
+    }
+    const payload = await response.json();
+    const candidate = ensureDocShape(payload);
+    const fallbackNotes = sanitizeLinearNotesByScope(candidate.state.linearNotesByScope);
+    if (!hasLinearNotes(fallbackNotes)) {
+      return;
+    }
+    Object.keys(linearNotesByScope).forEach((scopeId) => {
+      delete linearNotesByScope[scopeId];
+    });
+    Object.assign(linearNotesByScope, fallbackNotes);
+    syncLinearNotesToDocState();
+    scheduleRender();
+  } catch {
+    // Fallback load is best-effort. Keep current document as-is when unavailable.
+  }
+}
+
 function scheduleAutosave(): void {
   if (!doc) {
     return;
@@ -3356,6 +3386,7 @@ async function initializeDocument(): Promise<void> {
   if (cloudSyncEnabled && cloudSyncExists) {
     const loadedFromCloud = await pullDocFromCloud(false);
     if (loadedFromCloud) {
+      await loadLinearNotesFromLocalDbFallback();
       return;
     }
   }

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -4293,14 +4293,6 @@ linearTextEl?.addEventListener("keydown", (event: KeyboardEvent) => {
     setStatus("Linear memo saved in current scope.");
     return;
   }
-  if (event.key === "Escape") {
-    event.preventDefault();
-    linearNotesByScope[currentLinearMemoScopeId()] = buildLinearFromScope().text;
-    syncLinearNotesToDocState();
-    scheduleAutosave();
-    renderLinearPanel();
-    setStatus("Linear memo reset to outline template.");
-  }
 });
 
 linearPanelEl?.addEventListener("pointerup", () => {

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -210,6 +210,17 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+function isImeComposingEvent(event: KeyboardEvent): boolean {
+  if (event.isComposing) {
+    return true;
+  }
+  const legacy = event as KeyboardEvent & { keyCode?: number };
+  if (legacy.keyCode === 229) {
+    return true;
+  }
+  return event.key === "Process";
+}
+
 function updateCloudSyncUi(): void {
   if (!cloudSyncBadgeEl) {
     return;
@@ -3031,6 +3042,9 @@ function startInlineEdit(nodeId: string, options?: { selectAll?: boolean }): voi
   }
 
   input.addEventListener("keydown", (event: KeyboardEvent) => {
+    if (isImeComposingEvent(event)) {
+      return;
+    }
     if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key === "Enter") {
       event.preventDefault();
       // Equivalent to Esc -> DownArrow -> Enter while editing.
@@ -4285,6 +4299,9 @@ linearTextEl?.addEventListener("keydown", (event: KeyboardEvent) => {
   if (!doc) {
     return;
   }
+  if (isImeComposingEvent(event)) {
+    return;
+  }
   if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
     event.preventDefault();
     linearNotesByScope[currentLinearMemoScopeId()] = linearTextEl.value;
@@ -4687,6 +4704,9 @@ document.addEventListener("pointerdown", (event: PointerEvent) => {
 
 document.addEventListener("keydown", (event: KeyboardEvent) => {
   if (!doc) {
+    return;
+  }
+  if (isImeComposingEvent(event)) {
     return;
   }
 

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -39,6 +39,12 @@ const visualCheckEl = document.getElementById("visual-check");
 const board = document.getElementById("board") as HTMLElement;
 const canvas = document.getElementById("canvas") as unknown as SVGSVGElement;
 const linearPanelEl = document.querySelector(".linear-panel") as HTMLElement | null;
+const linearMenuEl = document.getElementById("linear-menu") as HTMLElement | null;
+const linearMenuToggleBtn = document.getElementById("linear-menu-toggle") as HTMLButtonElement | null;
+const linearAdjustControlsEl = document.getElementById("linear-adjust-controls") as HTMLElement | null;
+const linearFontDecBtn = document.getElementById("linear-font-dec") as HTMLButtonElement | null;
+const linearFontIncBtn = document.getElementById("linear-font-inc") as HTMLButtonElement | null;
+const linearFontResetBtn = document.getElementById("linear-font-reset") as HTMLButtonElement | null;
 const linearResizeHandleEl = document.getElementById("linear-resize-handle") as HTMLElement | null;
 const linearTextEl = document.getElementById("linear-text") as HTMLTextAreaElement;
 const linearMetaEl = document.getElementById("linear-meta") as HTMLElement | null;
@@ -64,7 +70,9 @@ const CLOUD_DOC_ID = normalizeDocId(queryParams.get("cloudDocId"), LOCAL_DOC_ID)
 const AUTOSAVE_DELAY_MS = 700;
 const MAX_UNDO_STEPS = 200;
 const TAB_ID = crypto.randomUUID();
-document.documentElement.style.setProperty("--linear-text-font-size", `${VIEWER_TUNING.typography.nodeFont}px`);
+const LINEAR_TEXT_FONT_SCALE_MIN = 0.6;
+const LINEAR_TEXT_FONT_SCALE_MAX = 1.4;
+const LINEAR_TEXT_FONT_SCALE_STEP = 0.1;
 
 interface BcStateMessage {
   type: "STATE_UPDATE";
@@ -121,6 +129,8 @@ let cloudSyncExists = false;
 let cloudSavedAt: string | null = null;
 let cloudConflictPending = false;
 let linearTransformStatus: LinearTransformStatus | null = null;
+let linearTextFontScale = 1;
+let linearAdjustMenuOpen = false;
 const DRAG_CENTER_BAND_HALF = 20;
 const DRAG_EDGE_BAND = 14;
 const DRAG_REORDER_TAIL = 28;
@@ -143,6 +153,8 @@ let viewState: ViewState = {
   dragState: null,
   collapsedIds: new Set<string>(),
 };
+applyLinearTextFontScale(false);
+syncLinearAdjustMenuUi();
 
 function thinkingModeLabel(mode: ThinkingMode): string {
   switch (mode) {
@@ -286,6 +298,52 @@ function hasLinearNotes(notes: Record<string, string> | undefined): boolean {
   return Boolean(notes && Object.keys(notes).length > 0);
 }
 
+function normalizeLinearTextFontScale(raw: unknown): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    return 1;
+  }
+  return Math.max(LINEAR_TEXT_FONT_SCALE_MIN, Math.min(LINEAR_TEXT_FONT_SCALE_MAX, n));
+}
+
+function applyLinearTextFontScale(syncToState = true): void {
+  const clamped = normalizeLinearTextFontScale(linearTextFontScale);
+  linearTextFontScale = clamped;
+  const px = Math.round(VIEWER_TUNING.typography.nodeFont * clamped);
+  document.documentElement.style.setProperty("--linear-text-font-size", `${px}px`);
+  if (syncToState && doc) {
+    doc.state.linearTextFontScale = clamped;
+  }
+}
+
+function hydrateLinearTextFontScaleFromDocState(): void {
+  linearTextFontScale = normalizeLinearTextFontScale(doc?.state.linearTextFontScale);
+  applyLinearTextFontScale(false);
+}
+
+function syncLinearAdjustMenuUi(): void {
+  if (linearAdjustControlsEl) {
+    linearAdjustControlsEl.hidden = !linearAdjustMenuOpen;
+  }
+  if (linearMenuToggleBtn) {
+    linearMenuToggleBtn.setAttribute("aria-expanded", linearAdjustMenuOpen ? "true" : "false");
+  }
+}
+
+function setLinearTextFontScale(nextScale: number, showStatus = true): void {
+  const normalized = normalizeLinearTextFontScale(nextScale);
+  if (Math.abs(normalized - linearTextFontScale) < 0.0001) {
+    return;
+  }
+  linearTextFontScale = normalized;
+  applyLinearTextFontScale(true);
+  scheduleAutosave();
+  if (showStatus) {
+    const px = Math.round(VIEWER_TUNING.typography.nodeFont * linearTextFontScale);
+    setStatus(`Linear font: ${px}px (${Math.round(linearTextFontScale * 100)}%).`);
+  }
+}
+
 function ensureDocShape(payload: unknown): SavedDoc {
   const p = payload as Record<string, unknown>;
   const candidate = (p && p["state"])
@@ -330,6 +388,7 @@ function ensureDocShape(payload: unknown): SavedDoc {
     };
   });
   candidate.state.linearNotesByScope = sanitizeLinearNotesByScope(candidate.state.linearNotesByScope);
+  candidate.state.linearTextFontScale = normalizeLinearTextFontScale(candidate.state.linearTextFontScale);
   return candidate as SavedDoc;
 }
 
@@ -3521,6 +3580,7 @@ function loadPayload(payload: unknown): void {
   try {
     doc = ensureDocShape(payload);
     hydrateLinearNotesFromDocState();
+    hydrateLinearTextFontScaleFromDocState();
     undoStack = [];
     redoStack = [];
     linearDirty = false;
@@ -4113,6 +4173,27 @@ fileInput.addEventListener("change", (event: Event) => {
   reader.readAsText(file, "utf-8");
 });
 
+linearMenuToggleBtn?.addEventListener("click", (event: MouseEvent) => {
+  event.preventDefault();
+  linearAdjustMenuOpen = !linearAdjustMenuOpen;
+  syncLinearAdjustMenuUi();
+});
+
+linearFontDecBtn?.addEventListener("click", (event: MouseEvent) => {
+  event.preventDefault();
+  setLinearTextFontScale(linearTextFontScale - LINEAR_TEXT_FONT_SCALE_STEP);
+});
+
+linearFontIncBtn?.addEventListener("click", (event: MouseEvent) => {
+  event.preventDefault();
+  setLinearTextFontScale(linearTextFontScale + LINEAR_TEXT_FONT_SCALE_STEP);
+});
+
+linearFontResetBtn?.addEventListener("click", (event: MouseEvent) => {
+  event.preventDefault();
+  setLinearTextFontScale(1);
+});
+
 linearTextEl?.addEventListener("input", () => {
   if (!doc) {
     return;
@@ -4533,8 +4614,27 @@ function endPan(event: PointerEvent): void {
 board.addEventListener("pointerup", endPan);
 board.addEventListener("pointercancel", endPan);
 
+document.addEventListener("pointerdown", (event: PointerEvent) => {
+  if (!linearAdjustMenuOpen) {
+    return;
+  }
+  const target = event.target as HTMLElement | null;
+  if (target?.closest("#linear-menu")) {
+    return;
+  }
+  linearAdjustMenuOpen = false;
+  syncLinearAdjustMenuUi();
+});
+
 document.addEventListener("keydown", (event: KeyboardEvent) => {
   if (!doc) {
+    return;
+  }
+
+  if (linearAdjustMenuOpen && event.key === "Escape") {
+    linearAdjustMenuOpen = false;
+    syncLinearAdjustMenuUi();
+    event.preventDefault();
     return;
   }
 

--- a/beta/src/shared/types.ts
+++ b/beta/src/shared/types.ts
@@ -37,6 +37,7 @@ export interface AppState {
   nodes: Record<string, TreeNode>;
   links?: Record<string, GraphLink>;
   linearNotesByScope?: Record<string, string>;
+  linearTextFontScale?: number;
 }
 
 export interface SavedDoc {

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -225,6 +225,14 @@
         flex-direction: column;
         align-items: flex-end;
         gap: 6px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.12s ease;
+      }
+
+      .linear-panel.menu-visible .linear-menu {
+        opacity: 1;
+        pointer-events: auto;
       }
 
       .linear-menu-toggle {

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -216,6 +216,46 @@
         overflow: visible;
       }
 
+      .linear-menu {
+        position: absolute;
+        top: 10px;
+        right: 24px;
+        z-index: 4;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 6px;
+      }
+
+      .linear-menu-toggle {
+        width: 34px;
+        height: 34px;
+        border-radius: 10px;
+        border: 1px solid #d5d5d5;
+        background: rgba(255, 255, 255, 0.92);
+        color: #353535;
+        font-size: 18px;
+        font-weight: 700;
+        line-height: 1;
+        padding: 0;
+      }
+
+      .linear-adjust-controls {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px;
+        border: 1px solid #d8d8d8;
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.96);
+        box-shadow: 0 8px 18px rgba(24, 24, 24, 0.12);
+      }
+
+      .linear-adjust-controls > button {
+        min-width: 52px;
+        padding: 5px 8px;
+      }
+
       .linear-text {
         width: 100%;
         flex: 1;
@@ -224,7 +264,7 @@
         border: 4px solid var(--accent);
         border-radius: 34px;
         background: #fff;
-        padding: 18px 20px;
+        padding: 56px 20px 18px;
         font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
         font-size: var(--linear-text-font-size, 44px);
         line-height: 1.2;

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -226,8 +226,8 @@
         background: #fff;
         padding: 18px 20px;
         font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-        font-size: 14px;
-        line-height: 1.45;
+        font-size: var(--linear-text-font-size, 44px);
+        line-height: 1.2;
         color: #222;
         box-shadow: 0 8px 18px rgba(24, 24, 24, 0.1);
         overflow: hidden;

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -74,6 +74,14 @@
             <svg id="canvas" width="1600" height="900" viewBox="0 0 1600 900"></svg>
           </div>
           <aside class="linear-panel" aria-label="Linear tree editor panel">
+            <div id="linear-menu" class="linear-menu">
+              <button id="linear-menu-toggle" class="linear-menu-toggle" type="button" aria-label="Linear settings" aria-expanded="false">☰</button>
+              <div id="linear-adjust-controls" class="linear-adjust-controls" hidden>
+                <button id="linear-font-dec" type="button" aria-label="Decrease linear text font">A-</button>
+                <button id="linear-font-inc" type="button" aria-label="Increase linear text font">A+</button>
+                <button id="linear-font-reset" type="button" aria-label="Reset linear text font">Reset</button>
+              </div>
+            </div>
             <textarea
               id="linear-text"
               class="linear-text"

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -14,7 +14,7 @@
           <button id="load-default" class="primary">Default</button>
           <button id="load-airplane">Airplane</button>
           <button id="load-aircraft-mm">Aircraft.mm</button>
-          <input id="file-input" type="file" accept=".json,.mm,application/json,text/xml,application/xml" />
+          <input id="file-input" type="file" accept=".json,.mm,.md,.markdown,application/json,text/xml,application/xml,text/markdown,text/plain" />
           <span class="toolbar-sep">|</span>
           <div class="mode-switch" aria-label="Thinking mode">
             <button id="mode-flash" class="mode-btn" type="button">Flash</button>

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -116,6 +116,17 @@
 
 - `npm --prefix beta run test:unit`: pass
 
+## 追加実施（Beta: Cloud優先ロード時の Linear Text 欠落フォールバック）
+
+- `beta/src/browser/viewer.ts`
+  - 起動時に cloud ドキュメントが読み込まれた際、`linearNotesByScope` が空なら local DB から linear memo を補完するフォールバックを追加
+  - cloud 側が旧フォーマット（memo未保存）でも、local に保存済みの Linear Text を復元できるよう修正
+
+## 確認（Beta: Cloud優先ロード時の Linear Text 欠落フォールバック）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -140,6 +140,28 @@
 
 - `npm --prefix beta run build`: pass
 
+## 追加実施（Beta: Linear パネルにハンバーガーメニュー式フォント調整UIを追加）
+
+- `beta/viewer.html`
+  - Linear パネル内にハンバーガーボタン（☰）を追加
+  - メニュー展開時のみ表示される `A- / A+ / Reset` ボタンを追加
+- `beta/viewer.css`
+  - ハンバーガーボタンと調整ポップアップのスタイルを追加
+  - メニューと重ならないよう Linear Text の上部 padding を調整
+- `beta/src/browser/viewer.ts`
+  - メニュー開閉状態の管理を追加（外側クリック/Escapeで閉じる）
+  - `A- / A+ / Reset` で `linearTextFontScale` を変更する処理を追加
+  - `linearTextFontScale` を `state` に保存し、再読込時に復元する処理を追加
+- `beta/src/shared/types.ts`
+  - `AppState` に `linearTextFontScale?: number` を追加
+- `beta/src/browser/viewer.globals.d.ts`
+  - browser 側 `AppState` 宣言に `linearTextFontScale` を追加
+
+## 確認（Beta: Linear パネルにハンバーガーメニュー式フォント調整UIを追加）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -127,6 +127,19 @@
 - `npm --prefix beta run build`: pass
 - `npm --prefix beta run test:unit`: pass
 
+## 追加実施（Beta: Linear Text のフォントサイズをノード基準へ統一）
+
+- `beta/viewer.css`
+  - `.linear-text` の `font-size` を固定値 `14px` から `--linear-text-font-size` 変数参照へ変更
+  - 行間をノード表示に近づけるため `line-height: 1.2` へ調整
+- `beta/src/browser/viewer.ts`
+  - 起動時に `VIEWER_TUNING.typography.nodeFont` を `--linear-text-font-size` へ同期する処理を追加
+  - Linear Text がノード文字サイズ設定と連動するよう統一
+
+## 確認（Beta: Linear Text のフォントサイズをノード基準へ統一）
+
+- `npm --prefix beta run build`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -176,6 +176,20 @@
 - `npm --prefix beta run build`: pass
 - `npm --prefix beta run test:unit`: pass
 
+## 追加実施（Beta: Linear Text メニューの表示を押下時のみへ変更）
+
+- `beta/src/browser/viewer.ts`
+  - Linear パネルメニュー表示状態を追加し、`linear text` 押下/フォーカス時のみハンバーガーを表示
+  - パネル外クリックまたは `Escape` でメニューを閉じ、非表示へ戻す挙動に変更
+- `beta/viewer.css`
+  - `.linear-menu` をデフォルト非表示（opacity/pointer-events）に変更
+  - `.linear-panel.menu-visible` 時のみ表示するスタイルを追加
+
+## 確認（Beta: Linear Text メニューの表示を押下時のみへ変更）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -190,6 +190,17 @@
 - `npm --prefix beta run build`: pass
 - `npm --prefix beta run test:unit`: pass
 
+## 追加実施（Beta: Linear Text 内 Esc のテンプレート上書きを廃止）
+
+- `beta/src/browser/viewer.ts`
+  - Linear Text の `keydown` ハンドラから `Escape` 時の `buildLinearFromScope()` 上書き処理を削除
+  - `Ctrl/Cmd + Enter` の明示保存動作は維持
+
+## 確認（Beta: Linear Text 内 Esc のテンプレート上書きを廃止）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -201,6 +201,20 @@
 - `npm --prefix beta run build`: pass
 - `npm --prefix beta run test:unit`: pass
 
+## 追加実施（Beta: macOS IME 変換確定 Enter でノード操作が誤発火する問題を修正）
+
+- `beta/src/browser/viewer.ts`
+  - `isImeComposingEvent()` を追加し、`event.isComposing` / `keyCode === 229` / `key === "Process"` を IME変換中として判定
+  - inline editor の `keydown` で IME変換中イベントを無視
+  - viewer 全体 `document.keydown` でも IME変換中イベントを無視
+  - Linear Text の `keydown` でも同様に IME変換中イベントを無視
+  - これにより macOS の変換確定 Enter で sibling 追加や編集遷移が走らないよう修正
+
+## 確認（Beta: macOS IME 変換確定 Enter 誤発火修正）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし

--- a/dev-docs/daily/260408.md
+++ b/dev-docs/daily/260408.md
@@ -162,6 +162,20 @@
 - `npm --prefix beta run build`: pass
 - `npm --prefix beta run test:unit`: pass
 
+## 追加実施（Beta: Linear Text パネルの横幅上限拡張 + Markdown取込）
+
+- `beta/src/browser/viewer.ts`
+  - Linear パネルの横幅クランプを定数化し、最大幅を `1200 -> 2200` に拡張
+  - `.md/.markdown` ファイル取込時、Markdown を Linear Text 用のインデントテキストへ変換して現在スコープに保存する処理を追加
+  - Markdown 取込時は `linearNotesByScope` と `state` を同期し autosave を実行
+- `beta/viewer.html`
+  - ファイル入力 `accept` に `.md/.markdown` と markdown MIME を追加
+
+## 確認（Beta: Linear Text パネルの横幅上限拡張 + Markdown取込）
+
+- `npm --prefix beta run build`: pass
+- `npm --prefix beta run test:unit`: pass
+
 ## 依存関係メモ
 
 - 依存関係の追加なし


### PR DESCRIPTION
## Summary
- fix linear text persistence across reload and add fallback when cloud payload lacks linear memo
- remove Escape-based auto-reset in linear text to prevent accidental overwrite
- add linear panel hamburger controls for font size, and persist font scale in document state
- show linear menu only when linear textbox is active
- expand linear panel resize max width
- add markdown import (.md/.markdown) into linear text memo
- guard keyboard handlers against IME composition Enter (macOS issue)

## Verification
- npm --prefix beta run build
- npm --prefix beta run test:unit