### PR TITLE
visual: add entity list panel and conflict resolution UI

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -41,6 +41,17 @@ const cloudPullBtn = document.getElementById("cloud-pull") as HTMLButtonElement;
 const cloudPushBtn = document.getElementById("cloud-push") as HTMLButtonElement;
 const cloudUseLocalBtn = document.getElementById("cloud-use-local") as HTMLButtonElement;
 const cloudUseCloudBtn = document.getElementById("cloud-use-cloud") as HTMLButtonElement;
+const entityListPanelEl = document.getElementById("entity-list-panel") as HTMLElement | null;
+const entityListTreeEl = document.getElementById("entity-list-tree") as HTMLElement | null;
+const entityListSearchEl = document.getElementById("entity-list-search") as HTMLInputElement | null;
+const entityListCloseBtn = document.getElementById("entity-list-close") as HTMLButtonElement | null;
+const conflictPanelEl = document.getElementById("conflict-panel") as HTMLElement | null;
+const conflictLocalTreeEl = document.getElementById("conflict-local-tree") as HTMLElement | null;
+const conflictRemoteTreeEl = document.getElementById("conflict-remote-tree") as HTMLElement | null;
+const conflictDiffSummaryEl = document.getElementById("conflict-diff-summary") as HTMLElement | null;
+const conflictCloseBtn = document.getElementById("conflict-close") as HTMLButtonElement | null;
+const conflictUseLocalBtn = document.getElementById("conflict-use-local") as HTMLButtonElement | null;
+const conflictUseRemoteBtn = document.getElementById("conflict-use-remote") as HTMLButtonElement | null;
 
 function normalizeDocId(raw: string | null, fallback: string): string {
   const trimmed = (raw || "").trim();
@@ -121,6 +132,9 @@ let linearTextFontScale = 1;
 let linearAdjustMenuOpen = false;
 let linearMenuVisible = false;
 let homeScreenVisible = false;
+let entityListVisible = false;
+let conflictPanelVisible = false;
+let conflictRemoteState: AppState | null = null;
 const DRAG_CENTER_BAND_HALF = 20;
 const DRAG_EDGE_BAND = 14;
 const DRAG_REORDER_TAIL = 28;
@@ -3026,6 +3040,380 @@ function hideHomeScreen(): void {
   board.focus();
 }
 
+// ---- Entity List Panel ----
+
+function collectEntityTree(parentId: string): { id: string; label: string; nodeType: string; children: ReturnType<typeof collectEntityTree> }[] {
+  if (!doc) {
+    return [];
+  }
+  const parent = doc.state.nodes[parentId];
+  if (!parent) {
+    return [];
+  }
+  const result: { id: string; label: string; nodeType: string; children: ReturnType<typeof collectEntityTree> }[] = [];
+  for (const childId of parent.children || []) {
+    const child = doc.state.nodes[childId];
+    if (!child) {
+      continue;
+    }
+    result.push({
+      id: child.id,
+      label: uiLabel(child),
+      nodeType: child.nodeType || "text",
+      children: collectEntityTree(child.id),
+    });
+  }
+  return result;
+}
+
+function highlightText(text: string, query: string): string {
+  if (!query) {
+    return escapeHtml(text);
+  }
+  const escaped = escapeHtml(text);
+  const escapedQuery = escapeHtml(query);
+  const regex = new RegExp(`(${escapedQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
+  return escaped.replace(regex, '<span class="entity-highlight">$1</span>');
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function filterEntityTree(
+  nodes: ReturnType<typeof collectEntityTree>,
+  query: string,
+): ReturnType<typeof collectEntityTree> {
+  if (!query) {
+    return nodes;
+  }
+  const lowerQuery = query.toLowerCase();
+  const result: ReturnType<typeof collectEntityTree> = [];
+  for (const node of nodes) {
+    const filteredChildren = filterEntityTree(node.children, query);
+    if (node.label.toLowerCase().includes(lowerQuery) || filteredChildren.length > 0) {
+      result.push({
+        ...node,
+        children: filteredChildren,
+      });
+    }
+  }
+  return result;
+}
+
+function renderEntityTree(
+  container: HTMLElement,
+  nodes: ReturnType<typeof collectEntityTree>,
+  query: string,
+  forceExpand: boolean,
+): void {
+  container.innerHTML = "";
+  for (const node of nodes) {
+    const hasChildren = node.children.length > 0;
+
+    const row = document.createElement("div");
+    row.className = "entity-row";
+    if (viewState.selectedNodeId === node.id) {
+      row.classList.add("is-selected");
+    }
+    row.dataset.nodeId = node.id;
+
+    const toggle = document.createElement("button");
+    toggle.className = "entity-toggle" + (hasChildren ? "" : " no-children");
+    toggle.textContent = "\u25B6";
+    toggle.type = "button";
+    if (forceExpand && hasChildren) {
+      toggle.classList.add("expanded");
+    }
+
+    const name = document.createElement("span");
+    name.className = "entity-name";
+    name.innerHTML = highlightText(node.label, query);
+
+    row.appendChild(toggle);
+    row.appendChild(name);
+
+    if (node.nodeType === "folder") {
+      const badge = document.createElement("span");
+      badge.className = "entity-badge entity-badge-folder";
+      badge.textContent = "folder";
+      row.appendChild(badge);
+    } else if (node.nodeType === "alias") {
+      const badge = document.createElement("span");
+      badge.className = "entity-badge entity-badge-alias";
+      badge.textContent = "alias";
+      row.appendChild(badge);
+    }
+
+    container.appendChild(row);
+
+    let childContainer: HTMLElement | null = null;
+    if (hasChildren) {
+      childContainer = document.createElement("div");
+      childContainer.className = "entity-children";
+      childContainer.hidden = !forceExpand;
+      renderEntityTree(childContainer, node.children, query, forceExpand);
+      container.appendChild(childContainer);
+    }
+
+    toggle.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (!childContainer) {
+        return;
+      }
+      const isExpanded = !childContainer.hidden;
+      childContainer.hidden = isExpanded;
+      toggle.classList.toggle("expanded", !isExpanded);
+    });
+
+    row.addEventListener("click", (e) => {
+      if ((e.target as HTMLElement).closest(".entity-toggle")) {
+        return;
+      }
+      hideEntityListPanel();
+      setSingleSelection(node.id);
+      centerOnNode(node.id, Math.max(1, viewState.zoom));
+      setStatus(`Focused: ${node.label}`);
+    });
+  }
+}
+
+function buildEntityList(query = ""): void {
+  if (!doc || !entityListTreeEl) {
+    return;
+  }
+  const scopeRoot = currentScopeRootId();
+  const allNodes = collectEntityTree(scopeRoot);
+  const filtered = filterEntityTree(allNodes, query);
+  const forceExpand = Boolean(query);
+  renderEntityTree(entityListTreeEl, filtered, query, forceExpand);
+}
+
+function showEntityListPanel(): void {
+  if (!entityListPanelEl || !doc) {
+    return;
+  }
+  entityListVisible = true;
+  entityListPanelEl.hidden = false;
+  if (entityListSearchEl) {
+    entityListSearchEl.value = "";
+  }
+  buildEntityList();
+}
+
+function hideEntityListPanel(): void {
+  if (!entityListPanelEl) {
+    return;
+  }
+  entityListVisible = false;
+  entityListPanelEl.hidden = true;
+  board.focus();
+}
+
+function toggleEntityListPanel(): void {
+  if (entityListVisible) {
+    hideEntityListPanel();
+  } else {
+    showEntityListPanel();
+  }
+}
+
+if (entityListSearchEl) {
+  entityListSearchEl.addEventListener("input", () => {
+    buildEntityList(entityListSearchEl!.value.trim());
+  });
+  entityListSearchEl.addEventListener("keydown", (e) => {
+    e.stopPropagation();
+  });
+}
+
+if (entityListCloseBtn) {
+  entityListCloseBtn.addEventListener("click", () => {
+    hideEntityListPanel();
+  });
+}
+
+// ---- Conflict Panel ----
+
+function collectFlatNodes(state: AppState, rootId: string): { id: string; text: string; depth: number }[] {
+  const result: { id: string; text: string; depth: number }[] = [];
+  const stack: { id: string; depth: number }[] = [{ id: rootId, depth: 0 }];
+  while (stack.length > 0) {
+    const { id, depth } = stack.pop()!;
+    const node = state.nodes[id];
+    if (!node) {
+      continue;
+    }
+    result.push({ id, text: node.text || "Untitled", depth });
+    const children = [...(node.children || [])].reverse();
+    for (const childId of children) {
+      stack.push({ id: childId, depth: depth + 1 });
+    }
+  }
+  return result;
+}
+
+interface ConflictDiffResult {
+  localOnly: Set<string>;
+  remoteOnly: Set<string>;
+  changed: Set<string>;
+  addedCount: number;
+  removedCount: number;
+  changedCount: number;
+}
+
+function diffStates(localState: AppState, remoteState: AppState): ConflictDiffResult {
+  const localIds = new Set(Object.keys(localState.nodes));
+  const remoteIds = new Set(Object.keys(remoteState.nodes));
+
+  const localOnly = new Set<string>();
+  const remoteOnly = new Set<string>();
+  const changed = new Set<string>();
+
+  for (const id of localIds) {
+    if (!remoteIds.has(id)) {
+      localOnly.add(id);
+    }
+  }
+
+  for (const id of remoteIds) {
+    if (!localIds.has(id)) {
+      remoteOnly.add(id);
+    }
+  }
+
+  for (const id of localIds) {
+    if (remoteIds.has(id)) {
+      const localNode = localState.nodes[id];
+      const remoteNode = remoteState.nodes[id];
+      if (localNode.text !== remoteNode.text ||
+          JSON.stringify(localNode.children) !== JSON.stringify(remoteNode.children) ||
+          localNode.parentId !== remoteNode.parentId ||
+          localNode.nodeType !== remoteNode.nodeType) {
+        changed.add(id);
+      }
+    }
+  }
+
+  return {
+    localOnly,
+    remoteOnly,
+    changed,
+    addedCount: remoteOnly.size,
+    removedCount: localOnly.size,
+    changedCount: changed.size,
+  };
+}
+
+function renderConflictTree(
+  container: HTMLElement,
+  flatNodes: { id: string; text: string; depth: number }[],
+  diffClasses: Map<string, string>,
+): void {
+  container.innerHTML = "";
+  for (const node of flatNodes) {
+    const row = document.createElement("div");
+    row.className = "conflict-node-row";
+    const diffClass = diffClasses.get(node.id);
+    if (diffClass) {
+      row.classList.add(diffClass);
+    }
+
+    const indent = document.createElement("span");
+    indent.className = "conflict-node-indent";
+    indent.style.width = `${node.depth * 16}px`;
+
+    const text = document.createElement("span");
+    text.className = "conflict-node-text";
+    text.textContent = node.text;
+
+    row.appendChild(indent);
+    row.appendChild(text);
+    container.appendChild(row);
+  }
+}
+
+function showConflictPanel(remoteState: AppState): void {
+  if (!conflictPanelEl || !conflictLocalTreeEl || !conflictRemoteTreeEl || !conflictDiffSummaryEl || !doc) {
+    return;
+  }
+
+  conflictRemoteState = remoteState;
+  conflictPanelVisible = true;
+  conflictPanelEl.hidden = false;
+
+  const localState = doc.state;
+  const diff = diffStates(localState, remoteState);
+
+  // Build diff class maps
+  const localDiffClasses = new Map<string, string>();
+  const remoteDiffClasses = new Map<string, string>();
+
+  for (const id of diff.localOnly) {
+    localDiffClasses.set(id, "diff-removed");
+  }
+  for (const id of diff.remoteOnly) {
+    remoteDiffClasses.set(id, "diff-added");
+  }
+  for (const id of diff.changed) {
+    localDiffClasses.set(id, "diff-changed");
+    remoteDiffClasses.set(id, "diff-changed");
+  }
+
+  const localFlat = collectFlatNodes(localState, localState.rootId);
+  const remoteFlat = collectFlatNodes(remoteState, remoteState.rootId);
+
+  renderConflictTree(conflictLocalTreeEl, localFlat, localDiffClasses);
+  renderConflictTree(conflictRemoteTreeEl, remoteFlat, remoteDiffClasses);
+
+  const parts: string[] = [];
+  if (diff.addedCount > 0) {
+    parts.push(`${diff.addedCount} node(s) added in remote`);
+  }
+  if (diff.removedCount > 0) {
+    parts.push(`${diff.removedCount} node(s) removed in remote`);
+  }
+  if (diff.changedCount > 0) {
+    parts.push(`${diff.changedCount} node(s) modified`);
+  }
+  if (parts.length === 0) {
+    parts.push("No structural differences detected (metadata may differ).");
+  }
+  conflictDiffSummaryEl.textContent = parts.join(" | ");
+}
+
+function hideConflictPanel(): void {
+  if (!conflictPanelEl) {
+    return;
+  }
+  conflictPanelVisible = false;
+  conflictPanelEl.hidden = true;
+  conflictRemoteState = null;
+  board.focus();
+}
+
+if (conflictCloseBtn) {
+  conflictCloseBtn.addEventListener("click", () => {
+    hideConflictPanel();
+  });
+}
+
+if (conflictUseLocalBtn) {
+  conflictUseLocalBtn.addEventListener("click", () => {
+    hideConflictPanel();
+    pushDocToCloud(true, true);
+  });
+}
+
+if (conflictUseRemoteBtn) {
+  conflictUseRemoteBtn.addEventListener("click", () => {
+    if (conflictRemoteState && doc) {
+      hideConflictPanel();
+      pullDocFromCloud(true);
+    }
+  });
+}
+
 function addChild(): void {
   const parentId = viewState.selectedNodeId;
   const parent = getNode(parentId);
@@ -3541,6 +3929,22 @@ async function pushDocToCloud(showStatus = false, force = false): Promise<boolea
       updateCloudSyncUi();
       if (showStatus) {
         setStatus("Cloud conflict detected. Choose Use Local or Use Cloud.", true);
+      }
+      // Attempt to fetch remote state to populate conflict panel
+      try {
+        const pullResp = await fetch(`/api/sync/pull/${encodeURIComponent(CLOUD_DOC_ID)}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+          body: JSON.stringify({}),
+        });
+        if (pullResp.ok) {
+          const pullPayload = await pullResp.json();
+          if (pullPayload.state) {
+            showConflictPanel(pullPayload.state as AppState);
+          }
+        }
+      } catch {
+        // Conflict panel will not be shown if remote fetch fails
       }
       return false;
     }
@@ -4874,6 +5278,18 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     return;
   }
 
+  if (entityListVisible && event.key === "Escape") {
+    event.preventDefault();
+    hideEntityListPanel();
+    return;
+  }
+
+  if (conflictPanelVisible && event.key === "Escape") {
+    event.preventDefault();
+    hideConflictPanel();
+    return;
+  }
+
   if (homeScreenVisible && event.key === "Escape") {
     event.preventDefault();
     hideHomeScreen();
@@ -5071,6 +5487,12 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
         EnterScopeCommand();
         return;
       }
+
+  if (event.altKey && event.key.toLowerCase() === "e") {
+    event.preventDefault();
+    toggleEntityListPanel();
+    return;
+  }
 
   if (event.altKey && event.key.toLowerCase() === "h") {
     event.preventDefault();

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -632,6 +632,351 @@
         margin: 0;
       }
 
+      /* ── Entity List Panel ── */
+      .entity-list-panel {
+        position: absolute;
+        top: 60px;
+        right: 14px;
+        z-index: 12;
+        width: 320px;
+        max-height: calc(100vh - 90px);
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #ddd;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.95);
+        backdrop-filter: blur(10px);
+        box-shadow: 0 12px 34px rgba(24, 24, 24, 0.14);
+        pointer-events: auto;
+        overflow: hidden;
+      }
+
+      .entity-list-panel[hidden] {
+        display: none;
+      }
+
+      .entity-list-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px 14px 8px;
+        border-bottom: 1px solid #e8e8e8;
+        flex-shrink: 0;
+      }
+
+      .entity-list-title {
+        font-size: 14px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--accent);
+      }
+
+      .entity-list-close {
+        width: 28px;
+        height: 28px;
+        border: none;
+        background: none;
+        font-size: 18px;
+        color: #999;
+        cursor: pointer;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+      }
+
+      .entity-list-close:hover {
+        background: #f0f0f0;
+        color: #333;
+      }
+
+      .entity-list-search-wrap {
+        padding: 8px 14px;
+        flex-shrink: 0;
+      }
+
+      .entity-list-search {
+        width: 100%;
+        min-width: 0;
+        padding: 6px 10px;
+        border: 1px solid #d4d4d4;
+        border-radius: 8px;
+        background: #fff;
+        font-size: 13px;
+        outline: none;
+      }
+
+      .entity-list-search:focus {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px var(--accent-soft);
+      }
+
+      .entity-list-tree {
+        flex: 1;
+        overflow-y: auto;
+        padding: 4px 0 8px;
+      }
+
+      .entity-row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 14px 4px;
+        cursor: pointer;
+        user-select: none;
+        transition: background 0.08s ease;
+        font-size: 13px;
+        color: var(--ink);
+        line-height: 1.4;
+      }
+
+      .entity-row:hover {
+        background: rgba(122, 53, 255, 0.06);
+      }
+
+      .entity-row.is-selected {
+        background: var(--accent-soft);
+        color: #5221b2;
+        font-weight: 600;
+      }
+
+      .entity-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        font-size: 10px;
+        color: #999;
+        flex-shrink: 0;
+        transition: transform 0.12s ease;
+        border: none;
+        background: none;
+        padding: 0;
+        cursor: pointer;
+      }
+
+      .entity-toggle.expanded {
+        transform: rotate(90deg);
+      }
+
+      .entity-toggle.no-children {
+        visibility: hidden;
+      }
+
+      .entity-name {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .entity-badge {
+        font-size: 10px;
+        font-weight: 600;
+        padding: 1px 5px;
+        border-radius: 4px;
+        flex-shrink: 0;
+      }
+
+      .entity-badge-folder {
+        background: #fff3e2;
+        color: #9a6b1f;
+      }
+
+      .entity-badge-alias {
+        background: #e8f0ff;
+        color: #2f5fd9;
+      }
+
+      .entity-children {
+        padding-left: 16px;
+      }
+
+      .entity-children[hidden] {
+        display: none;
+      }
+
+      .entity-row .entity-highlight {
+        background: #ffe066;
+        border-radius: 2px;
+      }
+
+      /* ── Conflict Panel ── */
+      .conflict-panel {
+        position: absolute;
+        inset: 0;
+        z-index: 25;
+        display: flex;
+        flex-direction: column;
+        background: rgba(255, 255, 255, 0.96);
+        backdrop-filter: blur(12px);
+        pointer-events: auto;
+        overflow: hidden;
+      }
+
+      .conflict-panel[hidden] {
+        display: none;
+      }
+
+      .conflict-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px 12px;
+        border-bottom: 1px solid #e8e8e8;
+        flex-shrink: 0;
+      }
+
+      .conflict-title {
+        font-size: 18px;
+        font-weight: 700;
+        color: #a35d16;
+        letter-spacing: 0.02em;
+      }
+
+      .conflict-close {
+        width: 32px;
+        height: 32px;
+        border: none;
+        background: none;
+        font-size: 20px;
+        color: #999;
+        cursor: pointer;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+      }
+
+      .conflict-close:hover {
+        background: #f0f0f0;
+        color: #333;
+      }
+
+      .conflict-body {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        padding: 16px 24px;
+        gap: 16px;
+        overflow-y: auto;
+      }
+
+      .conflict-columns {
+        display: flex;
+        gap: 16px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .conflict-col {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #e0e0e0;
+        border-radius: 10px;
+        overflow: hidden;
+        min-width: 0;
+      }
+
+      .conflict-col-header {
+        padding: 8px 12px;
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #888;
+        background: #f8f8f8;
+        border-bottom: 1px solid #e8e8e8;
+        flex-shrink: 0;
+      }
+
+      .conflict-tree {
+        flex: 1;
+        overflow-y: auto;
+        padding: 8px 0;
+      }
+
+      .conflict-node-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 12px;
+        font-size: 13px;
+        color: var(--ink);
+        line-height: 1.4;
+      }
+
+      .conflict-node-row.diff-added {
+        background: #e8f7ee;
+        color: #1f7a43;
+      }
+
+      .conflict-node-row.diff-removed {
+        background: #fde8e8;
+        color: #b94040;
+      }
+
+      .conflict-node-row.diff-changed {
+        background: #fff3e2;
+        color: #a35d16;
+      }
+
+      .conflict-node-indent {
+        display: inline-block;
+        flex-shrink: 0;
+      }
+
+      .conflict-node-text {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .conflict-diff {
+        padding: 10px 14px;
+        font-size: 12px;
+        color: #666;
+        background: #f8f8f8;
+        border-radius: 8px;
+        border: 1px solid #e8e8e8;
+        flex-shrink: 0;
+      }
+
+      .conflict-actions {
+        display: flex;
+        gap: 10px;
+        justify-content: flex-end;
+        flex-shrink: 0;
+      }
+
+      .conflict-actions button {
+        min-width: 120px;
+        padding: 8px 16px;
+        font-size: 14px;
+        font-weight: 600;
+        border-radius: 8px;
+      }
+
+      @media (max-width: 900px) {
+        .entity-list-panel {
+          width: 280px;
+          right: 10px;
+          top: 56px;
+        }
+
+        .conflict-columns {
+          flex-direction: column;
+        }
+      }
+
       /* ── Shortcut Cheatsheet Overlay ── */
       .shortcut-cheatsheet {
         position: absolute;

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -84,6 +84,39 @@
           <div id="home-scope-tree" class="home-scope-tree"></div>
         </div>
       </div>
+      <div id="entity-list-panel" class="entity-list-panel" hidden>
+        <div class="entity-list-header">
+          <span class="entity-list-title">Entities</span>
+          <button id="entity-list-close" class="entity-list-close" type="button" aria-label="Close entity list">&times;</button>
+        </div>
+        <div class="entity-list-search-wrap">
+          <input id="entity-list-search" class="entity-list-search" type="text" placeholder="Filter nodes..." spellcheck="false" />
+        </div>
+        <div id="entity-list-tree" class="entity-list-tree"></div>
+      </div>
+      <div id="conflict-panel" class="conflict-panel" hidden>
+        <div class="conflict-header">
+          <span class="conflict-title">Conflict Detected</span>
+          <button id="conflict-close" class="conflict-close" type="button" aria-label="Close conflict panel">&times;</button>
+        </div>
+        <div class="conflict-body">
+          <div class="conflict-columns">
+            <div class="conflict-col">
+              <div class="conflict-col-header">Local</div>
+              <div id="conflict-local-tree" class="conflict-tree"></div>
+            </div>
+            <div class="conflict-col">
+              <div class="conflict-col-header">Remote</div>
+              <div id="conflict-remote-tree" class="conflict-tree"></div>
+            </div>
+          </div>
+          <div class="conflict-diff" id="conflict-diff-summary"></div>
+          <div class="conflict-actions">
+            <button id="conflict-use-local" class="danger" type="button">Use Local</button>
+            <button id="conflict-use-remote" class="primary" type="button">Use Remote</button>
+          </div>
+        </div>
+      </div>
       <div id="shortcut-cheatsheet" class="shortcut-cheatsheet" hidden>
         <div class="cheatsheet-header">Keyboard Shortcuts</div>
         <div class="cheatsheet-body">
@@ -95,6 +128,7 @@
               <div class="cheatsheet-row"><kbd>J</kbd><span>Deeper (child)</span></div>
               <div class="cheatsheet-row"><kbd>K</kbd><span>Shallower (parent)</span></div>
               <div class="cheatsheet-row"><kbd>Alt+H</kbd><span>Home screen</span></div>
+              <div class="cheatsheet-row"><kbd>Alt+E</kbd><span>Entity list panel</span></div>
               <div class="cheatsheet-row"><kbd>Alt+V</kbd><span>Toggle focus / fit</span></div>
               <div class="cheatsheet-row"><kbd>Alt+J</kbd><span>Jump to alias target</span></div>
             </div>


### PR DESCRIPTION
## Summary
- **Entity list panel** (Alt+E): right sidebar showing all nodes in the current scope as a collapsible tree with search/filter, type badges (folder/alias), and click-to-focus navigation
- **Conflict resolution panel**: full-screen side-by-side diff view for cloud sync conflicts with color-coded diff highlighting (added/removed/changed) and one-click use-local/use-remote resolution
- Auto-opens conflict panel when push returns HTTP 409 and remote state is fetchable
- Keyboard shortcuts: Alt+E to toggle entity list, Escape to close either panel

## Test plan
- [ ] Open viewer, press Alt+E to verify entity list panel appears with full node tree
- [ ] Type in search box to filter nodes, verify highlighting and subtree expansion
- [ ] Click a node in entity list to verify it closes panel and focuses the node on canvas
- [ ] Verify conflict panel renders correctly when cloud sync conflict occurs (HTTP 409)
- [ ] Verify Use Local and Use Remote buttons resolve the conflict correctly
- [ ] Verify Escape key closes both panels
- [ ] Verify TypeScript compiles cleanly (`npx tsc --project tsconfig.browser.json --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)