### PR TITLE
data: abstract Cloud Sync transport layer

### DIFF
--- a/beta/src/node/cloud_sync.ts
+++ b/beta/src/node/cloud_sync.ts
@@ -1,3 +1,20 @@
+import fs from "fs";
+import path from "path";
+import type {
+  AppState,
+  CloudSyncConfig,
+  CloudSyncTransport,
+  CloudTransportKind,
+  PullResult,
+  PushResult,
+  SavedDoc,
+  SyncStatus,
+} from "../shared/types";
+
+// ---------------------------------------------------------------------------
+// Conflict detection (unchanged public API)
+// ---------------------------------------------------------------------------
+
 export function detectCloudConflict(
   existingCloudSavedAt: string | null,
   baseSavedAt: string | null,
@@ -10,4 +27,214 @@ export function detectCloudConflict(
     return false;
   }
   return existingCloudSavedAt !== baseSavedAt;
+}
+
+// ---------------------------------------------------------------------------
+// FileTransport — file-mirror implementation
+// ---------------------------------------------------------------------------
+
+function sanitizeDocId(docId: string): string {
+  return docId.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+export class FileTransport implements CloudSyncTransport {
+  readonly kind: CloudTransportKind = "file";
+  private readonly cloudDir: string;
+
+  constructor(cloudDir: string) {
+    this.cloudDir = cloudDir;
+  }
+
+  private docPath(docId: string): string {
+    return path.join(this.cloudDir, `${sanitizeDocId(docId)}.json`);
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.cloudDir)) {
+      fs.mkdirSync(this.cloudDir, { recursive: true });
+    }
+  }
+
+  private readCloudDoc(filePath: string): SavedDoc | null {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as SavedDoc;
+    if (!parsed || parsed.version !== 1 || !parsed.state) {
+      return null;
+    }
+    return parsed;
+  }
+
+  async push(
+    docId: string,
+    savedDoc: SavedDoc,
+    options?: { baseSavedAt?: string | null; force?: boolean },
+  ): Promise<PushResult> {
+    this.ensureDir();
+    const filePath = this.docPath(docId);
+    const existingDoc = this.readCloudDoc(filePath);
+    const baseSavedAt = options?.baseSavedAt ?? null;
+    const forcePush = Boolean(options?.force);
+
+    if (detectCloudConflict(existingDoc?.savedAt ?? null, baseSavedAt, forcePush)) {
+      return {
+        ok: false,
+        savedAt: savedDoc.savedAt,
+        forced: false,
+        error: "Cloud conflict detected.",
+        code: "CLOUD_CONFLICT",
+        cloudSavedAt: existingDoc?.savedAt ?? null,
+        baseSavedAt,
+      };
+    }
+
+    fs.writeFileSync(filePath, JSON.stringify(savedDoc, null, 2), "utf8");
+    return {
+      ok: true,
+      savedAt: savedDoc.savedAt,
+      forced: forcePush,
+    };
+  }
+
+  async pull(docId: string): Promise<PullResult> {
+    this.ensureDir();
+    const filePath = this.docPath(docId);
+
+    if (!fs.existsSync(filePath)) {
+      return {
+        ok: false,
+        version: 1,
+        savedAt: "",
+        state: { rootId: "", nodes: {} },
+        error: "Cloud document not found.",
+        code: "SYNC_CLOUD_NOT_FOUND",
+      };
+    }
+
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as { version?: number; state?: AppState; savedAt?: string };
+    if (!parsed || parsed.version !== 1 || !parsed.state) {
+      return {
+        ok: false,
+        version: 1,
+        savedAt: "",
+        state: { rootId: "", nodes: {} },
+        error: "Cloud document has unsupported format.",
+        code: "SYNC_CLOUD_UNSUPPORTED_FORMAT",
+      };
+    }
+
+    return {
+      ok: true,
+      version: 1,
+      savedAt: parsed.savedAt || fs.statSync(filePath).mtime.toISOString(),
+      state: parsed.state,
+    };
+  }
+
+  async status(docId: string): Promise<SyncStatus> {
+    this.ensureDir();
+    const filePath = this.docPath(docId);
+    const exists = fs.existsSync(filePath);
+    const cloudDoc = exists ? this.readCloudDoc(filePath) : null;
+
+    return {
+      ok: true,
+      enabled: true,
+      mode: "file",
+      documentId: docId,
+      exists,
+      cloudSavedAt: cloudDoc?.savedAt ?? null,
+      lastSyncedAt: exists ? fs.statSync(filePath).mtime.toISOString() : null,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HttpTransport — stub for future HTTP/REST remote sync
+// ---------------------------------------------------------------------------
+
+export class HttpTransport implements CloudSyncTransport {
+  readonly kind: CloudTransportKind = "http";
+  private readonly endpoint: string;
+
+  constructor(endpoint: string) {
+    this.endpoint = endpoint;
+  }
+
+  async push(_docId: string, _savedDoc: SavedDoc, _options?: { baseSavedAt?: string | null; force?: boolean }): Promise<PushResult> {
+    throw new Error("HttpTransport.push is not implemented. Endpoint: " + this.endpoint);
+  }
+
+  async pull(_docId: string): Promise<PullResult> {
+    throw new Error("HttpTransport.pull is not implemented. Endpoint: " + this.endpoint);
+  }
+
+  async status(_docId: string): Promise<SyncStatus> {
+    throw new Error("HttpTransport.status is not implemented. Endpoint: " + this.endpoint);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SupabaseTransport — stub for future Supabase remote sync
+// ---------------------------------------------------------------------------
+
+export class SupabaseTransport implements CloudSyncTransport {
+  readonly kind: CloudTransportKind = "supabase";
+  private readonly endpoint: string;
+
+  constructor(endpoint: string) {
+    this.endpoint = endpoint;
+  }
+
+  async push(_docId: string, _savedDoc: SavedDoc, _options?: { baseSavedAt?: string | null; force?: boolean }): Promise<PushResult> {
+    throw new Error("SupabaseTransport.push is not implemented. Endpoint: " + this.endpoint);
+  }
+
+  async pull(_docId: string): Promise<PullResult> {
+    throw new Error("SupabaseTransport.pull is not implemented. Endpoint: " + this.endpoint);
+  }
+
+  async status(_docId: string): Promise<SyncStatus> {
+    throw new Error("SupabaseTransport.status is not implemented. Endpoint: " + this.endpoint);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory and config
+// ---------------------------------------------------------------------------
+
+export function loadCloudSyncConfig(): CloudSyncConfig {
+  const enabled = process.env.M3E_CLOUD_SYNC === "1";
+  const transport = (process.env.M3E_CLOUD_TRANSPORT as CloudTransportKind) || "file";
+  const cloudDir = process.env.M3E_CLOUD_DIR
+    ? path.resolve(process.env.M3E_CLOUD_DIR)
+    : "";
+  const endpoint = process.env.M3E_CLOUD_ENDPOINT || null;
+
+  return { enabled, transport, cloudDir, endpoint };
+}
+
+export function createTransport(config: CloudSyncConfig): CloudSyncTransport {
+  switch (config.transport) {
+    case "http":
+      if (!config.endpoint) {
+        throw new Error("M3E_CLOUD_ENDPOINT is required for http transport.");
+      }
+      return new HttpTransport(config.endpoint);
+
+    case "supabase":
+      if (!config.endpoint) {
+        throw new Error("M3E_CLOUD_ENDPOINT is required for supabase transport.");
+      }
+      return new SupabaseTransport(config.endpoint);
+
+    case "file":
+    default:
+      if (!config.cloudDir) {
+        throw new Error("M3E_CLOUD_DIR is required for file transport.");
+      }
+      return new FileTransport(config.cloudDir);
+  }
 }

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -5,7 +5,8 @@ import path from "path";
 import http from "http";
 import { spawnSync, exec } from "child_process";
 import { RapidMvpModel } from "./rapid_mvp";
-import { detectCloudConflict } from "./cloud_sync";
+import { detectCloudConflict, FileTransport, loadCloudSyncConfig, createTransport } from "./cloud_sync";
+import type { CloudSyncTransport } from "../shared/types";
 import { getAiStatus, runAiSubagent } from "./ai_subagent";
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
 import {
@@ -39,10 +40,19 @@ const DB_FILE = process.env.M3E_DB_FILE || DEFAULT_DB_FILE;
 const SQLITE_DB_PATH = path.join(DATA_DIR, DB_FILE);
 const FIRST_RUN_MARKER = path.join(DATA_DIR, ".m3e-launched");
 const TUTORIAL_SCOPE_ID = "n_1775650869381_rns0cp";
-const CLOUD_SYNC_ENABLED = process.env.M3E_CLOUD_SYNC === "1";
-const CLOUD_SYNC_DIR = process.env.M3E_CLOUD_DIR
-  ? path.resolve(process.env.M3E_CLOUD_DIR)
-  : path.join(DATA_DIR, "cloud-sync");
+const cloudSyncConfig = loadCloudSyncConfig();
+// Backward compat: if cloudDir is empty, default to DATA_DIR/cloud-sync for file transport
+if (cloudSyncConfig.transport === "file" && !cloudSyncConfig.cloudDir) {
+  cloudSyncConfig.cloudDir = path.join(DATA_DIR, "cloud-sync");
+}
+const CLOUD_SYNC_ENABLED = cloudSyncConfig.enabled;
+let cloudTransport: CloudSyncTransport | null = null;
+function getCloudTransport(): CloudSyncTransport {
+  if (!cloudTransport) {
+    cloudTransport = createTransport(cloudSyncConfig);
+  }
+  return cloudTransport;
+}
 
 const MIME_BY_EXT: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -172,30 +182,7 @@ function isAiStatusRoute(urlPath: string): boolean {
   return pathname === "/api/ai/status";
 }
 
-function cloudDocPath(docId: string): string {
-  const safeId = docId.replace(/[^a-zA-Z0-9._-]/g, "_");
-  return path.join(CLOUD_SYNC_DIR, `${safeId}.json`);
-}
-
-function ensureCloudSyncDir(): void {
-  if (!CLOUD_SYNC_ENABLED) {
-    return;
-  }
-  if (!fs.existsSync(CLOUD_SYNC_DIR)) {
-    fs.mkdirSync(CLOUD_SYNC_DIR, { recursive: true });
-  }
-}
-
-function readCloudDoc(filePath: string): SavedDoc | null {
-  if (!fs.existsSync(filePath)) {
-    return null;
-  }
-  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as SavedDoc;
-  if (!parsed || parsed.version !== 1 || !parsed.state) {
-    return null;
-  }
-  return parsed;
-}
+// Cloud sync helpers removed — now handled by CloudSyncTransport implementations
 
 function readRequestBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -293,38 +280,31 @@ async function handleSyncApi(
     return true;
   }
 
-  ensureCloudSyncDir();
-  const filePath = cloudDocPath(route.docId);
+  const transport = getCloudTransport();
+  // Map transport kind to legacy mode string for backward compatibility
+  const modeLabel = transport.kind === "file" ? "file-mirror" : transport.kind;
 
   if (route.action === "status" && req.method === "GET") {
-    const exists = fs.existsSync(filePath);
-    const cloudDoc = exists ? readCloudDoc(filePath) : null;
+    const result = await transport.status(route.docId);
     sendJson(res, 200, {
-      ok: true,
-      enabled: true,
-      mode: "file-mirror",
-      documentId: route.docId,
-      exists,
-      cloudSavedAt: cloudDoc?.savedAt ?? null,
-      lastSyncedAt: exists ? fs.statSync(filePath).mtime.toISOString() : null,
+      ...result,
+      mode: modeLabel,
     });
     return true;
   }
 
   if (route.action === "pull" && req.method === "POST") {
-    if (!fs.existsSync(filePath)) {
-      sendSyncError(res, 404, "SYNC_CLOUD_NOT_FOUND", "Cloud document not found.", route.docId);
-      return true;
-    }
-
     try {
-      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as { version?: number; state?: AppState; savedAt?: string };
-      if (!parsed || parsed.version !== 1 || !parsed.state) {
-        sendSyncError(res, 400, "SYNC_CLOUD_UNSUPPORTED_FORMAT", "Cloud document has unsupported format.", route.docId);
+      const result = await transport.pull(route.docId);
+      if (!result.ok) {
+        const statusCode = result.code === "SYNC_CLOUD_NOT_FOUND" ? 404
+          : result.code === "SYNC_CLOUD_UNSUPPORTED_FORMAT" ? 400
+          : 500;
+        sendSyncError(res, statusCode, result.code || "SYNC_PULL_FAILED", result.error || "Cloud pull failed.", route.docId);
         return true;
       }
 
-      const model = RapidMvpModel.fromJSON(parsed.state);
+      const model = RapidMvpModel.fromJSON(result.state);
       const errors = model.validate();
       if (errors.length > 0) {
         sendSyncError(
@@ -339,9 +319,9 @@ async function handleSyncApi(
 
       sendJson(res, 200, {
         ok: true,
-        mode: "file-mirror",
+        mode: modeLabel,
         version: 1,
-        savedAt: parsed.savedAt || fs.statSync(filePath).mtime.toISOString(),
+        savedAt: result.savedAt,
         state: model.toJSON(),
         documentId: route.docId,
       });
@@ -368,17 +348,6 @@ async function handleSyncApi(
         return true;
       }
 
-      const existingCloudDoc = readCloudDoc(filePath);
-      const baseSavedAt = parsed.baseSavedAt ?? null;
-      const forcePush = Boolean(parsed.force);
-      if (detectCloudConflict(existingCloudDoc?.savedAt ?? null, baseSavedAt, forcePush)) {
-        sendSyncError(res, 409, "CLOUD_CONFLICT", "Cloud conflict detected.", route.docId, {
-          cloudSavedAt: existingCloudDoc?.savedAt ?? null,
-          baseSavedAt,
-        });
-        return true;
-      }
-
       const model = RapidMvpModel.fromJSON(candidate.state as never);
       const errors = model.validate();
       if (errors.length > 0) {
@@ -397,13 +366,26 @@ async function handleSyncApi(
         savedAt: String(candidate.savedAt || new Date().toISOString()),
         state: model.toJSON(),
       };
-      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf8");
+      const result = await transport.push(route.docId, payload, {
+        baseSavedAt: parsed.baseSavedAt ?? null,
+        force: Boolean(parsed.force),
+      });
+
+      if (!result.ok) {
+        const statusCode = result.code === "CLOUD_CONFLICT" ? 409 : 500;
+        sendSyncError(res, statusCode, result.code || "SYNC_PUSH_FAILED", result.error || "Cloud push failed.", route.docId, {
+          ...(result.cloudSavedAt !== undefined ? { cloudSavedAt: result.cloudSavedAt } : {}),
+          ...(result.baseSavedAt !== undefined ? { baseSavedAt: result.baseSavedAt } : {}),
+        });
+        return true;
+      }
+
       sendJson(res, 200, {
         ok: true,
-        mode: "file-mirror",
-        savedAt: payload.savedAt,
+        mode: modeLabel,
+        savedAt: result.savedAt,
         documentId: route.docId,
-        forced: forcePush,
+        forced: result.forced,
       });
       return true;
     } catch (err) {

--- a/beta/src/shared/types.ts
+++ b/beta/src/shared/types.ts
@@ -106,6 +106,59 @@ export interface AiStatusResponse {
   features: Record<string, AiFeatureStatus>;
 }
 
+// ---------------------------------------------------------------------------
+// Cloud Sync Transport
+// ---------------------------------------------------------------------------
+
+export type CloudTransportKind = "file" | "http" | "supabase";
+
+export interface PushResult {
+  ok: boolean;
+  savedAt: string;
+  forced: boolean;
+  error?: string;
+  code?: string;
+  cloudSavedAt?: string | null;
+  baseSavedAt?: string | null;
+}
+
+export interface PullResult {
+  ok: boolean;
+  version: 1;
+  savedAt: string;
+  state: AppState;
+  error?: string;
+  code?: string;
+}
+
+export interface SyncStatus {
+  ok: boolean;
+  enabled: boolean;
+  mode: CloudTransportKind;
+  documentId: string;
+  exists: boolean;
+  cloudSavedAt: string | null;
+  lastSyncedAt: string | null;
+}
+
+export interface CloudSyncTransport {
+  readonly kind: CloudTransportKind;
+  push(docId: string, savedDoc: SavedDoc, options?: { baseSavedAt?: string | null; force?: boolean }): Promise<PushResult>;
+  pull(docId: string): Promise<PullResult>;
+  status(docId: string): Promise<SyncStatus>;
+}
+
+export interface CloudSyncConfig {
+  enabled: boolean;
+  transport: CloudTransportKind;
+  cloudDir: string;
+  endpoint: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// AI Subagent
+// ---------------------------------------------------------------------------
+
 export interface AiSubagentRequest {
   documentId: string;
   scopeId: string;

--- a/beta/tests/unit/cloud_sync_transport.test.js
+++ b/beta/tests/unit/cloud_sync_transport.test.js
@@ -1,0 +1,225 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { FileTransport, HttpTransport, SupabaseTransport, createTransport, loadCloudSyncConfig, detectCloudConflict } = require("../../dist/node/cloud_sync.js");
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+function createSavedDoc(label, savedAt) {
+  const model = new RapidMvpModel("Root");
+  model.addNode(model.state.rootId, label || "child");
+  return {
+    version: 1,
+    savedAt: savedAt || new Date().toISOString(),
+    state: model.toJSON(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FileTransport unit tests
+// ---------------------------------------------------------------------------
+
+test("FileTransport: push and pull round-trip", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const doc = createSavedDoc("A", "2026-04-09T00:00:00.000Z");
+
+    const pushResult = await transport.push("doc1", doc);
+    assert.equal(pushResult.ok, true);
+    assert.equal(pushResult.savedAt, "2026-04-09T00:00:00.000Z");
+    assert.equal(pushResult.forced, false);
+
+    const pullResult = await transport.pull("doc1");
+    assert.equal(pullResult.ok, true);
+    assert.equal(pullResult.version, 1);
+    assert.equal(pullResult.savedAt, "2026-04-09T00:00:00.000Z");
+    assert.ok(pullResult.state.rootId);
+    assert.ok(Object.keys(pullResult.state.nodes).length > 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: status returns exists=false for missing doc", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const result = await transport.status("nonexistent");
+    assert.equal(result.ok, true);
+    assert.equal(result.enabled, true);
+    assert.equal(result.mode, "file");
+    assert.equal(result.documentId, "nonexistent");
+    assert.equal(result.exists, false);
+    assert.equal(result.cloudSavedAt, null);
+    assert.equal(result.lastSyncedAt, null);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: status returns exists=true after push", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const doc = createSavedDoc("B", "2026-04-09T01:00:00.000Z");
+    await transport.push("doc2", doc);
+
+    const result = await transport.status("doc2");
+    assert.equal(result.ok, true);
+    assert.equal(result.exists, true);
+    assert.equal(result.cloudSavedAt, "2026-04-09T01:00:00.000Z");
+    assert.ok(result.lastSyncedAt);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: push detects conflict", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const doc1 = createSavedDoc("V1", "2026-04-09T00:00:00.000Z");
+    await transport.push("doc3", doc1);
+
+    // Update the doc
+    const doc2 = createSavedDoc("V2", "2026-04-09T00:00:10.000Z");
+    await transport.push("doc3", doc2, { baseSavedAt: "2026-04-09T00:00:00.000Z" });
+
+    // Conflict: stale baseSavedAt
+    const doc3 = createSavedDoc("V3", "2026-04-09T00:00:20.000Z");
+    const result = await transport.push("doc3", doc3, { baseSavedAt: "2026-04-09T00:00:00.000Z" });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "CLOUD_CONFLICT");
+    assert.equal(result.cloudSavedAt, "2026-04-09T00:00:10.000Z");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: force push overrides conflict", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const doc1 = createSavedDoc("V1", "2026-04-09T00:00:00.000Z");
+    await transport.push("doc4", doc1);
+
+    const doc2 = createSavedDoc("V2", "2026-04-09T00:00:10.000Z");
+    await transport.push("doc4", doc2, { baseSavedAt: "2026-04-09T00:00:00.000Z" });
+
+    // Force push with stale baseSavedAt
+    const doc3 = createSavedDoc("Forced", "2026-04-09T00:00:30.000Z");
+    const result = await transport.push("doc4", doc3, { baseSavedAt: "2026-04-09T00:00:00.000Z", force: true });
+    assert.equal(result.ok, true);
+    assert.equal(result.forced, true);
+
+    // Verify forced doc is what we get back
+    const pulled = await transport.pull("doc4");
+    assert.equal(pulled.ok, true);
+    assert.equal(pulled.savedAt, "2026-04-09T00:00:30.000Z");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: pull returns error for missing doc", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const result = await transport.pull("missing");
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "SYNC_CLOUD_NOT_FOUND");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: pull returns error for unsupported format", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const filePath = path.join(dir, "bad-format.json");
+    fs.writeFileSync(filePath, JSON.stringify({ version: 99, state: {} }), "utf8");
+
+    const result = await transport.pull("bad-format");
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "SYNC_CLOUD_UNSUPPORTED_FORMAT");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: creates cloud dir if it does not exist", async () => {
+  const dir = path.join(os.tmpdir(), `m3e-ft-nested-${Date.now()}`);
+  const nested = path.join(dir, "sub", "deep");
+  try {
+    assert.equal(fs.existsSync(nested), false);
+    const transport = new FileTransport(nested);
+    await transport.status("probe");
+    assert.equal(fs.existsSync(nested), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Stub transport tests
+// ---------------------------------------------------------------------------
+
+test("HttpTransport: methods throw not-implemented", async () => {
+  const transport = new HttpTransport("https://example.com/sync");
+  await assert.rejects(() => transport.push("x", createSavedDoc()), /not implemented/);
+  await assert.rejects(() => transport.pull("x"), /not implemented/);
+  await assert.rejects(() => transport.status("x"), /not implemented/);
+});
+
+test("SupabaseTransport: methods throw not-implemented", async () => {
+  const transport = new SupabaseTransport("https://example.supabase.co");
+  await assert.rejects(() => transport.push("x", createSavedDoc()), /not implemented/);
+  await assert.rejects(() => transport.pull("x"), /not implemented/);
+  await assert.rejects(() => transport.status("x"), /not implemented/);
+});
+
+// ---------------------------------------------------------------------------
+// createTransport factory tests
+// ---------------------------------------------------------------------------
+
+test("createTransport returns FileTransport for file config", () => {
+  const transport = createTransport({ enabled: true, transport: "file", cloudDir: "/tmp/test", endpoint: null });
+  assert.equal(transport.kind, "file");
+  assert.ok(transport instanceof FileTransport);
+});
+
+test("createTransport returns HttpTransport for http config", () => {
+  const transport = createTransport({ enabled: true, transport: "http", cloudDir: "", endpoint: "https://example.com" });
+  assert.equal(transport.kind, "http");
+  assert.ok(transport instanceof HttpTransport);
+});
+
+test("createTransport returns SupabaseTransport for supabase config", () => {
+  const transport = createTransport({ enabled: true, transport: "supabase", cloudDir: "", endpoint: "https://example.supabase.co" });
+  assert.equal(transport.kind, "supabase");
+  assert.ok(transport instanceof SupabaseTransport);
+});
+
+test("createTransport throws when http transport has no endpoint", () => {
+  assert.throws(() => createTransport({ enabled: true, transport: "http", cloudDir: "", endpoint: null }), /M3E_CLOUD_ENDPOINT is required/);
+});
+
+test("createTransport throws when file transport has no cloudDir", () => {
+  assert.throws(() => createTransport({ enabled: true, transport: "file", cloudDir: "", endpoint: null }), /M3E_CLOUD_DIR is required/);
+});
+
+// ---------------------------------------------------------------------------
+// detectCloudConflict backward compat
+// ---------------------------------------------------------------------------
+
+test("detectCloudConflict still works after refactor", () => {
+  assert.equal(detectCloudConflict("a", "b", false), true);
+  assert.equal(detectCloudConflict("a", "a", false), false);
+  assert.equal(detectCloudConflict("a", "b", true), false);
+  assert.equal(detectCloudConflict(null, "b", false), false);
+  assert.equal(detectCloudConflict("a", null, false), false);
+});

--- a/scripts/beta/launch-full.bat
+++ b/scripts/beta/launch-full.bat
@@ -1,0 +1,50 @@
+@echo off
+setlocal
+
+REM M3E Beta full launch: Cloud Sync + Collab + AI all enabled.
+REM Requires AI API key set via launch-with-ai.bat or env vars.
+
+cd /d "%~dp0\..\.."
+
+set "M3E_DATA_DIR=%CD%\beta\data"
+if not exist "%M3E_DATA_DIR%" mkdir "%M3E_DATA_DIR%"
+
+REM --- Cloud Sync ---
+set "M3E_CLOUD_SYNC=1"
+if "%M3E_CLOUD_DIR%"=="" set "M3E_CLOUD_DIR=%M3E_DATA_DIR%\cloud-sync"
+if "%M3E_CLOUD_TRANSPORT%"=="" set "M3E_CLOUD_TRANSPORT=file"
+
+REM --- Collab ---
+set "M3E_COLLAB=1"
+
+REM --- AI (must be configured externally or via env vars) ---
+if "%M3E_AI_ENABLED%"=="" set "M3E_AI_ENABLED=1"
+
+call :kill_port_4173
+
+echo Launching M3E Beta (full mode: Cloud Sync + Collab + AI)
+echo   Cloud Sync: %M3E_CLOUD_TRANSPORT% (%M3E_CLOUD_DIR%)
+echo   Collab:     enabled
+echo   AI:         %M3E_AI_PROVIDER% / %M3E_AI_MODEL%
+echo.
+
+call npm --prefix beta start
+if errorlevel 1 goto :error
+
+exit /b 0
+
+:kill_port_4173
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr :4173 ^| findstr LISTENING') do (
+  if not "%%P"=="0" (
+    echo Stopping existing process on port 4173 ^(PID %%P^)...
+    taskkill /PID %%P /F >nul 2>&1
+  )
+)
+exit /b 0
+
+:error
+echo.
+echo [ERROR] Launch failed. Check beta build and try again.
+echo   Use scripts\beta\update-and-launch.bat after dependency updates.
+pause
+exit /b 1

--- a/scripts/beta/launch-full.sh
+++ b/scripts/beta/launch-full.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PORT=4173
+URL="http://localhost:${PORT}/viewer.html"
+
+export M3E_DATA_DIR="$ROOT_DIR/beta/data"
+mkdir -p "$M3E_DATA_DIR"
+
+# --- Cloud Sync ---
+export M3E_CLOUD_SYNC=1
+export M3E_CLOUD_TRANSPORT="${M3E_CLOUD_TRANSPORT:-file}"
+export M3E_CLOUD_DIR="${M3E_CLOUD_DIR:-$M3E_DATA_DIR/cloud-sync}"
+
+# --- Collab ---
+export M3E_COLLAB=1
+
+# --- AI (must be configured externally or via env vars) ---
+export M3E_AI_ENABLED="${M3E_AI_ENABLED:-1}"
+
+kill_port() {
+  local pids
+  pids="$(lsof -ti tcp:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    echo "Stopping existing process on port ${PORT}: ${pids}"
+    kill $pids 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+cleanup() {
+  if [[ -n "${APP_PID:-}" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+    kill "$APP_PID" 2>/dev/null || true
+    wait "$APP_PID" 2>/dev/null || true
+  fi
+}
+
+wait_for_server() {
+  local attempt
+  for attempt in {1..50}; do
+    if curl -fsS "http://localhost:${PORT}/" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
+
+kill_port
+
+trap cleanup INT TERM EXIT
+
+echo "Launching M3E Beta (full mode: Cloud Sync + Collab + AI)"
+echo "  Cloud Sync: ${M3E_CLOUD_TRANSPORT} (${M3E_CLOUD_DIR})"
+echo "  Collab:     enabled"
+echo "  AI:         ${M3E_AI_PROVIDER:-not set} / ${M3E_AI_MODEL:-not set}"
+echo ""
+
+cd "$ROOT_DIR"
+npm --prefix beta start &
+APP_PID=$!
+
+if wait_for_server; then
+  if command -v open &>/dev/null; then
+    open "$URL"
+  elif command -v xdg-open &>/dev/null; then
+    xdg-open "$URL"
+  else
+    echo "Open ${URL} in your browser."
+  fi
+else
+  echo "[WARN] Server did not become ready in time. Open ${URL} manually."
+fi
+
+wait "$APP_PID"


### PR DESCRIPTION
## Summary
- Extract `CloudSyncTransport` interface (`push`/`pull`/`status`) in `beta/src/shared/types.ts`
- Implement `FileTransport` (refactored file-mirror), `HttpTransport` stub, `SupabaseTransport` stub in `beta/src/node/cloud_sync.ts`
- Refactor `start_viewer.ts` sync endpoints to use transport abstraction (backward-compatible API responses)
- Add env var support: `M3E_CLOUD_TRANSPORT` (file/http/supabase), `M3E_CLOUD_ENDPOINT`
- Add `scripts/beta/launch-full.bat` and `launch-full.sh` (Cloud Sync + Collab + AI)
- Add 16 new unit tests for FileTransport, stub transports, and factory

## Test plan
- [x] All 61 existing unit tests pass (0 failures)
- [x] 16 new `cloud_sync_transport.test.js` tests pass
- [x] Existing `cloud_sync_api_integration.test.js` (6 tests) confirms API backward compat
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [ ] Manual: verify `launch-full.bat` starts with all features enabled

Generated with [Claude Code](https://claude.com/claude-code)