### PR TITLE
visual: add Home View scope navigator UI

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -32,6 +32,10 @@ const linearMetaEl = document.getElementById("linear-meta") as HTMLElement | nul
 const linearApplyBtn = document.getElementById("linear-apply") as HTMLButtonElement | null;
 const linearResetBtn = document.getElementById("linear-reset") as HTMLButtonElement | null;
 const cheatsheetEl = document.getElementById("shortcut-cheatsheet") as HTMLElement | null;
+const homeBtn = document.getElementById("home-btn") as HTMLButtonElement | null;
+const homeViewEl = document.getElementById("home-view") as HTMLElement | null;
+const homeBreadcrumbEl = document.getElementById("home-breadcrumb") as HTMLElement | null;
+const homeGridEl = document.getElementById("home-grid") as HTMLElement | null;
 const cloudSyncBadgeEl = document.getElementById("cloud-sync-badge") as HTMLElement;
 const cloudPullBtn = document.getElementById("cloud-pull") as HTMLButtonElement;
 const cloudPushBtn = document.getElementById("cloud-push") as HTMLButtonElement;
@@ -116,6 +120,8 @@ let linearTransformStatus: LinearTransformStatus | null = null;
 let linearTextFontScale = 1;
 let linearAdjustMenuOpen = false;
 let linearMenuVisible = false;
+let homeViewActive = false;
+let homeBrowseScopeId: string | null = null;
 const DRAG_CENTER_BAND_HALF = 20;
 const DRAG_EDGE_BAND = 14;
 const DRAG_REORDER_TAIL = 28;
@@ -801,6 +807,206 @@ function exitScope(): boolean {
   board.focus();
   return true;
 }
+
+// ── Home View ──────────────────────────────────────────────────
+
+function countDescendants(nodeId: string): number {
+  if (!doc) return 0;
+  const node = doc.state.nodes[nodeId];
+  if (!node) return 0;
+  let count = 0;
+  const stack = [...(node.children || [])];
+  while (stack.length) {
+    const id = stack.pop()!;
+    const n = doc.state.nodes[id];
+    if (!n) continue;
+    count++;
+    stack.push(...(n.children || []));
+  }
+  return count;
+}
+
+function countChildFolders(nodeId: string): number {
+  if (!doc) return 0;
+  const node = doc.state.nodes[nodeId];
+  if (!node) return 0;
+  return (node.children || []).filter((cid) => {
+    const child = doc!.state.nodes[cid];
+    return child && isFolderNode(child);
+  }).length;
+}
+
+function renderHomeView(): void {
+  if (!doc || !homeGridEl || !homeBreadcrumbEl) return;
+
+  const state = doc.state;
+  const browseId = homeBrowseScopeId || state.rootId;
+  const browseNode = state.nodes[browseId];
+  if (!browseNode) {
+    homeBrowseScopeId = state.rootId;
+    renderHomeView();
+    return;
+  }
+
+  // Build breadcrumb
+  const crumbIds: string[] = [];
+  let cursor: string | null = browseId;
+  while (cursor) {
+    crumbIds.unshift(cursor);
+    const crumbNode: TreeNode | undefined = state.nodes[cursor];
+    if (!crumbNode || cursor === state.rootId) break;
+    cursor = crumbNode.parentId ?? null;
+  }
+
+  homeBreadcrumbEl.innerHTML = "";
+  crumbIds.forEach((cid, idx) => {
+    if (idx > 0) {
+      const sep = document.createElement("span");
+      sep.className = "home-breadcrumb-sep";
+      sep.textContent = "/";
+      homeBreadcrumbEl!.appendChild(sep);
+    }
+    const item = document.createElement("span");
+    item.className = "home-breadcrumb-item";
+    const isLast = idx === crumbIds.length - 1;
+    if (isLast) {
+      item.classList.add("current");
+    }
+    item.textContent = cid === state.rootId ? "Home" : uiLabel(state.nodes[cid]);
+    if (!isLast) {
+      item.addEventListener("click", () => {
+        homeBrowseScopeId = cid;
+        renderHomeView();
+      });
+    }
+    homeBreadcrumbEl!.appendChild(item);
+  });
+
+  // Build grid cards
+  homeGridEl.innerHTML = "";
+  const children = (browseNode.children || [])
+    .map((cid) => state.nodes[cid])
+    .filter((n): n is TreeNode => Boolean(n));
+
+  if (children.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "home-empty";
+    empty.textContent = "This scope is empty.";
+    homeGridEl.appendChild(empty);
+    return;
+  }
+
+  // Sort: folders first, then by text
+  const sorted = [...children].sort((a, b) => {
+    const aFolder = isFolderNode(a) ? 0 : 1;
+    const bFolder = isFolderNode(b) ? 0 : 1;
+    if (aFolder !== bFolder) return aFolder - bFolder;
+    return (a.text || "").localeCompare(b.text || "");
+  });
+
+  for (const child of sorted) {
+    const isFolder = isFolderNode(child);
+    const card = document.createElement("div");
+    card.className = "home-card";
+    if (!isFolder) card.classList.add("is-leaf");
+
+    // Icon
+    const icon = document.createElement("div");
+    icon.className = "home-card-icon";
+    if (isFolder) {
+      // Folder SVG icon
+      icon.innerHTML = `<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>`;
+    } else {
+      // Document SVG icon
+      icon.innerHTML = `<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>`;
+    }
+    card.appendChild(icon);
+
+    // Title
+    const title = document.createElement("div");
+    title.className = "home-card-title";
+    title.textContent = uiLabel(child);
+    card.appendChild(title);
+
+    // Meta
+    const meta = document.createElement("div");
+    meta.className = "home-card-meta";
+    if (isFolder) {
+      const desc = countDescendants(child.id);
+      const subFolders = countChildFolders(child.id);
+      const parts: string[] = [];
+      if (subFolders > 0) parts.push(`${subFolders} sub-scope${subFolders > 1 ? "s" : ""}`);
+      parts.push(`${desc} item${desc !== 1 ? "s" : ""}`);
+      meta.textContent = parts.join(" / ");
+    } else {
+      const text = (child.text || "").trim();
+      if (text.length > 60) {
+        meta.textContent = text.substring(0, 60) + "...";
+      } else if (child.children && child.children.length > 0) {
+        meta.textContent = `${child.children.length} child${child.children.length > 1 ? "ren" : ""}`;
+      }
+    }
+    card.appendChild(meta);
+
+    // Click handler
+    card.addEventListener("click", () => {
+      if (isFolder) {
+        // Navigate deeper in home view
+        homeBrowseScopeId = child.id;
+        renderHomeView();
+      } else {
+        // Enter this scope in editor and close home
+        hideHomeView();
+        const parentScope = homeBrowseScopeId || doc!.state.rootId;
+        if (parentScope !== doc!.state.rootId) {
+          EnterScopeCommand(parentScope);
+        }
+        setSingleSelection(child.id, false);
+        render();
+        fitDocument();
+      }
+    });
+
+    // Double-click on folder: open scope in editor
+    if (isFolder) {
+      card.addEventListener("dblclick", (e) => {
+        e.preventDefault();
+        hideHomeView();
+        EnterScopeCommand(child.id);
+        fitDocument();
+      });
+    }
+
+    homeGridEl!.appendChild(card);
+  }
+}
+
+function showHomeView(): void {
+  if (!homeViewEl) return;
+  homeViewActive = true;
+  homeBrowseScopeId = currentScopeRootId();
+  homeViewEl.hidden = false;
+  homeBtn?.classList.add("is-active");
+  renderHomeView();
+}
+
+function hideHomeView(): void {
+  if (!homeViewEl) return;
+  homeViewActive = false;
+  homeViewEl.hidden = true;
+  homeBtn?.classList.remove("is-active");
+  board.focus();
+}
+
+function toggleHomeView(): void {
+  if (homeViewActive) {
+    hideHomeView();
+  } else {
+    showHomeView();
+  }
+}
+
+// ── End Home View ──────────────────────────────────────────────
 
 function makeSelectedFolder(): boolean {
   if (!doc) {
@@ -4203,6 +4409,10 @@ stopVisualCheckBtn?.addEventListener("click", () => {
   stopVisualCheck();
 });
 
+homeBtn?.addEventListener("click", () => {
+  toggleHomeView();
+});
+
 modeFlashBtn?.addEventListener("click", () => {
   setThinkingMode("flash");
 });
@@ -4744,6 +4954,20 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
       setThinkingMode("deep");
       return;
     }
+  }
+
+  // Home view toggle: Ctrl+H
+  if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "h") {
+    event.preventDefault();
+    toggleHomeView();
+    return;
+  }
+
+  // Escape closes home view if active
+  if (event.key === "Escape" && homeViewActive) {
+    event.preventDefault();
+    hideHomeView();
+    return;
   }
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "s") {

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -796,6 +796,147 @@
         color: rgba(255, 255, 255, 0.7);
       }
 
+      /* ── Home button ── */
+      .home-btn {
+        font-size: 20px;
+        line-height: 1;
+        padding: 4px 8px;
+        border: 1px solid #d4d4d4;
+        border-radius: 8px;
+        background: #fff;
+        cursor: pointer;
+      }
+      .home-btn:hover { background: #f5f5f5; }
+      .home-btn.is-active {
+        border-color: var(--accent);
+        background: var(--accent-soft);
+        color: #5221b2;
+      }
+
+      /* ── Home View ── */
+      .home-view {
+        position: absolute;
+        inset: 0;
+        z-index: 4;
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        background: var(--grid-bg);
+        overflow-y: auto;
+        padding: 72px 32px 32px;
+      }
+      .home-view[hidden] {
+        display: none;
+      }
+
+      .home-breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        flex-wrap: wrap;
+        padding: 0 4px 16px;
+        font-size: 13px;
+        color: #777;
+        user-select: none;
+      }
+      .home-breadcrumb-item {
+        cursor: pointer;
+        color: var(--accent);
+        font-weight: 600;
+        padding: 2px 6px;
+        border-radius: 6px;
+        transition: background 0.1s;
+      }
+      .home-breadcrumb-item:hover {
+        background: var(--accent-soft);
+      }
+      .home-breadcrumb-item.current {
+        color: var(--ink);
+        cursor: default;
+        font-weight: 700;
+      }
+      .home-breadcrumb-item.current:hover {
+        background: transparent;
+      }
+      .home-breadcrumb-sep {
+        color: #bbb;
+        font-size: 11px;
+      }
+
+      .home-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: 16px;
+        padding: 0 4px;
+      }
+
+      .home-card {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 18px 16px;
+        border: 1px solid #e0e0e0;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.92);
+        backdrop-filter: blur(8px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+        cursor: pointer;
+        transition: box-shadow 0.15s, border-color 0.15s, transform 0.1s;
+        user-select: none;
+      }
+      .home-card:hover {
+        border-color: var(--accent);
+        box-shadow: 0 8px 24px rgba(122, 53, 255, 0.12);
+        transform: translateY(-2px);
+      }
+      .home-card:active {
+        transform: translateY(0);
+      }
+
+      .home-card-icon {
+        width: 40px;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 20px;
+        flex-shrink: 0;
+      }
+      .home-card.is-leaf .home-card-icon {
+        background: #f0f0f0;
+        color: #888;
+      }
+
+      .home-card-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--ink);
+        line-height: 1.3;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+
+      .home-card-meta {
+        font-size: 11px;
+        color: #999;
+        display: flex;
+        gap: 8px;
+      }
+
+      .home-empty {
+        grid-column: 1 / -1;
+        text-align: center;
+        padding: 48px 16px;
+        color: #aaa;
+        font-size: 14px;
+      }
+
       @media (max-width: 900px) {
         .label-root,
         .label-node {

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -29,6 +29,7 @@
             <button id="mode-rapid" class="mode-btn is-active" type="button">Rapid</button>
             <button id="mode-deep" class="mode-btn" type="button">Deep</button>
           </div>
+          <button id="home-btn" class="home-btn" type="button" aria-label="Home view">&#8962;</button>
           <div class="export-wrap">
             <button id="export-btn" type="button">Export ▾</button>
             <div id="export-menu" class="export-menu" hidden>
@@ -70,6 +71,10 @@
           </aside>
         </div>
       </div>
+      <div id="home-view" class="home-view" hidden>
+        <div class="home-breadcrumb" id="home-breadcrumb"></div>
+        <div class="home-grid" id="home-grid"></div>
+      </div>
       <div id="shortcut-cheatsheet" class="shortcut-cheatsheet" hidden>
         <div class="cheatsheet-header">Keyboard Shortcuts</div>
         <div class="cheatsheet-body">
@@ -100,6 +105,7 @@
               <div class="cheatsheet-row"><kbd>Ctrl+0</kbd><span>Fit all</span></div>
               <div class="cheatsheet-row"><kbd>I</kbd><span>Toggle meta panel</span></div>
               <div class="cheatsheet-row"><kbd>Ctrl+S</kbd><span>Download JSON</span></div>
+              <div class="cheatsheet-row"><kbd>Ctrl+H</kbd><span>Toggle Home view</span></div>
             </div>
           </div>
           <div class="cheatsheet-col">
@@ -125,6 +131,12 @@
               <div class="cheatsheet-row"><kbd>Shift+L</kbd><span>Apply link</span></div>
               <div class="cheatsheet-row"><kbd>M</kbd> → <kbd>P</kbd><span>Move (reparent)</span></div>
               <div class="cheatsheet-row"><kbd>Alt+M</kbd><span>Hold reparent</span></div>
+            </div>
+            <div class="cheatsheet-group">
+              <div class="cheatsheet-group-title">Scope</div>
+              <div class="cheatsheet-row"><kbd>Ctrl+]</kbd><span>Enter scope</span></div>
+              <div class="cheatsheet-row"><kbd>Ctrl+[</kbd><span>Exit scope</span></div>
+              <div class="cheatsheet-row"><kbd>Ctrl+H</kbd><span>Home view</span></div>
             </div>
             <div class="cheatsheet-group">
               <div class="cheatsheet-group-title">Thinking Mode</div>


### PR DESCRIPTION
## Summary
- Add a file-explorer-style **Home View** for browsing scopes (folders) as card grid
- Breadcrumb navigation for scope hierarchy with click-to-navigate
- Folder cards show sub-scope count and item count; leaf cards show preview
- Click folder to drill down in home view, double-click to enter scope in editor
- Toolbar home button and **Ctrl+H** keyboard shortcut to toggle
- Escape key closes home view and returns to editor
- Cheatsheet updated with Ctrl+H and scope navigation shortcuts

## Files changed
- `beta/viewer.html` -- home-view container, home button, cheatsheet entries
- `beta/viewer.css` -- card grid, breadcrumb, home button styles (matching existing theme)
- `beta/src/browser/viewer.ts` -- renderHomeView, showHomeView, hideHomeView, toggleHomeView + wiring

## Test plan
- [ ] Open viewer, click home button (house icon) in toolbar -- home view should appear
- [ ] Verify breadcrumb shows "Home" at root level
- [ ] Click a folder card -- should drill down showing its children
- [ ] Breadcrumb updates, clicking parent crumb navigates back
- [ ] Double-click a folder card -- should close home view and enter that scope in editor
- [ ] Click a leaf node card -- should close home view and select that node
- [ ] Press Ctrl+H -- should toggle home view on/off
- [ ] Press Escape while home view is open -- should close it
- [ ] Hold Ctrl to see cheatsheet -- verify Ctrl+H and scope shortcuts listed

Generated with [Claude Code](https://claude.com/claude-code)