### PR TITLE
data: add SQLite snapshot backup module

### DIFF
--- a/beta/src/node/backup.ts
+++ b/beta/src/node/backup.ts
@@ -1,0 +1,155 @@
+"use strict";
+
+import fs from "fs";
+import path from "path";
+import Database from "better-sqlite3";
+
+/**
+ * SQLite snapshot backup module.
+ *
+ * Primary strategy: better-sqlite3 `.backup()` API (online-safe).
+ * Fallback: `fs.copyFileSync()` when `.backup()` is unavailable.
+ *
+ * Design ref: dev-docs/design/data_import_export.md section 2.e
+ */
+
+const BACKUP_PREFIX = "M3E_dataV1_";
+const BACKUP_SUFFIX = ".sqlite";
+const BACKUP_PATTERN = /^M3E_dataV1_\d{8}_\d{6}\.sqlite$/;
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_MAX_GENERATIONS = 10;
+
+function formatTimestamp(date: Date): string {
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  const y = date.getFullYear();
+  const m = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const hh = pad(date.getHours());
+  const mm = pad(date.getMinutes());
+  const ss = pad(date.getSeconds());
+  return `${y}${m}${d}_${hh}${mm}${ss}`;
+}
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Create a snapshot backup of the SQLite database.
+ *
+ * Returns the absolute path of the created backup file.
+ * Throws only if both primary and fallback strategies fail.
+ */
+export async function createBackup(dbPath: string, backupDir: string): Promise<string> {
+  ensureDir(backupDir);
+
+  const timestamp = formatTimestamp(new Date());
+  const backupName = `${BACKUP_PREFIX}${timestamp}${BACKUP_SUFFIX}`;
+  const backupPath = path.join(backupDir, backupName);
+
+  // Strategy A: better-sqlite3 .backup() — online-safe, no WAL issues
+  let usedFallback = false;
+  try {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      await db.backup(backupPath);
+    } finally {
+      db.close();
+    }
+  } catch (primaryErr) {
+    // Fallback: fs.copyFileSync — acceptable when DB is not being written
+    usedFallback = true;
+    try {
+      fs.copyFileSync(dbPath, backupPath);
+    } catch (fallbackErr) {
+      throw new Error(
+        `Backup failed. Primary: ${(primaryErr as Error).message}; Fallback: ${(fallbackErr as Error).message}`,
+      );
+    }
+  }
+
+  const method = usedFallback ? "fs.copyFileSync (fallback)" : "better-sqlite3 .backup()";
+  console.log(`[backup] Created: ${backupPath} via ${method}`);
+  return backupPath;
+}
+
+/**
+ * Delete old backup files exceeding `maxGenerations`, oldest first (FIFO).
+ */
+export function pruneOldBackups(backupDir: string, maxGenerations: number): void {
+  if (!fs.existsSync(backupDir)) {
+    return;
+  }
+
+  const files = fs
+    .readdirSync(backupDir)
+    .filter((name) => BACKUP_PATTERN.test(name))
+    .sort(); // lexicographic sort = chronological for YYYYMMDD_HHmmss
+
+  const excess = files.length - maxGenerations;
+  if (excess <= 0) {
+    return;
+  }
+
+  const toDelete = files.slice(0, excess);
+  for (const name of toDelete) {
+    const fullPath = path.join(backupDir, name);
+    try {
+      fs.unlinkSync(fullPath);
+      console.log(`[backup] Pruned old backup: ${name}`);
+    } catch (err) {
+      console.error(`[backup] Failed to prune ${name}: ${(err as Error).message}`);
+    }
+  }
+}
+
+let autoBackupTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start periodic automatic backups.
+ *
+ * - Runs `createBackup` followed by `pruneOldBackups` at each interval.
+ * - Failures are logged but never crash the server.
+ */
+export function startAutoBackup(
+  dbPath: string,
+  backupDir: string,
+  intervalMs?: number,
+  maxGenerations?: number,
+): void {
+  const interval = intervalMs ?? (Number(process.env.M3E_BACKUP_INTERVAL_MS) || DEFAULT_INTERVAL_MS);
+  const maxGen = maxGenerations ?? (Number(process.env.M3E_BACKUP_MAX_GENERATIONS) || DEFAULT_MAX_GENERATIONS);
+
+  // Clear any existing timer to avoid duplicates
+  stopAutoBackup();
+
+  console.log(`[backup] Auto-backup every ${interval / 1000}s, keeping ${maxGen} generations`);
+
+  autoBackupTimer = setInterval(() => {
+    createBackup(dbPath, backupDir)
+      .then(() => {
+        pruneOldBackups(backupDir, maxGen);
+      })
+      .catch((err) => {
+        console.error(`[backup] Auto-backup failed: ${(err as Error).message}`);
+      });
+  }, interval);
+
+  // Allow the Node process to exit even if the timer is still running
+  if (autoBackupTimer && typeof autoBackupTimer === "object" && "unref" in autoBackupTimer) {
+    autoBackupTimer.unref();
+  }
+}
+
+/**
+ * Stop the periodic backup timer (useful for tests / graceful shutdown).
+ */
+export function stopAutoBackup(): void {
+  if (autoBackupTimer !== null) {
+    clearInterval(autoBackupTimer);
+    autoBackupTimer = null;
+  }
+}

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -5,6 +5,7 @@ import path from "path";
 import http from "http";
 import { spawnSync, exec } from "child_process";
 import { RapidMvpModel } from "./rapid_mvp";
+import { createBackup, pruneOldBackups, startAutoBackup } from "./backup";
 import { detectCloudConflict } from "./cloud_sync";
 import { getAiStatus, runAiSubagent } from "./ai_subagent";
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
@@ -39,6 +40,7 @@ const DB_FILE = process.env.M3E_DB_FILE || DEFAULT_DB_FILE;
 const SQLITE_DB_PATH = path.join(DATA_DIR, DB_FILE);
 const FIRST_RUN_MARKER = path.join(DATA_DIR, ".m3e-launched");
 const TUTORIAL_SCOPE_ID = "n_1775650869381_rns0cp";
+const BACKUP_DIR = path.join(DATA_DIR, "backups");
 const CLOUD_SYNC_ENABLED = process.env.M3E_CLOUD_SYNC === "1";
 const CLOUD_SYNC_DIR = process.env.M3E_CLOUD_DIR
   ? path.resolve(process.env.M3E_CLOUD_DIR)
@@ -602,6 +604,16 @@ function startServer(): void {
     if (isFirstRun) {
       try { fs.writeFileSync(FIRST_RUN_MARKER, new Date().toISOString()); } catch { /* ignore */ }
     }
+
+    // Startup backup + periodic auto-backup
+    if (fs.existsSync(SQLITE_DB_PATH)) {
+      const maxGen = Number(process.env.M3E_BACKUP_MAX_GENERATIONS) || 10;
+      createBackup(SQLITE_DB_PATH, BACKUP_DIR)
+        .then(() => { pruneOldBackups(BACKUP_DIR, maxGen); })
+        .catch((err) => { console.error(`[backup] Startup backup failed: ${(err as Error).message}`); });
+      startAutoBackup(SQLITE_DB_PATH, BACKUP_DIR);
+    }
+
     console.log("Press Ctrl+C to stop the server.");
   });
 }

--- a/beta/tests/unit/backup.test.js
+++ b/beta/tests/unit/backup.test.js
@@ -1,0 +1,147 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { createBackup, pruneOldBackups, startAutoBackup, stopAutoBackup } = require("../../dist/node/backup.js");
+const Database = require("better-sqlite3");
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "m3e-backup-test-"));
+}
+
+function createTestDb(dir) {
+  const dbPath = path.join(dir, "test.sqlite");
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE IF NOT EXISTS documents (id TEXT PRIMARY KEY, version INTEGER, saved_at TEXT, state_json TEXT)");
+  db.prepare("INSERT INTO documents (id, version, saved_at, state_json) VALUES (?, ?, ?, ?)").run(
+    "default", 1, new Date().toISOString(), '{"rootId":"r1","nodes":{},"links":{}}'
+  );
+  db.close();
+  return dbPath;
+}
+
+test("createBackup produces a file in backupDir", async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = createTestDb(tmpDir);
+  const backupDir = path.join(tmpDir, "backups");
+
+  const result = await createBackup(dbPath, backupDir);
+
+  assert.ok(fs.existsSync(result), "backup file should exist");
+  assert.ok(result.startsWith(backupDir), "backup should be inside backupDir");
+  assert.match(path.basename(result), /^M3E_dataV1_\d{8}_\d{6}\.sqlite$/);
+
+  // Verify backup is a valid SQLite file
+  const backupDb = new Database(result, { readonly: true });
+  const row = backupDb.prepare("SELECT id FROM documents WHERE id = ?").get("default");
+  backupDb.close();
+  assert.ok(row, "backup DB should contain the document");
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("createBackup creates backupDir if it does not exist", async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = createTestDb(tmpDir);
+  const backupDir = path.join(tmpDir, "nested", "deep", "backups");
+
+  assert.ok(!fs.existsSync(backupDir));
+  await createBackup(dbPath, backupDir);
+  assert.ok(fs.existsSync(backupDir));
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("pruneOldBackups keeps maxGenerations and deletes oldest", () => {
+  const tmpDir = makeTmpDir();
+  const backupDir = path.join(tmpDir, "backups");
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  // Create 5 fake backup files with different timestamps
+  const names = [
+    "M3E_dataV1_20260401_100000.sqlite",
+    "M3E_dataV1_20260401_110000.sqlite",
+    "M3E_dataV1_20260401_120000.sqlite",
+    "M3E_dataV1_20260401_130000.sqlite",
+    "M3E_dataV1_20260401_140000.sqlite",
+  ];
+  for (const name of names) {
+    fs.writeFileSync(path.join(backupDir, name), "fake");
+  }
+
+  // Keep max 3
+  pruneOldBackups(backupDir, 3);
+
+  const remaining = fs.readdirSync(backupDir).sort();
+  assert.equal(remaining.length, 3);
+  // Oldest two should be gone
+  assert.ok(!remaining.includes("M3E_dataV1_20260401_100000.sqlite"));
+  assert.ok(!remaining.includes("M3E_dataV1_20260401_110000.sqlite"));
+  // Newest three should remain
+  assert.ok(remaining.includes("M3E_dataV1_20260401_120000.sqlite"));
+  assert.ok(remaining.includes("M3E_dataV1_20260401_130000.sqlite"));
+  assert.ok(remaining.includes("M3E_dataV1_20260401_140000.sqlite"));
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("pruneOldBackups does nothing when under limit", () => {
+  const tmpDir = makeTmpDir();
+  const backupDir = path.join(tmpDir, "backups");
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  fs.writeFileSync(path.join(backupDir, "M3E_dataV1_20260401_100000.sqlite"), "fake");
+  fs.writeFileSync(path.join(backupDir, "M3E_dataV1_20260401_110000.sqlite"), "fake");
+
+  pruneOldBackups(backupDir, 10);
+
+  const remaining = fs.readdirSync(backupDir);
+  assert.equal(remaining.length, 2);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("pruneOldBackups ignores non-matching files", () => {
+  const tmpDir = makeTmpDir();
+  const backupDir = path.join(tmpDir, "backups");
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  fs.writeFileSync(path.join(backupDir, "M3E_dataV1_20260401_100000.sqlite"), "fake");
+  fs.writeFileSync(path.join(backupDir, "random-file.txt"), "other");
+  fs.writeFileSync(path.join(backupDir, "M3E_dataV1_20260401_110000.sqlite"), "fake");
+
+  pruneOldBackups(backupDir, 1);
+
+  const remaining = fs.readdirSync(backupDir).sort();
+  assert.equal(remaining.length, 2); // 1 backup + 1 random file
+  assert.ok(remaining.includes("random-file.txt"));
+  assert.ok(remaining.includes("M3E_dataV1_20260401_110000.sqlite"));
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("pruneOldBackups handles missing directory gracefully", () => {
+  // Should not throw
+  pruneOldBackups("/nonexistent/path/that/should/not/exist", 5);
+});
+
+test("stopAutoBackup can be called safely without prior start", () => {
+  // Should not throw
+  stopAutoBackup();
+});
+
+test("startAutoBackup and stopAutoBackup lifecycle", () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = createTestDb(tmpDir);
+  const backupDir = path.join(tmpDir, "backups");
+
+  // Start with a very long interval so it won't fire during the test
+  startAutoBackup(dbPath, backupDir, 999999999, 10);
+  // Calling start again should replace the timer (not leak)
+  startAutoBackup(dbPath, backupDir, 999999999, 10);
+  stopAutoBackup();
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- Add `beta/src/node/backup.ts` — SQLite snapshot backup using `better-sqlite3` `.backup()` API with `fs.copyFileSync` fallback
- Integrate into `start_viewer.ts`: startup backup + periodic auto-backup (default 1h interval, 10 generation FIFO)
- Configurable via `M3E_BACKUP_INTERVAL_MS` and `M3E_BACKUP_MAX_GENERATIONS` environment variables
- Backup failures are logged but never crash the server

## Test plan
- [x] 8 new unit tests in `beta/tests/unit/backup.test.js` — all passing
- [x] Existing 15 `rapid_mvp.test.js` tests still pass
- [x] TypeScript compiles clean (`tsc -p tsconfig.node.json --noEmit`)
- [ ] Manual: start server with existing DB, verify backup file appears in `data/backups/`
- [ ] Manual: confirm old backups are pruned when exceeding 10

Generated with [Claude Code](https://claude.com/claude-code)