### PR TITLE
data: add conflict backup save/restore for cloud sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ beta/dist/
 beta/.env
 beta/data/rapid-sample.json
 beta/data/*.sqlite
+beta/data/conflict-backups/
 beta/test-results/
 
 final/node_modules/

--- a/beta/src/node/conflict_backup.ts
+++ b/beta/src/node/conflict_backup.ts
@@ -1,0 +1,195 @@
+"use strict";
+
+import fs from "fs";
+import path from "path";
+import type { AppState, SavedDoc } from "../shared/types";
+
+export interface ConflictBackupEntry {
+  backupId: string;
+  documentId: string;
+  reason: string;
+  createdAt: string;
+  savedAt: string;
+}
+
+export interface ConflictBackupFull extends ConflictBackupEntry {
+  version: 1;
+  state: AppState;
+}
+
+const MAX_BACKUPS_PER_DOC = 10;
+
+function backupDir(dataDir: string): string {
+  return path.join(dataDir, "conflict-backups");
+}
+
+function ensureBackupDir(dataDir: string): void {
+  const dir = backupDir(dataDir);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function backupFileName(documentId: string, backupId: string): string {
+  const safeDocId = documentId.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return `${safeDocId}_${backupId}.json`;
+}
+
+function parseBackupFileName(
+  fileName: string,
+  documentId: string,
+): string | null {
+  const safeDocId = documentId.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const prefix = `${safeDocId}_`;
+  if (!fileName.startsWith(prefix) || !fileName.endsWith(".json")) {
+    return null;
+  }
+  return fileName.slice(prefix.length, -5);
+}
+
+function generateBackupId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[:.]/g, "-").replace("T", "_").slice(0, -1);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${ts}_${rand}`;
+}
+
+/**
+ * Save a conflict backup of the local state before it is overwritten.
+ */
+export function createConflictBackup(
+  dataDir: string,
+  documentId: string,
+  localState: AppState,
+  reason: string,
+): ConflictBackupEntry {
+  ensureBackupDir(dataDir);
+
+  const backupId = generateBackupId();
+  const now = new Date().toISOString();
+
+  const entry: ConflictBackupFull = {
+    version: 1,
+    backupId,
+    documentId,
+    reason,
+    createdAt: now,
+    savedAt: now,
+    state: localState,
+  };
+
+  const filePath = path.join(backupDir(dataDir), backupFileName(documentId, backupId));
+  fs.writeFileSync(filePath, JSON.stringify(entry, null, 2), "utf8");
+
+  // Enforce max backups per document
+  pruneOldBackups(dataDir, documentId);
+
+  return {
+    backupId: entry.backupId,
+    documentId: entry.documentId,
+    reason: entry.reason,
+    createdAt: entry.createdAt,
+    savedAt: entry.savedAt,
+  };
+}
+
+/**
+ * List all conflict backups for a document, newest first.
+ */
+export function listConflictBackups(
+  dataDir: string,
+  documentId: string,
+): ConflictBackupEntry[] {
+  const dir = backupDir(dataDir);
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(dir);
+  const entries: ConflictBackupEntry[] = [];
+
+  for (const file of files) {
+    const bid = parseBackupFileName(file, documentId);
+    if (!bid) continue;
+
+    try {
+      const raw = fs.readFileSync(path.join(dir, file), "utf8");
+      const parsed = JSON.parse(raw) as ConflictBackupFull;
+      if (parsed.version === 1 && parsed.documentId === documentId) {
+        entries.push({
+          backupId: parsed.backupId,
+          documentId: parsed.documentId,
+          reason: parsed.reason,
+          createdAt: parsed.createdAt,
+          savedAt: parsed.savedAt,
+        });
+      }
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  // Sort newest first
+  entries.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return entries;
+}
+
+/**
+ * Get a single conflict backup with full state.
+ */
+export function getConflictBackup(
+  dataDir: string,
+  documentId: string,
+  backupId: string,
+): ConflictBackupFull | null {
+  const dir = backupDir(dataDir);
+  const filePath = path.join(dir, backupFileName(documentId, backupId));
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as ConflictBackupFull;
+    if (parsed.version === 1 && parsed.documentId === documentId) {
+      return parsed;
+    }
+  } catch {
+    // Invalid backup
+  }
+  return null;
+}
+
+/**
+ * Delete a conflict backup.
+ */
+export function deleteConflictBackup(
+  dataDir: string,
+  documentId: string,
+  backupId: string,
+): boolean {
+  const dir = backupDir(dataDir);
+  const filePath = path.join(dir, backupFileName(documentId, backupId));
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+
+  fs.unlinkSync(filePath);
+  return true;
+}
+
+/**
+ * Remove oldest backups when count exceeds MAX_BACKUPS_PER_DOC.
+ */
+function pruneOldBackups(dataDir: string, documentId: string): void {
+  const entries = listConflictBackups(dataDir, documentId);
+  if (entries.length <= MAX_BACKUPS_PER_DOC) {
+    return;
+  }
+
+  // entries is sorted newest first; remove from the end
+  const toRemove = entries.slice(MAX_BACKUPS_PER_DOC);
+  for (const entry of toRemove) {
+    deleteConflictBackup(dataDir, documentId, entry.backupId);
+  }
+}

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -6,6 +6,12 @@ import http from "http";
 import { spawnSync, exec } from "child_process";
 import { RapidMvpModel } from "./rapid_mvp";
 import { detectCloudConflict } from "./cloud_sync";
+import {
+  createConflictBackup,
+  listConflictBackups,
+  getConflictBackup,
+  deleteConflictBackup,
+} from "./conflict_backup";
 import { getAiStatus, runAiSubagent } from "./ai_subagent";
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
 import {
@@ -149,6 +155,32 @@ function parseSyncRoute(urlPath: string): { action: "status" | "push" | "pull"; 
     action: match[1] as "status" | "push" | "pull",
     docId: decodeURIComponent(match[2] || ""),
   };
+}
+
+function parseBackupRoute(
+  urlPath: string,
+): { action: "list" | "get" | "restore" | "delete"; docId: string; backupId?: string } | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+
+  // GET /api/sync/backups/{docId}
+  const listMatch = pathname.match(/^\/api\/sync\/backups\/([^/]+)$/);
+  if (listMatch) {
+    return { action: "list", docId: decodeURIComponent(listMatch[1]) };
+  }
+
+  // GET /api/sync/backups/{docId}/{backupId}
+  const getMatch = pathname.match(/^\/api\/sync\/backups\/([^/]+)\/([^/]+)$/);
+  if (getMatch) {
+    return { action: "get", docId: decodeURIComponent(getMatch[1]), backupId: decodeURIComponent(getMatch[2]) };
+  }
+
+  // POST /api/sync/backups/{docId}/restore/{backupId}
+  const restoreMatch = pathname.match(/^\/api\/sync\/backups\/([^/]+)\/restore\/([^/]+)$/);
+  if (restoreMatch) {
+    return { action: "restore", docId: decodeURIComponent(restoreMatch[1]), backupId: decodeURIComponent(restoreMatch[2]) };
+  }
+
+  return null;
 }
 
 function isLinearTransformRoute(urlPath: string): boolean {
@@ -318,6 +350,21 @@ async function handleSyncApi(
     }
 
     try {
+      // Read optional localState from request body for conflict backup
+      let localState: AppState | null = null;
+      let backupEntry: { backupId: string; reason: string } | null = null;
+      try {
+        const rawBody = await readRequestBody(req);
+        if (rawBody.trim()) {
+          const body = JSON.parse(rawBody) as { localState?: AppState; reason?: string };
+          if (body.localState) {
+            localState = body.localState;
+          }
+        }
+      } catch {
+        // Body is optional for pull; ignore parse errors
+      }
+
       const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as { version?: number; state?: AppState; savedAt?: string };
       if (!parsed || parsed.version !== 1 || !parsed.state) {
         sendSyncError(res, 400, "SYNC_CLOUD_UNSUPPORTED_FORMAT", "Cloud document has unsupported format.", route.docId);
@@ -337,6 +384,13 @@ async function handleSyncApi(
         return true;
       }
 
+      // Auto-backup local state before overwriting with cloud data
+      if (localState) {
+        const reason = "cloud-sync-pull";
+        const entry = createConflictBackup(DATA_DIR, route.docId, localState, reason);
+        backupEntry = { backupId: entry.backupId, reason: entry.reason };
+      }
+
       sendJson(res, 200, {
         ok: true,
         mode: "file-mirror",
@@ -344,6 +398,7 @@ async function handleSyncApi(
         savedAt: parsed.savedAt || fs.statSync(filePath).mtime.toISOString(),
         state: model.toJSON(),
         documentId: route.docId,
+        ...(backupEntry ? { backup: backupEntry } : {}),
       });
       return true;
     } catch (err) {
@@ -372,9 +427,25 @@ async function handleSyncApi(
       const baseSavedAt = parsed.baseSavedAt ?? null;
       const forcePush = Boolean(parsed.force);
       if (detectCloudConflict(existingCloudDoc?.savedAt ?? null, baseSavedAt, forcePush)) {
+        // Auto-backup the local state that is about to be rejected
+        let backupEntry: { backupId: string; reason: string } | null = null;
+        if (candidate.state) {
+          try {
+            const entry = createConflictBackup(
+              DATA_DIR,
+              route.docId,
+              candidate.state as AppState,
+              "cloud-conflict-push",
+            );
+            backupEntry = { backupId: entry.backupId, reason: entry.reason };
+          } catch {
+            // Backup failure should not block the conflict response
+          }
+        }
         sendSyncError(res, 409, "CLOUD_CONFLICT", "Cloud conflict detected.", route.docId, {
           cloudSavedAt: existingCloudDoc?.savedAt ?? null,
           baseSavedAt,
+          ...(backupEntry ? { backup: backupEntry } : {}),
         });
         return true;
       }
@@ -423,6 +494,93 @@ async function handleSyncApi(
   }
 
   sendSyncError(res, 405, "SYNC_METHOD_NOT_ALLOWED", "Method not allowed.", route.docId);
+  return true;
+}
+
+async function handleBackupApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: { action: "list" | "get" | "restore" | "delete"; docId: string; backupId?: string },
+): Promise<boolean> {
+  if (!route.docId) {
+    sendJson(res, 400, { ok: false, error: "Document id is required." });
+    return true;
+  }
+
+  if (route.action === "list" && req.method === "GET") {
+    const entries = listConflictBackups(DATA_DIR, route.docId);
+    sendJson(res, 200, { ok: true, documentId: route.docId, backups: entries });
+    return true;
+  }
+
+  if (route.action === "get" && req.method === "GET") {
+    if (!route.backupId) {
+      sendJson(res, 400, { ok: false, error: "Backup id is required." });
+      return true;
+    }
+    const backup = getConflictBackup(DATA_DIR, route.docId, route.backupId);
+    if (!backup) {
+      sendJson(res, 404, { ok: false, error: "Backup not found." });
+      return true;
+    }
+    sendJson(res, 200, { ok: true, backup });
+    return true;
+  }
+
+  if (route.action === "get" && req.method === "DELETE") {
+    if (!route.backupId) {
+      sendJson(res, 400, { ok: false, error: "Backup id is required." });
+      return true;
+    }
+    const deleted = deleteConflictBackup(DATA_DIR, route.docId, route.backupId);
+    if (!deleted) {
+      sendJson(res, 404, { ok: false, error: "Backup not found." });
+      return true;
+    }
+    sendJson(res, 200, { ok: true, deleted: true });
+    return true;
+  }
+
+  if (route.action === "restore" && req.method === "POST") {
+    if (!route.backupId) {
+      sendJson(res, 400, { ok: false, error: "Backup id is required." });
+      return true;
+    }
+    const backup = getConflictBackup(DATA_DIR, route.docId, route.backupId);
+    if (!backup) {
+      sendJson(res, 404, { ok: false, error: "Backup not found." });
+      return true;
+    }
+
+    try {
+      const model = RapidMvpModel.fromJSON(backup.state);
+      const errors = model.validate();
+      if (errors.length > 0) {
+        sendJson(res, 400, {
+          ok: false,
+          error: `Backup state is invalid: ${errors.join(" | ")}`,
+        });
+        return true;
+      }
+
+      model.saveToSqlite(SQLITE_DB_PATH, route.docId);
+      sendJson(res, 200, {
+        ok: true,
+        restored: true,
+        backupId: route.backupId,
+        documentId: route.docId,
+        savedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      sendJson(res, 500, {
+        ok: false,
+        error: (err as Error).message || "Restore failed.",
+      });
+    }
+    return true;
+  }
+
+  sendJson(res, 405, { ok: false, error: "Method not allowed." });
   return true;
 }
 
@@ -763,6 +921,12 @@ export function createAppServer(): http.Server {
 
     if (isLinearTransformRoute(req.url ?? "/")) {
       await handleLinearTransformApi(req, res);
+      return;
+    }
+
+    const backupRoute = parseBackupRoute(req.url ?? "/");
+    if (backupRoute) {
+      await handleBackupApi(req, res, backupRoute);
       return;
     }
 

--- a/beta/tests/unit/conflict_backup.test.js
+++ b/beta/tests/unit/conflict_backup.test.js
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  createConflictBackup,
+  listConflictBackups,
+  getConflictBackup,
+  deleteConflictBackup,
+} = require("../../dist/node/conflict_backup.js");
+
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+let tempDataDir;
+
+function createState(label) {
+  const model = new RapidMvpModel("Root");
+  model.addNode(model.state.rootId, label);
+  return model.toJSON();
+}
+
+test.beforeEach(() => {
+  tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-backup-test-"));
+});
+
+test.afterEach(() => {
+  fs.rmSync(tempDataDir, { recursive: true, force: true });
+});
+
+test("createConflictBackup saves a backup and returns entry metadata", () => {
+  const state = createState("TestNode");
+  const entry = createConflictBackup(tempDataDir, "doc-1", state, "cloud-sync-pull");
+
+  assert.ok(entry.backupId);
+  assert.equal(entry.documentId, "doc-1");
+  assert.equal(entry.reason, "cloud-sync-pull");
+  assert.ok(entry.createdAt);
+  assert.ok(entry.savedAt);
+});
+
+test("listConflictBackups returns saved backups sorted newest first", () => {
+  const state1 = createState("A");
+  const state2 = createState("B");
+
+  const entry1 = createConflictBackup(tempDataDir, "doc-1", state1, "reason-1");
+  const entry2 = createConflictBackup(tempDataDir, "doc-1", state2, "reason-2");
+
+  const list = listConflictBackups(tempDataDir, "doc-1");
+  assert.equal(list.length, 2);
+  // Newest first
+  assert.equal(list[0].backupId, entry2.backupId);
+  assert.equal(list[1].backupId, entry1.backupId);
+});
+
+test("listConflictBackups returns empty array when no backups exist", () => {
+  const list = listConflictBackups(tempDataDir, "nonexistent");
+  assert.deepEqual(list, []);
+});
+
+test("listConflictBackups filters by documentId", () => {
+  createConflictBackup(tempDataDir, "doc-a", createState("A"), "r1");
+  createConflictBackup(tempDataDir, "doc-b", createState("B"), "r2");
+
+  const listA = listConflictBackups(tempDataDir, "doc-a");
+  assert.equal(listA.length, 1);
+  assert.equal(listA[0].documentId, "doc-a");
+
+  const listB = listConflictBackups(tempDataDir, "doc-b");
+  assert.equal(listB.length, 1);
+  assert.equal(listB[0].documentId, "doc-b");
+});
+
+test("getConflictBackup returns full backup with state", () => {
+  const state = createState("GetTest");
+  const entry = createConflictBackup(tempDataDir, "doc-1", state, "test-reason");
+
+  const full = getConflictBackup(tempDataDir, "doc-1", entry.backupId);
+  assert.ok(full);
+  assert.equal(full.version, 1);
+  assert.equal(full.backupId, entry.backupId);
+  assert.equal(full.documentId, "doc-1");
+  assert.ok(full.state);
+  assert.ok(full.state.rootId);
+  assert.ok(full.state.nodes);
+});
+
+test("getConflictBackup returns null for nonexistent backup", () => {
+  const full = getConflictBackup(tempDataDir, "doc-1", "nonexistent-id");
+  assert.equal(full, null);
+});
+
+test("deleteConflictBackup removes the backup file", () => {
+  const entry = createConflictBackup(tempDataDir, "doc-1", createState("Del"), "r");
+
+  const deleted = deleteConflictBackup(tempDataDir, "doc-1", entry.backupId);
+  assert.equal(deleted, true);
+
+  const list = listConflictBackups(tempDataDir, "doc-1");
+  assert.equal(list.length, 0);
+
+  const full = getConflictBackup(tempDataDir, "doc-1", entry.backupId);
+  assert.equal(full, null);
+});
+
+test("deleteConflictBackup returns false for nonexistent backup", () => {
+  const deleted = deleteConflictBackup(tempDataDir, "doc-1", "nonexistent");
+  assert.equal(deleted, false);
+});
+
+test("createConflictBackup prunes backups beyond limit of 10", () => {
+  for (let i = 0; i < 12; i++) {
+    createConflictBackup(tempDataDir, "doc-prune", createState(`N${i}`), `r${i}`);
+  }
+
+  const list = listConflictBackups(tempDataDir, "doc-prune");
+  assert.equal(list.length, 10);
+});

--- a/beta/tests/unit/conflict_backup_api.test.js
+++ b/beta/tests/unit/conflict_backup_api.test.js
@@ -1,0 +1,253 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const tempCloudDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-backup-api-cloud-"));
+const tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-backup-api-data-"));
+process.env.M3E_CLOUD_SYNC = "1";
+process.env.M3E_CLOUD_DIR = tempCloudDir;
+process.env.M3E_DATA_DIR = tempDataDir;
+
+const { createAppServer } = require("../../dist/node/start_viewer.js");
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+let server;
+let baseUrl;
+
+async function requestJson(url, init) {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => ({}));
+  return { response, payload };
+}
+
+function createState(label) {
+  const model = new RapidMvpModel("Root");
+  model.addNode(model.state.rootId, label);
+  return model.toJSON();
+}
+
+test.before(async () => {
+  server = createAppServer();
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+  fs.rmSync(tempCloudDir, { recursive: true, force: true });
+  fs.rmSync(tempDataDir, { recursive: true, force: true });
+});
+
+test("backup list returns empty array when no backups exist", async () => {
+  const res = await requestJson(`${baseUrl}/api/sync/backups/no-backups`);
+  assert.equal(res.response.status, 200);
+  assert.equal(res.payload.ok, true);
+  assert.equal(res.payload.documentId, "no-backups");
+  assert.deepEqual(res.payload.backups, []);
+});
+
+test("pull with localState creates a conflict backup", async () => {
+  const docId = "backup-pull-test";
+  const localState = createState("LocalVersion");
+
+  // First push something to cloud
+  const push = await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: createState("CloudVersion"), savedAt: "2026-04-02T00:00:00.000Z" }),
+  });
+  assert.equal(push.response.status, 200);
+
+  // Pull with localState to trigger backup
+  const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ localState }),
+  });
+  assert.equal(pull.response.status, 200);
+  assert.equal(pull.payload.ok, true);
+  assert.ok(pull.payload.backup);
+  assert.ok(pull.payload.backup.backupId);
+  assert.equal(pull.payload.backup.reason, "cloud-sync-pull");
+
+  // Verify backup appears in list
+  const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
+  assert.equal(list.response.status, 200);
+  assert.equal(list.payload.backups.length, 1);
+  assert.equal(list.payload.backups[0].backupId, pull.payload.backup.backupId);
+});
+
+test("pull without localState does not create a backup", async () => {
+  const docId = "backup-pull-no-local";
+
+  // Push to cloud
+  await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: createState("Cloud"), savedAt: "2026-04-02T00:00:00.000Z" }),
+  });
+
+  // Pull without localState
+  const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(pull.response.status, 200);
+  assert.equal(pull.payload.backup, undefined);
+
+  // No backup in list
+  const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
+  assert.equal(list.payload.backups.length, 0);
+});
+
+test("push conflict creates a backup of the pushed state", async () => {
+  const docId = "backup-conflict-push";
+
+  // Initial push
+  await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: createState("V1"), savedAt: "2026-04-02T00:00:00.000Z" }),
+  });
+
+  // Second push (advances cloud)
+  await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({
+      state: createState("V2"),
+      savedAt: "2026-04-02T00:00:10.000Z",
+      baseSavedAt: "2026-04-02T00:00:00.000Z",
+    }),
+  });
+
+  // Conflicting push with stale baseSavedAt
+  const conflict = await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({
+      state: createState("Stale"),
+      savedAt: "2026-04-02T00:00:20.000Z",
+      baseSavedAt: "2026-04-02T00:00:00.000Z",
+    }),
+  });
+  assert.equal(conflict.response.status, 409);
+  assert.equal(conflict.payload.code, "CLOUD_CONFLICT");
+  assert.ok(conflict.payload.backup);
+  assert.ok(conflict.payload.backup.backupId);
+  assert.equal(conflict.payload.backup.reason, "cloud-conflict-push");
+
+  // Backup should be in list
+  const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
+  assert.equal(list.payload.backups.length, 1);
+});
+
+test("get backup returns full state", async () => {
+  const docId = "backup-get-test";
+  const localState = createState("LocalGet");
+
+  // Push to cloud
+  await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: createState("Cloud"), savedAt: "2026-04-02T00:00:00.000Z" }),
+  });
+
+  // Pull with localState
+  const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ localState }),
+  });
+  const backupId = pull.payload.backup.backupId;
+
+  // Get the backup
+  const get = await requestJson(`${baseUrl}/api/sync/backups/${docId}/${backupId}`);
+  assert.equal(get.response.status, 200);
+  assert.equal(get.payload.ok, true);
+  assert.ok(get.payload.backup);
+  assert.equal(get.payload.backup.backupId, backupId);
+  assert.ok(get.payload.backup.state);
+  assert.ok(get.payload.backup.state.rootId);
+});
+
+test("get nonexistent backup returns 404", async () => {
+  const get = await requestJson(`${baseUrl}/api/sync/backups/doc/nonexistent-id`);
+  assert.equal(get.response.status, 404);
+  assert.equal(get.payload.ok, false);
+});
+
+test("restore backup saves state to SQLite", async () => {
+  const docId = "backup-restore-test";
+  const localState = createState("RestoreMe");
+
+  // Push to cloud
+  await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: createState("Cloud"), savedAt: "2026-04-02T00:00:00.000Z" }),
+  });
+
+  // Pull with localState to create backup
+  const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ localState }),
+  });
+  const backupId = pull.payload.backup.backupId;
+
+  // Restore the backup
+  const restore = await requestJson(`${baseUrl}/api/sync/backups/${docId}/restore/${backupId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+  assert.equal(restore.response.status, 200);
+  assert.equal(restore.payload.ok, true);
+  assert.equal(restore.payload.restored, true);
+  assert.equal(restore.payload.backupId, backupId);
+  assert.equal(restore.payload.documentId, docId);
+  assert.ok(restore.payload.savedAt);
+});
+
+test("delete backup via DELETE method on get endpoint", async () => {
+  const docId = "backup-delete-test";
+  const localState = createState("DeleteMe");
+
+  // Push + pull to create backup
+  await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: createState("Cloud"), savedAt: "2026-04-02T00:00:00.000Z" }),
+  });
+  const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ localState }),
+  });
+  const backupId = pull.payload.backup.backupId;
+
+  // Delete
+  const del = await requestJson(`${baseUrl}/api/sync/backups/${docId}/${backupId}`, {
+    method: "DELETE",
+  });
+  assert.equal(del.response.status, 200);
+  assert.equal(del.payload.ok, true);
+  assert.equal(del.payload.deleted, true);
+
+  // Verify gone
+  const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
+  assert.equal(list.payload.backups.length, 0);
+});

--- a/dev-docs/03_Spec/REST_API.md
+++ b/dev-docs/03_Spec/REST_API.md
@@ -33,6 +33,10 @@ M3E_ROOT=C:\Users\chiec\dev\M3E
 | `POST` | `/api/ai/subagent/{name}` | AI subagent 実行 | AI_Common_API.md |
 | `GET` | `/api/linear-transform/status` | Linear transform ステータス | AI_Common_API.md |
 | `POST` | `/api/linear-transform/convert` | Linear transform 実行 | AI_Common_API.md |
+| `GET` | `/api/sync/backups/{docId}` | 競合バックアップ一覧 | 本文書 |
+| `GET` | `/api/sync/backups/{docId}/{backupId}` | 競合バックアップ取得 | 本文書 |
+| `DELETE` | `/api/sync/backups/{docId}/{backupId}` | 競合バックアップ削除 | 本文書 |
+| `POST` | `/api/sync/backups/{docId}/restore/{backupId}` | 競合バックアップからリストア | 本文書 |
 | `GET` | `/{path}` | 静的ファイル配信 | — |
 
 ---
@@ -225,6 +229,136 @@ Body:
 | 400 | `SYNC_CLOUD_UNSUPPORTED_FORMAT` | フォーマット不正 |
 | 400 | `SYNC_CLOUD_INVALID_MODEL` | バリデーション失敗 |
 | 500 | `SYNC_PULL_FAILED` | ファイル読み込み失敗 |
+
+---
+
+## Conflict Backup API
+
+クラウド同期で競合が発生した際に、ローカル state の自動バックアップを管理する。
+
+### 自動バックアップの動作
+
+以下の状況でローカル state が自動的にバックアップされる:
+
+1. **push 時の競合 (409)**: `POST /api/sync/push/{docId}` で `CLOUD_CONFLICT` が検出された場合、push しようとした state が `cloud-conflict-push` の理由でバックアップされる。レスポンスの `backup` フィールドに `backupId` が含まれる。
+2. **pull 時のローカル保護**: `POST /api/sync/pull/{docId}` のリクエスト body に `localState` を含めた場合、クラウドデータを返す前にローカル state が `cloud-sync-pull` の理由でバックアップされる。
+
+バックアップはドキュメントごとに最大 10 件保持され、超過分は古い順に自動削除される。
+保存先: `{M3E_DATA_DIR}/conflict-backups/`
+
+### `GET /api/sync/backups/{docId}`
+
+指定ドキュメントの競合バックアップ一覧を取得する（新しい順）。
+
+#### 成功レスポンス (200)
+
+```json
+{
+  "ok": true,
+  "documentId": "rapid-main",
+  "backups": [
+    {
+      "backupId": "2026-04-09_12-00-00-000Z_abc123",
+      "documentId": "rapid-main",
+      "reason": "cloud-sync-pull",
+      "createdAt": "2026-04-09T12:00:00.000Z",
+      "savedAt": "2026-04-09T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+### `GET /api/sync/backups/{docId}/{backupId}`
+
+指定バックアップの全データ（state 含む）を取得する。
+
+#### 成功レスポンス (200)
+
+```json
+{
+  "ok": true,
+  "backup": {
+    "version": 1,
+    "backupId": "...",
+    "documentId": "rapid-main",
+    "reason": "cloud-sync-pull",
+    "createdAt": "2026-04-09T12:00:00.000Z",
+    "savedAt": "2026-04-09T12:00:00.000Z",
+    "state": { "rootId": "...", "nodes": { ... }, "links": { ... } }
+  }
+}
+```
+
+#### エラーレスポンス
+
+| status | 条件 |
+|--------|------|
+| 404 | バックアップが存在しない |
+
+### `DELETE /api/sync/backups/{docId}/{backupId}`
+
+指定バックアップを削除する。
+
+#### 成功レスポンス (200)
+
+```json
+{ "ok": true, "deleted": true }
+```
+
+#### エラーレスポンス
+
+| status | 条件 |
+|--------|------|
+| 404 | バックアップが存在しない |
+
+### `POST /api/sync/backups/{docId}/restore/{backupId}`
+
+バックアップの state を SQLite に復元する。
+
+#### 成功レスポンス (200)
+
+```json
+{
+  "ok": true,
+  "restored": true,
+  "backupId": "...",
+  "documentId": "rapid-main",
+  "savedAt": "2026-04-09T12:01:00.000Z"
+}
+```
+
+#### エラーレスポンス
+
+| status | 条件 |
+|--------|------|
+| 400 | バックアップの state がバリデーション失敗 |
+| 404 | バックアップが存在しない |
+| 500 | SQLite 書き込み失敗 |
+
+### `POST /api/sync/pull/{docId}` (拡張)
+
+既存の pull エンドポイントに `localState` フィールドが追加された。
+
+#### リクエスト Body（オプション）
+
+```json
+{
+  "localState": { "rootId": "...", "nodes": { ... } }
+}
+```
+
+`localState` を含む場合、pull レスポンスに `backup` フィールドが付加される:
+
+```json
+{
+  "ok": true,
+  "state": { ... },
+  "backup": {
+    "backupId": "...",
+    "reason": "cloud-sync-pull"
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `conflict_backup.ts` module for saving/listing/restoring/deleting conflict backups as JSON files in `{DATA_DIR}/conflict-backups/`
- Auto-backup local state on cloud sync push conflict (409) and pull with `localState` field
- Add REST API endpoints: `GET/DELETE /api/sync/backups/{docId}/{backupId}`, `POST /api/sync/backups/{docId}/restore/{backupId}`
- Backups auto-pruned to max 10 per document
- REST API spec updated with new endpoint documentation

## Test plan
- [x] 9 unit tests for `conflict_backup.ts` (create, list, get, delete, prune, filtering)
- [x] 8 API integration tests (list, pull backup, push conflict backup, get, restore, delete)
- [x] All 11 existing cloud sync tests still pass
- [x] All 15 existing rapid_mvp tests still pass
- [x] TypeScript compilation clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)