### PR TITLE
visual: add read-only mode and URL share

### DIFF
--- a/beta/src/browser/viewer.globals.d.ts
+++ b/beta/src/browser/viewer.globals.d.ts
@@ -237,4 +237,5 @@ interface ViewState {
   reparentSourceIds: Set<string>;
   dragState: DragState | null;
   collapsedIds: Set<string>;
+  readOnly: boolean;
 }

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -32,6 +32,8 @@ const linearMetaEl = document.getElementById("linear-meta") as HTMLElement | nul
 const linearApplyBtn = document.getElementById("linear-apply") as HTMLButtonElement | null;
 const linearResetBtn = document.getElementById("linear-reset") as HTMLButtonElement | null;
 const cheatsheetEl = document.getElementById("shortcut-cheatsheet") as HTMLElement | null;
+const readonlyBannerEl = document.getElementById("readonly-banner") as HTMLElement | null;
+const shareBtnEl = document.getElementById("share-btn") as HTMLButtonElement | null;
 const cloudSyncBadgeEl = document.getElementById("cloud-sync-badge") as HTMLElement;
 const cloudPullBtn = document.getElementById("cloud-pull") as HTMLButtonElement;
 const cloudPushBtn = document.getElementById("cloud-push") as HTMLButtonElement;
@@ -49,6 +51,8 @@ function normalizeDocId(raw: string | null, fallback: string): string {
 const queryParams = new URLSearchParams(window.location.search);
 const LOCAL_DOC_ID = normalizeDocId(queryParams.get("localDocId"), "rapid-main");
 const CLOUD_DOC_ID = normalizeDocId(queryParams.get("cloudDocId"), LOCAL_DOC_ID);
+const CLOUD_DOC_REQUESTED = queryParams.has("cloudDocId");
+const READONLY_REQUESTED = queryParams.get("readonly") === "1";
 const AUTOSAVE_DELAY_MS = 700;
 const MAX_UNDO_STEPS = 200;
 const TAB_ID = crypto.randomUUID();
@@ -137,6 +141,7 @@ let viewState: ViewState = {
   reparentSourceIds: new Set<string>(),
   dragState: null,
   collapsedIds: new Set<string>(),
+  readOnly: false,
 };
 applyLinearTextFontScale(false);
 syncLinearAdjustMenuUi();
@@ -223,6 +228,45 @@ function updateCloudSyncUi(): void {
   if (cloudPushBtn) cloudPushBtn.disabled = false;
   if (cloudUseLocalBtn) cloudUseLocalBtn.hidden = !cloudConflictPending;
   if (cloudUseCloudBtn) cloudUseCloudBtn.hidden = !cloudConflictPending;
+}
+
+function isReadOnly(): boolean {
+  return viewState.readOnly;
+}
+
+function applyReadOnlyMode(): void {
+  const ro = isReadOnly();
+
+  // Show/hide read-only banner
+  if (readonlyBannerEl) {
+    readonlyBannerEl.hidden = !ro;
+  }
+
+  // Disable linear text editing in read-only mode
+  if (linearTextEl) {
+    linearTextEl.readOnly = ro;
+  }
+
+  // Hide editing toolbar items in read-only mode
+  const editToolbarItems = document.querySelectorAll("[data-edit-only]");
+  editToolbarItems.forEach((el) => {
+    (el as HTMLElement).hidden = ro;
+  });
+
+  // Show share button only in non-read-only mode (editors can share)
+  // Share button is always visible so readers can also re-share
+}
+
+function handleShareClick(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set("cloudDocId", CLOUD_DOC_ID);
+  url.searchParams.set("readonly", "1");
+  // Remove localDocId if present -- shared URL uses cloudDocId
+  url.searchParams.delete("localDocId");
+  navigator.clipboard.writeText(url.toString()).then(
+    () => setStatus("Link copied!"),
+    () => setStatus("Failed to copy link.", true),
+  );
 }
 
 function createNodeRecord(id: string, parentId: string | null, text = "New Node"): TreeNode {
@@ -3499,16 +3543,35 @@ async function initializeDocument(): Promise<void> {
   await fetchLinearTransformStatus();
   await fetchCloudSyncStatus();
 
+  // When cloudDocId is specified in URL, pull from cloud
+  if (CLOUD_DOC_REQUESTED) {
+    const loadedFromCloud = await pullDocFromCloud(true);
+    if (loadedFromCloud) {
+      // Cloud docs default to read-only unless explicitly opted out
+      viewState.readOnly = true;
+      applyReadOnlyMode();
+      return;
+    }
+  }
+
   if (cloudSyncEnabled && cloudSyncExists) {
     const loadedFromCloud = await pullDocFromCloud(false);
     if (loadedFromCloud) {
       await loadLinearNotesFromLocalDbFallback();
+      if (READONLY_REQUESTED) {
+        viewState.readOnly = true;
+        applyReadOnlyMode();
+      }
       return;
     }
   }
 
   const loadedFromDb = await loadDocFromLocalDb(false);
   if (loadedFromDb) {
+    if (READONLY_REQUESTED) {
+      viewState.readOnly = true;
+      applyReadOnlyMode();
+    }
     return;
   }
 
@@ -3516,6 +3579,11 @@ async function initializeDocument(): Promise<void> {
     await loadDefaultSample();
   } catch {
     loadPayload(createEmptyDoc());
+  }
+
+  if (READONLY_REQUESTED) {
+    viewState.readOnly = true;
+    applyReadOnlyMode();
   }
 }
 
@@ -4407,6 +4475,10 @@ downloadBtn?.addEventListener("click", () => {
   downloadJson();
 });
 
+shareBtnEl?.addEventListener("click", () => {
+  handleShareClick();
+});
+
 /* ── Hamburger & Export dropdown toggle ── */
 function toggleDropdown(menu: HTMLElement | null, btn: HTMLElement | null): void {
   if (!menu || !btn) return;
@@ -4448,6 +4520,15 @@ canvas.addEventListener("pointerdown", (event: PointerEvent) => {
   const nodeId = (event.target as Element | null)?.getAttribute("data-node-id") ??
     ((event.target as HTMLElement | null)?.dataset?.["nodeId"] ?? null);
   if (!doc || !nodeId || event.button !== 0) {
+    return;
+  }
+  if (isReadOnly()) {
+    // In read-only mode, allow click selection but not drag
+    selectByPointerModifiers(nodeId, {
+      toggle: event.ctrlKey || event.metaKey,
+      range: event.shiftKey,
+    });
+    board.focus();
     return;
   }
   viewState.dragState = {
@@ -4547,7 +4628,9 @@ canvas.addEventListener("dblclick", (event: MouseEvent) => {
     return;
   }
   selectNode(nodeId);
-  startInlineEdit(nodeId);
+  if (!isReadOnly()) {
+    startInlineEdit(nodeId);
+  }
 });
 
 board.addEventListener("wheel", (event: WheelEvent) => {
@@ -4654,18 +4737,21 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === "z") {
     event.preventDefault();
+    if (isReadOnly()) return;
     undoLastChange();
     return;
   }
 
   if ((event.ctrlKey || event.metaKey) && (event.shiftKey && event.key.toLowerCase() === "z")) {
     event.preventDefault();
+    if (isReadOnly()) return;
     redoLastChange();
     return;
   }
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === "y") {
     event.preventDefault();
+    if (isReadOnly()) return;
     redoLastChange();
     return;
   }
@@ -4684,19 +4770,21 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "x") {
     event.preventDefault();
+    if (isReadOnly()) return;
     cutSelected();
     return;
   }
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "v") {
     event.preventDefault();
+    if (isReadOnly()) return;
     pasteClipboard();
     return;
   }
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key === "Enter") {
     event.preventDefault();
-    // Equivalent to Esc -> DownArrow -> Enter in normal mode.
+    if (isReadOnly()) return;
     clearCutClipboard();
     selectBreadth(1);
     startInlineEdit(viewState.selectedNodeId, { selectAll: false });
@@ -4712,18 +4800,21 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (event.key === "Tab") {
     event.preventDefault();
+    if (isReadOnly()) return;
     createNodeByDirectionAndEdit("depth");
     return;
   }
 
   if (event.key === "Enter") {
     event.preventDefault();
+    if (isReadOnly()) return;
     startInlineEdit(viewState.selectedNodeId, { selectAll: event.shiftKey });
     return;
   }
 
   if (event.key === "F2") {
     event.preventDefault();
+    if (isReadOnly()) return;
     startInlineEdit(viewState.selectedNodeId, { selectAll: true });
     return;
   }
@@ -4766,6 +4857,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if ((event.ctrlKey || event.metaKey) && event.shiftKey && !event.altKey && event.key.toLowerCase() === "t") {
     event.preventDefault();
+    if (isReadOnly()) return;
     void generateRelatedTopicsForSelectedNode();
     return;
   }
@@ -4800,6 +4892,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
           return;
         }
     event.preventDefault();
+    if (isReadOnly()) return;
     deleteSelected();
     return;
   }
@@ -4852,24 +4945,28 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (event.altKey && event.key.toLowerCase() === "a") {
     event.preventDefault();
+    if (isReadOnly()) return;
     addAliasAsChild();
     return;
   }
 
   if (event.altKey && event.key.toLowerCase() === "p") {
     event.preventDefault();
+    if (isReadOnly()) return;
     makeSelectedFolder();
     return;
   }
 
   if (event.altKey && event.key.toLowerCase() === "m") {
     event.preventDefault();
+    if (isReadOnly()) return;
     toggleHoldReparent();
     return;
   }
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "m") {
     event.preventDefault();
+    if (isReadOnly()) return;
     if (!event.repeat) {
       toggleReparentSource();
     }
@@ -4878,6 +4975,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "f") {
     event.preventDefault();
+    if (isReadOnly()) return;
     makeSelectedFolder();
     return;
   }
@@ -4911,6 +5009,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (event.key.toLowerCase() === "m") {
     event.preventDefault();
+    if (isReadOnly()) return;
     if (!event.repeat) {
       toggleReparentSource();
     }
@@ -4919,12 +5018,14 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (!event.ctrlKey && !event.metaKey && !event.altKey && event.shiftKey && event.key.toLowerCase() === "l") {
     event.preventDefault();
+    if (isReadOnly()) return;
     applyMarkedLink();
     return;
   }
 
   if (!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "l") {
     event.preventDefault();
+    if (isReadOnly()) return;
     if (!event.repeat) {
       markLinkSource();
     }
@@ -4933,6 +5034,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (event.key.toLowerCase() === "p") {
     event.preventDefault();
+    if (isReadOnly()) return;
     applyReparent();
     return;
   }
@@ -4965,6 +5067,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === "g") {
     event.preventDefault();
+    if (isReadOnly()) return;
     groupSelected();
     return;
   }

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -182,6 +182,38 @@
         color: var(--danger);
       }
 
+      /* ── Read-only banner ── */
+      .readonly-banner {
+        position: relative;
+        z-index: 5;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 14px;
+        border: 1px solid #c8daf6;
+        border-radius: 10px;
+        background: #e8f0fe;
+        color: #1a56bb;
+        font-size: 13px;
+        font-weight: 600;
+        pointer-events: auto;
+      }
+
+      .readonly-banner[hidden] {
+        display: none;
+      }
+
+      /* ── Share button ── */
+      .share-btn {
+        border-color: var(--accent);
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .share-btn:hover {
+        background: var(--accent-soft);
+      }
+
       .meta,
       .shortcuts,
       .status,

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -18,8 +18,8 @@
                 <div class="menu-section-title">Cloud Sync</div>
                 <span id="cloud-sync-badge" class="cloud-sync-badge">Cloud: off</span>
                 <button id="cloud-pull">Pull</button>
-                <button id="cloud-push">Push</button>
-                <button id="cloud-use-local" class="danger" hidden>Use Local</button>
+                <button id="cloud-push" data-edit-only>Push</button>
+                <button id="cloud-use-local" class="danger" data-edit-only hidden>Use Local</button>
                 <button id="cloud-use-cloud" hidden>Use Cloud</button>
               </div>
             </div>
@@ -29,13 +29,15 @@
             <button id="mode-rapid" class="mode-btn is-active" type="button">Rapid</button>
             <button id="mode-deep" class="mode-btn" type="button">Deep</button>
           </div>
-          <div class="export-wrap">
+          <button id="share-btn" class="share-btn" type="button">Share</button>
+          <div class="export-wrap" data-edit-only>
             <button id="export-btn" type="button">Export ▾</button>
             <div id="export-menu" class="export-menu" hidden>
               <button id="download-btn">JSON</button>
             </div>
           </div>
         </div>
+        <div id="readonly-banner" class="readonly-banner" hidden>Read-only view</div>
         <!-- hidden elements kept for JS references -->
         <input id="file-input" type="file" accept=".json,.mm,.md,.markdown,application/json,text/xml,application/xml,text/markdown,text/plain" hidden />
         <button id="load-default" hidden></button>


### PR DESCRIPTION
## Summary
- Add `?readonly=1` URL parameter to enable read-only mode in the viewer
- Cloud documents loaded via `?cloudDocId=xxx` default to read-only
- Read-only mode disables all editing (keyboard, drag-and-drop, inline edit, linear text) while preserving navigation, zoom, pan, collapse, and scope traversal
- Display a "Read-only view" banner when active
- Add a "Share" toolbar button that copies the read-only URL to clipboard
- Mark editing-only toolbar elements with `data-edit-only` attribute, hidden in read-only mode

## Test plan
- [ ] Open `viewer.html?readonly=1` -- verify banner appears, editing keys are blocked, navigation works
- [ ] Open `viewer.html?cloudDocId=xxx` -- verify document loads from cloud and defaults to read-only
- [ ] Click "Share" button -- verify correct URL is copied with `cloudDocId` and `readonly=1`
- [ ] Open `viewer.html` without params -- verify normal editing works unchanged
- [ ] Verify Export menu and Push button are hidden in read-only mode
- [ ] Verify zoom, pan, collapse, scope, and arrow key navigation work in read-only mode

Generated with [Claude Code](https://claude.com/claude-code)