### PR TITLE
data2: add keyboard shortcut test infrastructure

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -13,6 +13,7 @@
     "test:unit:watch": "npm run build:node && node --test --watch tests/unit/*.test.js",
     "test:ci": "npm run test:unit",
     "test:visual": "playwright test",
+    "test:shortcuts": "playwright test tests/visual/shortcuts.spec.js",
     "test:visual:reparent": "playwright test -g \"viewer range select multi reparent\"",
     "test:visual:selection": "playwright test -g \"viewer shift arrow expands selection\"",
     "test:visual:update": "playwright test --update-snapshots"

--- a/beta/tests/fixtures/shortcut_test.json
+++ b/beta/tests/fixtures/shortcut_test.json
@@ -1,0 +1,93 @@
+{
+  "version": 1,
+  "savedAt": "2026-04-09T00:00:00.000Z",
+  "state": {
+    "rootId": "root",
+    "nodes": {
+      "root": {
+        "id": "root",
+        "parentId": null,
+        "children": ["child-a", "child-b", "child-c"],
+        "nodeType": "text",
+        "text": "Test Root",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      },
+      "child-a": {
+        "id": "child-a",
+        "parentId": "root",
+        "children": ["grandchild-a1", "grandchild-a2"],
+        "nodeType": "text",
+        "text": "Child A",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      },
+      "child-b": {
+        "id": "child-b",
+        "parentId": "root",
+        "children": [],
+        "nodeType": "text",
+        "text": "Child B",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      },
+      "child-c": {
+        "id": "child-c",
+        "parentId": "root",
+        "children": ["grandchild-c1"],
+        "nodeType": "text",
+        "text": "Child C",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      },
+      "grandchild-a1": {
+        "id": "grandchild-a1",
+        "parentId": "child-a",
+        "children": [],
+        "nodeType": "text",
+        "text": "Grandchild A1",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      },
+      "grandchild-a2": {
+        "id": "grandchild-a2",
+        "parentId": "child-a",
+        "children": [],
+        "nodeType": "text",
+        "text": "Grandchild A2",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      },
+      "grandchild-c1": {
+        "id": "grandchild-c1",
+        "parentId": "child-c",
+        "children": [],
+        "nodeType": "text",
+        "text": "Grandchild C1",
+        "collapsed": false,
+        "details": "",
+        "note": "",
+        "attributes": {},
+        "link": ""
+      }
+    }
+  }
+}

--- a/beta/tests/helpers/viewer_test_utils.js
+++ b/beta/tests/helpers/viewer_test_utils.js
@@ -1,0 +1,212 @@
+// @ts-check
+/**
+ * Shared test utilities for M3E viewer Playwright tests.
+ *
+ * Provides helpers to launch the viewer with a fixed JSON document,
+ * query DOM state (#meta, #status, node elements), and send keyboard
+ * events in a consistent way.
+ */
+const { expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
+
+const FIXTURE_PATH = path.resolve(__dirname, "..", "fixtures", "shortcut_test.json");
+
+/**
+ * Load a JSON document into the viewer using the file-input mechanism.
+ * If no doc is given, loads the standard shortcut_test.json fixture.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {object} [doc] - Optional JSON document object. Falls back to fixture file.
+ * @returns {Promise<void>}
+ */
+async function launchViewer(page, doc) {
+  const isolatedDocId = `shortcut-test-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+  const qs = `localDocId=${encodeURIComponent(isolatedDocId)}&cloudDocId=${encodeURIComponent(isolatedDocId)}`;
+  await page.goto(`/viewer.html?${qs}`);
+
+  const payload = doc || JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf-8"));
+
+  await page.setInputFiles("#file-input", {
+    name: "shortcut-test.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(payload), "utf8"),
+  });
+
+  await expect(page.locator("#meta")).toContainText("nodes:");
+  // Use Alt+V to fit document (no #fit-all button in current UI).
+  await page.click("#board");
+  await page.keyboard.press("Alt+v");
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Parse the selected node label from #meta text.
+ * The meta format includes: `selected: <label> (<count>)`
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<string>} selected node label
+ */
+async function getSelectedNodeLabel(page) {
+  const metaText = await page.locator("#meta").textContent();
+  const match = (metaText || "").match(/selected:\s*(.+?)\s*\(\d+\)/);
+  if (!match) {
+    throw new Error(`Unable to parse selected label from meta: ${metaText}`);
+  }
+  return match[1].trim();
+}
+
+/**
+ * Get the currently selected node ID by evaluating the viewer's internal state.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<string>} selected node ID
+ */
+async function getSelectedNodeId(page) {
+  // The meta element contains a scope field with an ID-like string.
+  // However, to get the actual selected node ID, we look at the SVG element
+  // with the `selected` class.
+  const id = await page.locator("g.node-group.selected").first().getAttribute("data-node-id");
+  if (!id) {
+    throw new Error("No selected node found in SVG");
+  }
+  return id;
+}
+
+/**
+ * Get the text content of a specific node by its data-node-id.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} nodeId
+ * @returns {Promise<string>}
+ */
+async function getNodeText(page, nodeId) {
+  const textEl = page.locator(`text[data-node-id="${nodeId}"]`).first();
+  return (await textEl.textContent()) || "";
+}
+
+/**
+ * Get the total node count from #meta.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<number>}
+ */
+async function getNodeCount(page) {
+  const metaText = await page.locator("#meta").textContent();
+  const match = (metaText || "").match(/nodes:\s*(\d+)/);
+  if (!match) {
+    throw new Error(`Unable to parse node count from meta: ${metaText}`);
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Get the selected count from #meta.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<number>}
+ */
+async function getSelectedCount(page) {
+  const metaText = await page.locator("#meta").textContent();
+  const match = (metaText || "").match(/selected:\s*.+\((\d+)\)/);
+  if (!match) {
+    throw new Error(`Unable to parse selected count from meta: ${metaText}`);
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Get the link count from #meta.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<number>}
+ */
+async function getLinkCount(page) {
+  const metaText = await page.locator("#meta").textContent();
+  const match = (metaText || "").match(/links:\s*(\d+)/);
+  if (!match) {
+    throw new Error(`Unable to parse link count from meta: ${metaText}`);
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Get the status bar text.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<string>}
+ */
+async function getStatusText(page) {
+  return (await page.locator("#status").textContent()) || "";
+}
+
+/**
+ * Press a key combination on the page.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} key - Playwright key descriptor (e.g. "Tab", "Control+z", "Shift+ArrowDown")
+ * @returns {Promise<void>}
+ */
+async function pressKey(page, key) {
+  await page.keyboard.press(key);
+}
+
+/**
+ * Wait for the viewer to finish a render cycle.
+ * Uses a short timeout that matches the viewer's animation/debounce timing.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {number} [ms=200]
+ * @returns {Promise<void>}
+ */
+async function waitForRender(page, ms = 200) {
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Click on the SVG board to ensure keyboard focus is on the viewer.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<void>}
+ */
+async function focusBoard(page) {
+  await page.click("#board");
+}
+
+/**
+ * Check whether the meta text contains a given substring.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+async function expectMetaContains(page, text) {
+  await expect(page.locator("#meta")).toContainText(text);
+}
+
+/**
+ * Check whether the status text contains a given substring.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+async function expectStatusContains(page, text) {
+  await expect(page.locator("#status")).toContainText(text);
+}
+
+module.exports = {
+  launchViewer,
+  getSelectedNodeLabel,
+  getSelectedNodeId,
+  getNodeText,
+  getNodeCount,
+  getSelectedCount,
+  getLinkCount,
+  getStatusText,
+  pressKey,
+  waitForRender,
+  focusBoard,
+  expectMetaContains,
+  expectStatusContains,
+};

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -1,0 +1,623 @@
+// @ts-check
+/**
+ * Keyboard shortcut integration tests for M3E viewer.
+ *
+ * These tests load a fixed JSON fixture into the viewer via Playwright,
+ * send keyboard events, and verify the resulting state through the #meta
+ * and #status DOM elements.
+ *
+ * Fixture: tests/fixtures/shortcut_test.json
+ *   Test Root
+ *     Child A
+ *       Grandchild A1
+ *       Grandchild A2
+ *     Child B
+ *     Child C
+ *       Grandchild C1
+ *
+ * Total: 7 nodes
+ */
+const { test, expect } = require("@playwright/test");
+const {
+  launchViewer,
+  getNodeCount,
+  getSelectedCount,
+  getLinkCount,
+  pressKey,
+  waitForRender,
+  focusBoard,
+  expectMetaContains,
+  expectStatusContains,
+} = require("../helpers/viewer_test_utils");
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Navigation: Arrow keys
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Arrow key navigation", () => {
+  test("ArrowDown moves selection to next sibling", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+    // Initial selection is root. ArrowRight to enter children.
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child C");
+  });
+
+  test("ArrowUp moves selection to previous sibling", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    // Move down to Child C, then back up.
+    await pressKey(page, "ArrowDown");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child C");
+
+    await pressKey(page, "ArrowUp");
+    await expectMetaContains(page, "selected: Child B");
+  });
+
+  test("ArrowRight selects first child", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+    // Root -> Child A
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    // Child A -> Grandchild A1
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Grandchild A1");
+  });
+
+  test("ArrowLeft selects parent", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Grandchild A1");
+
+    await pressKey(page, "ArrowLeft");
+    await expectMetaContains(page, "selected: Child A");
+
+    await pressKey(page, "ArrowLeft");
+    await expectMetaContains(page, "selected: Test Root");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Shift+Arrow: Selection extension
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Shift+Arrow selection extension", () => {
+  test("Shift+ArrowDown extends selection from root", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Start from root (mirrors existing viewer.visual.spec.js pattern).
+    await expectMetaContains(page, "selected: Test Root (1)");
+    const before = await getSelectedCount(page);
+
+    await pressKey(page, "Shift+ArrowDown");
+    const after = await getSelectedCount(page);
+    expect(after).toBeGreaterThan(before);
+  });
+
+  test("Shift+ArrowDown extends further on consecutive presses from root", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    await pressKey(page, "Shift+ArrowDown");
+    const afterOne = await getSelectedCount(page);
+    expect(afterOne).toBeGreaterThanOrEqual(2);
+
+    await pressKey(page, "Shift+ArrowDown");
+    const afterTwo = await getSelectedCount(page);
+    // Second press should keep or extend selection (layout-dependent).
+    expect(afterTwo).toBeGreaterThanOrEqual(afterOne);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Tab: Add child node
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Tab: add child node", () => {
+  test("Tab creates a child node and enters edit mode", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Select Child B (a leaf) first.
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    await pressKey(page, "Tab");
+    await waitForRender(page);
+
+    // An inline editor should appear (input element).
+    await expect(page.locator("textarea.inline-node-editor")).toBeVisible();
+
+    // Escape to finish editing.
+    await pressKey(page, "Escape");
+    await waitForRender(page);
+
+    const newCount = await getNodeCount(page);
+    expect(newCount).toBe(initialCount + 1);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Space: Toggle collapse/expand
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Space: collapse/expand toggle", () => {
+  test("Space collapses a node with children, then expands it", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Navigate to Child A (has 2 children).
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    const beforeCollapse = await getNodeCount(page);
+
+    // Collapse.
+    await pressKey(page, " ");
+    await waitForRender(page);
+
+    // After collapse the visible node count remains the same in #meta
+    // (it counts all nodes), but Grandchild A1/A2 should be hidden visually.
+    // We verify that ArrowRight no longer enters children when collapsed.
+    // Actually, let's verify the node is collapsed by checking meta or
+    // re-expanding.
+
+    // Expand again.
+    await pressKey(page, " ");
+    await waitForRender(page);
+
+    // Verify can navigate into children again.
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Grandchild A1");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Delete / Backspace: Remove node
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Delete and Backspace: remove node", () => {
+  test("Delete removes a leaf node", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Navigate to Child B (leaf).
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    await pressKey(page, "Delete");
+    await waitForRender(page);
+
+    const afterCount = await getNodeCount(page);
+    expect(afterCount).toBe(initialCount - 1);
+  });
+
+  test("Backspace removes a leaf node", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Navigate to Child B (leaf).
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    await pressKey(page, "Backspace");
+    await waitForRender(page);
+
+    const afterCount = await getNodeCount(page);
+    expect(afterCount).toBe(initialCount - 1);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+Z / Ctrl+Y: Undo / Redo
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Undo and Redo", () => {
+  test("Ctrl+Z undoes node addition, Ctrl+Y redoes it", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Add a child node via Tab (creates node + opens inline edit), then Escape.
+    await pressKey(page, "Tab");
+    await pressKey(page, "Escape");
+    await waitForRender(page);
+    await expectMetaContains(page, `nodes: ${initialCount + 1}`);
+
+    // Undo.
+    await pressKey(page, "Control+z");
+    await expectMetaContains(page, `nodes: ${initialCount}`);
+
+    // Redo with Ctrl+Y.
+    await pressKey(page, "Control+y");
+    await expectMetaContains(page, `nodes: ${initialCount + 1}`);
+  });
+
+  test("Ctrl+Shift+Z also redoes", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Add a child node via Tab, then Escape.
+    await pressKey(page, "Tab");
+    await pressKey(page, "Escape");
+    await waitForRender(page);
+
+    await pressKey(page, "Control+z");
+    await expectMetaContains(page, `nodes: ${initialCount}`);
+
+    await pressKey(page, "Control+Shift+z");
+    await expectMetaContains(page, `nodes: ${initialCount + 1}`);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+C / Ctrl+V: Copy / Paste
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Copy and Paste", () => {
+  test("Ctrl+C then Ctrl+V duplicates a node", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Navigate to Child B.
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    // Copy.
+    await pressKey(page, "Control+c");
+    await waitForRender(page);
+
+    // Paste (pastes as sibling or child depending on impl).
+    await pressKey(page, "Control+v");
+    await waitForRender(page);
+
+    const afterCount = await getNodeCount(page);
+    expect(afterCount).toBeGreaterThan(initialCount);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+X: Cut (with Escape to cancel)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Cut and cancel", () => {
+  test("Ctrl+X puts node in cut state, Escape cancels", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Navigate to Child B.
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    const initialCount = await getNodeCount(page);
+
+    // Cut.
+    await pressKey(page, "Control+x");
+    await waitForRender(page);
+
+    // Cancel with Escape.
+    await pressKey(page, "Escape");
+    await waitForRender(page);
+
+    // Node count should remain the same (cut was cancelled before paste).
+    const afterCount = await getNodeCount(page);
+    expect(afterCount).toBe(initialCount);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 1, 2, 3: ThinkingMode toggle
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("ThinkingMode toggle (1/2/3)", () => {
+  test("pressing 1 sets flash mode", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    await pressKey(page, "1");
+    await waitForRender(page);
+    await expectStatusContains(page, "Mode: Flash");
+  });
+
+  test("pressing 2 sets rapid mode (after switching away first)", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Default mode is rapid, so switch to flash first then back to rapid.
+    await pressKey(page, "1");
+    await waitForRender(page);
+    await expectStatusContains(page, "Mode: Flash");
+
+    await pressKey(page, "2");
+    await waitForRender(page);
+    await expectStatusContains(page, "Mode: Rapid");
+  });
+
+  test("pressing 3 sets deep mode", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    await pressKey(page, "3");
+    await waitForRender(page);
+    await expectStatusContains(page, "Mode: Deep");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// L -> Shift+L: GraphLink creation
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("GraphLink via L / Shift+L", () => {
+  test("L marks link source, Shift+L applies link", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Select Child A as link source.
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    await pressKey(page, "l");
+    await waitForRender(page);
+    await expectMetaContains(page, "link-source: Child A");
+
+    // Navigate to Child B as target.
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    // Apply link.
+    await pressKey(page, "Shift+l");
+    await waitForRender(page);
+
+    expect(await getLinkCount(page)).toBe(1);
+    await expectStatusContains(page, "Linked");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+] / Ctrl+[: Scope navigation
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Scope navigation", () => {
+  test("F converts node to folder, then ArrowRight enters and ArrowLeft exits scope", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Select Child A.
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    // Convert to folder.
+    await pressKey(page, "f");
+    await waitForRender(page);
+    await expectStatusContains(page, "Marked as folder scope");
+
+    // ArrowRight on a folder node enters its scope.
+    await pressKey(page, "ArrowRight");
+    await waitForRender(page);
+    await expectMetaContains(page, "scope: child-a");
+
+    // At scope root, ArrowLeft exits scope.
+    await pressKey(page, "ArrowLeft");
+    await waitForRender(page);
+    await expectMetaContains(page, "scope: root");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Enter / F2: Inline edit
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Inline editing (Enter / F2)", () => {
+  test("Enter opens inline editor", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Navigate to Child A.
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    await pressKey(page, "Enter");
+    await expect(page.locator("textarea.inline-node-editor")).toBeVisible();
+
+    await pressKey(page, "Escape");
+    await expect(page.locator("textarea.inline-node-editor")).not.toBeVisible();
+  });
+
+  test("F2 opens inline editor with text selected", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    await pressKey(page, "ArrowRight");
+    await expectMetaContains(page, "selected: Child A");
+
+    await pressKey(page, "F2");
+    await expect(page.locator("textarea.inline-node-editor")).toBeVisible();
+
+    await pressKey(page, "Escape");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+A: Select all
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Ctrl+A: select all visible", () => {
+  test("Ctrl+A selects all visible nodes in scope", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    await pressKey(page, "Control+a");
+    await waitForRender(page);
+
+    // All 7 nodes should be selected.
+    const count = await getSelectedCount(page);
+    expect(count).toBe(7);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Zoom: -, =, 0
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Zoom shortcuts (-, =, 0)", () => {
+  test("minus zooms out, equals zooms in, zero resets", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Zoom out.
+    await pressKey(page, "-");
+    await waitForRender(page);
+
+    // Zoom in.
+    await pressKey(page, "=");
+    await waitForRender(page);
+
+    // Reset zoom to 1.
+    await pressKey(page, "0");
+    await waitForRender(page);
+
+    // No crash means success. We verify the page is still functional.
+    await expectMetaContains(page, "nodes: 7");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+G: Group selected
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Ctrl+G: group selected", () => {
+  test("Ctrl+G groups multiple selected nodes under a new parent", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+
+    // Click Child A, then Ctrl+click Child B to multi-select.
+    const childA = page.locator("text.label-node", { hasText: "Child A" }).first();
+    const childB = page.locator("text.label-node", { hasText: "Child B" }).first();
+    await childA.click({ force: true });
+    await childB.click({ modifiers: ["Control"], force: true });
+
+    const selectedCount = await getSelectedCount(page);
+    expect(selectedCount).toBe(2);
+
+    // Group.
+    await pressKey(page, "Control+g");
+    await waitForRender(page);
+
+    // Grouping creates a new parent node, so count increases by 1.
+    const afterCount = await getNodeCount(page);
+    expect(afterCount).toBe(initialCount + 1);
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// M / Ctrl+M: Mark reparent source, then P to apply
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Reparent via M -> P", () => {
+  test("M marks reparent source, navigate to target, P reparents", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Select Child B as source.
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    // Mark as move source.
+    await pressKey(page, "m");
+    await waitForRender(page);
+    await expectMetaContains(page, "move-node: 1 selected");
+
+    // Navigate to Child C as target.
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child C");
+
+    // Apply reparent.
+    await pressKey(page, "p");
+    await waitForRender(page);
+
+    await expectStatusContains(page, "Moved");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// I: Toggle meta panel
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("I: toggle meta panel", () => {
+  test("I toggles meta panel visibility", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Press I to toggle.
+    await pressKey(page, "i");
+    await waitForRender(page);
+
+    // Press I again to toggle back.
+    await pressKey(page, "i");
+    await waitForRender(page);
+
+    // Viewer should still be functional.
+    await expectMetaContains(page, "nodes: 7");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Ctrl+S: Download JSON (smoke test)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+test.describe("Ctrl+S: download JSON", () => {
+  test("Ctrl+S triggers download without error", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    // Set up download listener.
+    const downloadPromise = page.waitForEvent("download", { timeout: 3000 }).catch(() => null);
+
+    await pressKey(page, "Control+s");
+    await waitForRender(page);
+
+    const download = await downloadPromise;
+    // Download may or may not fire depending on browser config,
+    // but the page should not crash.
+    if (download) {
+      expect(download.suggestedFilename()).toMatch(/\.json$/);
+    }
+
+    // Viewer still functional.
+    await expectMetaContains(page, "nodes: 7");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 27 Playwright integration tests covering all major keyboard shortcuts in the M3E viewer (arrow navigation, Tab, Space, Delete, Ctrl+Z/Y, Ctrl+C/V/X, ThinkingMode 1/2/3, GraphLink L/Shift+L, scope via F+ArrowRight, Enter/F2 inline edit, Ctrl+A, zoom -/=/0, Ctrl+G group, M+P reparent, I toggle, Ctrl+S download)
- Create shared test helpers (`beta/tests/helpers/viewer_test_utils.js`) with `launchViewer`, `getNodeCount`, `getSelectedCount`, `pressKey`, `expectMetaContains`, etc.
- Add fixed test fixture (`beta/tests/fixtures/shortcut_test.json`) with 7-node tree for deterministic testing
- Add `test:shortcuts` npm script for targeted shortcut test runs

## Test plan
- [x] All 27 shortcut tests pass locally (`npx playwright test tests/visual/shortcuts.spec.js` -- 27 passed, 32.5s)
- [x] All 45 existing unit tests still pass (`npm run test:unit`)
- [x] TypeScript compilation clean (`npx tsc -p tsconfig.node.json --noEmit`)
- [ ] CI: Run `npm ci && npx playwright install chromium && npm run test:shortcuts`

## Notes
- Discovered a likely bug: `Alt+Enter` is intercepted by the bare `Enter` handler (line 4719 in viewer.ts) before the `Alt+Enter` handler (line 4825) can fire, because the bare handler doesn't check `!event.altKey`. Separate fix needed.
- Existing visual tests in `viewer.visual.spec.js` reference stale `#fit-all` button that no longer exists in viewer.html

Generated with [Claude Code](https://claude.com/claude-code)