### PR TITLE
visual: Home Screen Phase 1 - scope tree navigator

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -32,6 +32,9 @@ const linearMetaEl = document.getElementById("linear-meta") as HTMLElement | nul
 const linearApplyBtn = document.getElementById("linear-apply") as HTMLButtonElement | null;
 const linearResetBtn = document.getElementById("linear-reset") as HTMLButtonElement | null;
 const cheatsheetEl = document.getElementById("shortcut-cheatsheet") as HTMLElement | null;
+const homeScreenEl = document.getElementById("home-screen") as HTMLElement | null;
+const homeScopeTreeEl = document.getElementById("home-scope-tree") as HTMLElement | null;
+const appEl = document.querySelector(".app") as HTMLElement | null;
 const cloudSyncBadgeEl = document.getElementById("cloud-sync-badge") as HTMLElement;
 const cloudPullBtn = document.getElementById("cloud-pull") as HTMLButtonElement;
 const cloudPushBtn = document.getElementById("cloud-push") as HTMLButtonElement;
@@ -116,6 +119,7 @@ let linearTransformStatus: LinearTransformStatus | null = null;
 let linearTextFontScale = 1;
 let linearAdjustMenuOpen = false;
 let linearMenuVisible = false;
+let homeScreenVisible = false;
 const DRAG_CENTER_BAND_HALF = 20;
 const DRAG_EDGE_BAND = 14;
 const DRAG_REORDER_TAIL = 28;
@@ -2793,6 +2797,169 @@ function ExitScopeCommand(): void {
   updateScopeInUrl(viewState.currentScopeId);
 }
 
+// ── Home Screen ──
+
+function collectFolderTree(parentId: string): { id: string; label: string; childCount: number; subFolders: ReturnType<typeof collectFolderTree> }[] {
+  if (!doc) {
+    return [];
+  }
+  const parent = doc.state.nodes[parentId];
+  if (!parent) {
+    return [];
+  }
+  const result: { id: string; label: string; childCount: number; subFolders: ReturnType<typeof collectFolderTree> }[] = [];
+  for (const childId of parent.children || []) {
+    const child = doc.state.nodes[childId];
+    if (!child) {
+      continue;
+    }
+    if (isFolderNode(child)) {
+      result.push({
+        id: child.id,
+        label: uiLabel(child),
+        childCount: countHiddenDescendants(child.id),
+        subFolders: collectFolderTree(child.id),
+      });
+    }
+  }
+  return result;
+}
+
+function renderScopeTree(
+  container: HTMLElement,
+  folders: ReturnType<typeof collectFolderTree>,
+): void {
+  container.innerHTML = "";
+  for (const folder of folders) {
+    const hasChildren = folder.subFolders.length > 0;
+
+    const row = document.createElement("div");
+    row.className = "home-scope-row";
+    row.dataset.scopeId = folder.id;
+
+    const toggle = document.createElement("button");
+    toggle.className = "home-scope-toggle" + (hasChildren ? "" : " no-children");
+    toggle.textContent = "\u25B6";
+    toggle.type = "button";
+
+    const name = document.createElement("span");
+    name.className = "home-scope-name";
+    name.textContent = folder.label;
+
+    const count = document.createElement("span");
+    count.className = "home-scope-count";
+    count.textContent = `${folder.childCount} nodes`;
+
+    row.appendChild(toggle);
+    row.appendChild(name);
+    row.appendChild(count);
+    container.appendChild(row);
+
+    let childContainer: HTMLElement | null = null;
+    if (hasChildren) {
+      childContainer = document.createElement("div");
+      childContainer.className = "home-scope-children";
+      childContainer.hidden = true;
+      renderScopeTree(childContainer, folder.subFolders);
+      container.appendChild(childContainer);
+    }
+
+    toggle.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (!childContainer) {
+        return;
+      }
+      const isExpanded = !childContainer.hidden;
+      childContainer.hidden = isExpanded;
+      toggle.classList.toggle("expanded", !isExpanded);
+    });
+
+    row.addEventListener("click", () => {
+      hideHomeScreen();
+      EnterScopeCommand(folder.id);
+    });
+  }
+}
+
+function buildHomeBreadcrumb(): void {
+  if (!doc || !homeScreenEl) {
+    return;
+  }
+  const existingBreadcrumb = homeScreenEl.querySelector(".home-breadcrumb");
+  if (existingBreadcrumb) {
+    existingBreadcrumb.remove();
+  }
+
+  const scopeId = currentScopeRootId();
+  if (!scopeId || scopeId === doc.state.rootId) {
+    return;
+  }
+
+  const pathIds = scopePathIds(scopeId);
+  if (pathIds.length <= 1) {
+    return;
+  }
+
+  const breadcrumb = document.createElement("div");
+  breadcrumb.className = "home-breadcrumb";
+
+  for (let i = 0; i < pathIds.length; i++) {
+    if (i > 0) {
+      const sep = document.createElement("span");
+      sep.className = "home-breadcrumb-sep";
+      sep.textContent = "/";
+      breadcrumb.appendChild(sep);
+    }
+
+    const nodeId = pathIds[i];
+    const isLast = i === pathIds.length - 1;
+    const label = nodeId === doc.state.rootId ? "root" : uiLabel(doc.state.nodes[nodeId]);
+
+    const item = document.createElement("button");
+    item.className = "home-breadcrumb-item" + (isLast ? " current" : "");
+    item.textContent = label;
+    item.type = "button";
+
+    if (!isLast) {
+      item.addEventListener("click", () => {
+        hideHomeScreen();
+        EnterScopeCommand(nodeId);
+      });
+    }
+
+    breadcrumb.appendChild(item);
+  }
+
+  const homeBody = homeScreenEl.querySelector(".home-body");
+  if (homeBody) {
+    homeBody.insertBefore(breadcrumb, homeBody.firstChild);
+  }
+}
+
+function showHomeScreen(): void {
+  if (!homeScreenEl || !homeScopeTreeEl || !doc) {
+    return;
+  }
+  homeScreenVisible = true;
+  homeScreenEl.hidden = false;
+  appEl?.classList.add("home-active");
+
+  const rootId = doc.state.rootId;
+  const folders = collectFolderTree(rootId);
+  renderScopeTree(homeScopeTreeEl, folders);
+  buildHomeBreadcrumb();
+}
+
+function hideHomeScreen(): void {
+  if (!homeScreenEl) {
+    return;
+  }
+  homeScreenVisible = false;
+  homeScreenEl.hidden = true;
+  appEl?.classList.remove("home-active");
+  board.focus();
+}
+
 function addChild(): void {
   const parentId = viewState.selectedNodeId;
   const parent = getNode(parentId);
@@ -4636,6 +4803,12 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     return;
   }
 
+  if (homeScreenVisible && event.key === "Escape") {
+    event.preventDefault();
+    hideHomeScreen();
+    return;
+  }
+
   if (linearAdjustMenuOpen && event.key === "Escape") {
     linearMenuVisible = false;
     linearAdjustMenuOpen = false;
@@ -4827,6 +5000,16 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
         EnterScopeCommand();
         return;
       }
+
+  if (event.altKey && event.key.toLowerCase() === "h") {
+    event.preventDefault();
+    if (homeScreenVisible) {
+      hideHomeScreen();
+    } else {
+      showHomeScreen();
+    }
+    return;
+  }
 
   if (event.altKey && event.key.toLowerCase() === "v") {
     event.preventDefault();
@@ -5070,4 +5253,10 @@ void initializeDocument().then(() => {
     updateScopeInUrl(initialScopeId);
   }
   fitDocument() || applyZoom();
+
+  // Show home screen on startup if no scopeId is specified in URL
+  const hasInitialScope = queryParams.get("scopeId");
+  if (!hasInitialScope && doc) {
+    showHomeScreen();
+  }
 });

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -796,6 +796,181 @@
         color: rgba(255, 255, 255, 0.7);
       }
 
+      /* ── Home Screen ── */
+      .home-screen {
+        position: absolute;
+        inset: 0;
+        z-index: 10;
+        display: flex;
+        flex-direction: column;
+        background: rgba(255, 255, 255, 0.92);
+        backdrop-filter: blur(12px);
+        overflow-y: auto;
+        pointer-events: auto;
+      }
+
+      .home-screen[hidden] {
+        display: none;
+      }
+
+      .home-header {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 20px 28px 12px;
+        border-bottom: 1px solid #e8e8e8;
+      }
+
+      .home-title {
+        margin: 0;
+        font-size: 22px;
+        font-weight: 700;
+        color: var(--accent);
+        letter-spacing: 0.02em;
+      }
+
+      .home-body {
+        flex: 1;
+        padding: 20px 28px;
+        max-width: 800px;
+      }
+
+      .home-section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+      }
+
+      .home-section-title {
+        font-size: 14px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #888;
+      }
+
+      .home-scope-tree {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+      }
+
+      .home-scope-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border-radius: 8px;
+        cursor: pointer;
+        user-select: none;
+        transition: background 0.1s ease;
+      }
+
+      .home-scope-row:hover {
+        background: rgba(122, 53, 255, 0.06);
+      }
+
+      .home-scope-row:active {
+        background: rgba(122, 53, 255, 0.12);
+      }
+
+      .home-scope-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        font-size: 12px;
+        color: #999;
+        flex-shrink: 0;
+        transition: transform 0.15s ease;
+        border: none;
+        background: none;
+        padding: 0;
+        cursor: pointer;
+      }
+
+      .home-scope-toggle.expanded {
+        transform: rotate(90deg);
+      }
+
+      .home-scope-toggle.no-children {
+        visibility: hidden;
+      }
+
+      .home-scope-name {
+        font-size: 15px;
+        font-weight: 500;
+        color: var(--ink);
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .home-scope-count {
+        font-size: 12px;
+        color: #999;
+        flex-shrink: 0;
+      }
+
+      .home-scope-children {
+        padding-left: 20px;
+      }
+
+      .home-scope-children[hidden] {
+        display: none;
+      }
+
+      .home-breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 0 8px;
+        font-size: 12px;
+        color: #888;
+        flex-shrink: 0;
+      }
+
+      .home-breadcrumb-item {
+        cursor: pointer;
+        color: var(--accent);
+        text-decoration: none;
+        border: none;
+        background: none;
+        padding: 2px 4px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-family: inherit;
+      }
+
+      .home-breadcrumb-item:hover {
+        background: var(--accent-soft);
+      }
+
+      .home-breadcrumb-item.current {
+        color: var(--ink);
+        cursor: default;
+        font-weight: 600;
+      }
+
+      .home-breadcrumb-item.current:hover {
+        background: transparent;
+      }
+
+      .home-breadcrumb-sep {
+        color: #ccc;
+        user-select: none;
+      }
+
+      /* Hide board and linear panel when home screen is visible */
+      .app.home-active .workspace {
+        visibility: hidden;
+      }
+
       @media (max-width: 900px) {
         .label-root,
         .label-node {

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -70,6 +70,17 @@
           </aside>
         </div>
       </div>
+      <div id="home-screen" class="home-screen" hidden>
+        <div class="home-header">
+          <h1 class="home-title">M3E</h1>
+        </div>
+        <div class="home-body">
+          <div class="home-section-header">
+            <span class="home-section-title">All Scopes</span>
+          </div>
+          <div id="home-scope-tree" class="home-scope-tree"></div>
+        </div>
+      </div>
       <div id="shortcut-cheatsheet" class="shortcut-cheatsheet" hidden>
         <div class="cheatsheet-header">Keyboard Shortcuts</div>
         <div class="cheatsheet-body">
@@ -80,6 +91,7 @@
               <div class="cheatsheet-row"><kbd>Shift+↑↓</kbd><span>Extend selection</span></div>
               <div class="cheatsheet-row"><kbd>J</kbd><span>Deeper (child)</span></div>
               <div class="cheatsheet-row"><kbd>K</kbd><span>Shallower (parent)</span></div>
+              <div class="cheatsheet-row"><kbd>Alt+H</kbd><span>Home screen</span></div>
               <div class="cheatsheet-row"><kbd>Alt+V</kbd><span>Toggle focus / fit</span></div>
               <div class="cheatsheet-row"><kbd>Alt+J</kbd><span>Jump to alias target</span></div>
             </div>


### PR DESCRIPTION
## Summary
- Add Home Screen overlay (`#home-screen`) as an SPA div with glassmorphism styling
- Implement hierarchical scope tree that lists all folder nodes with expandable sub-folders and child node counts
- Add `Alt+H` keybinding to toggle home screen, `Escape` to dismiss
- Show home screen automatically on startup when no `?scopeId=` URL parameter is present
- Breadcrumb navigation displays current scope path using `scopePathIds()`

## Changed files
- `beta/viewer.html` -- added `#home-screen` div and `Alt+H` to cheatsheet
- `beta/viewer.css` -- home screen styles (overlay, tree rows, breadcrumb, toggle)
- `beta/src/browser/viewer.ts` -- `showHomeScreen()`/`hideHomeScreen()`, `collectFolderTree()`, `renderScopeTree()`, `buildHomeBreadcrumb()`, `Alt+H` keybind, startup logic

## Test plan
- [ ] Open viewer without `?scopeId=` -- home screen should appear
- [ ] Open viewer with `?scopeId=xxx` -- home screen should NOT appear, tree loads normally
- [ ] Click a scope in the tree -- home screen hides, scope enters
- [ ] Press `Alt+H` -- home screen toggles on/off
- [ ] Press `Escape` while home screen is visible -- home screen closes
- [ ] Expand/collapse sub-folders in the tree with triangle toggle
- [ ] Verify existing keybindings still work after closing home screen
- [ ] Verify `Ctrl+]` / `Ctrl+[` scope navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)