### PR TITLE
data: add audit log and presence tracking for collab

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -3464,6 +3464,7 @@ async function saveDocToLocalDb(showStatus = false): Promise<boolean> {
       method: "POST",
       headers: {
         "Content-Type": "application/json; charset=utf-8",
+        "X-M3E-Tab-Id": TAB_ID,
       },
       body: JSON.stringify(currentDocSnapshot()),
     });
@@ -3707,6 +3708,82 @@ function broadcastState(): void {
   }
   const msg: BcStateMessage = { type: "STATE_UPDATE", fromTabId: TAB_ID, state: doc.state };
   bc.postMessage(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Doc-watch SSE — auto-refresh on external DB changes
+// ---------------------------------------------------------------------------
+
+let docWatchEs: EventSource | null = null;
+let lastAppliedSavedAt: string | null = null;
+
+function initDocWatch(): void {
+  if (docWatchEs) return;
+  const url = `/api/docs/${encodeURIComponent(LOCAL_DOC_ID)}/watch`;
+  docWatchEs = new EventSource(url);
+
+  docWatchEs.addEventListener("doc_updated", (ev: MessageEvent) => {
+    try {
+      const data = JSON.parse(ev.data) as { docId: string; savedAt: string; sourceTabId: string | null };
+      // Ignore our own saves
+      if (data.sourceTabId === TAB_ID) return;
+      // Ignore duplicate events
+      if (data.savedAt === lastAppliedSavedAt) return;
+      // If user has unsaved edits, notify instead of overwriting
+      if (autosaveTimer !== null) {
+        setStatus("External update available — save your edits first.", false);
+        return;
+      }
+      void applyExternalUpdate(data.savedAt);
+    } catch {
+      // ignore malformed events
+    }
+  });
+
+  window.addEventListener("beforeunload", () => docWatchEs?.close());
+}
+
+async function applyExternalUpdate(savedAt: string): Promise<void> {
+  try {
+    const response = await fetch(`/api/docs/${encodeURIComponent(LOCAL_DOC_ID)}`, { cache: "no-store" });
+    if (!response.ok) return;
+    const payload = await response.json();
+    const newDoc = ensureDocShape(payload);
+    // Only apply if actually newer
+    if (doc && newDoc.savedAt <= (doc.savedAt || "")) return;
+    lastAppliedSavedAt = savedAt;
+
+    // Preserve view state
+    const prevScopeId = viewState.currentScopeId;
+    const prevSelectedId = viewState.selectedNodeId;
+    const prevCollapsed = new Set(viewState.collapsedIds);
+    const prevScopeHistory = [...viewState.scopeHistory];
+
+    doc = newDoc;
+    hydrateLinearNotesFromDocState();
+    hydrateLinearTextFontScaleFromDocState();
+    if (doc.state.linearPanelWidth != null) {
+      linearPanelCanvasWidth = doc.state.linearPanelWidth;
+    }
+
+    // Restore view state if nodes still exist
+    if (doc.state.nodes[prevScopeId]) {
+      viewState.currentScopeId = prevScopeId;
+      viewState.currentScopeRootId = prevScopeId;
+      viewState.scopeHistory = prevScopeHistory;
+    }
+    if (doc.state.nodes[prevSelectedId]) {
+      viewState.selectedNodeId = prevSelectedId;
+      viewState.selectedNodeIds = new Set([prevSelectedId]);
+    }
+    viewState.collapsedIds = prevCollapsed;
+
+    render();
+    setStatus("Document updated externally.");
+    broadcastState();
+  } catch {
+    // will retry on next SSE event
+  }
 }
 
 function touchDocument(): void {
@@ -5306,6 +5383,7 @@ updateCloudSyncUi();
 
 void initializeDocument().then(() => {
   initBroadcastSync();
+  initDocWatch();
   const initialScopeId = queryParams.get("scopeId");
   if (initialScopeId && doc && doc.state.nodes[initialScopeId] && initialScopeId !== doc.state.rootId) {
     // Build ancestor chain so ExitScopeCommand can step back through each level

--- a/beta/src/node/audit_log.ts
+++ b/beta/src/node/audit_log.ts
@@ -1,0 +1,118 @@
+"use strict";
+
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OperationType = "add" | "edit" | "delete" | "move";
+
+export interface AuditEntry {
+  timestamp: string;       // ISO 8601
+  userId: string;          // entityId or display name
+  operationType: OperationType;
+  targetNodeId: string;
+  details: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Ring buffer (in-memory, last N entries)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BUFFER_SIZE = 500;
+
+let buffer: AuditEntry[] = [];
+let bufferMaxSize = DEFAULT_BUFFER_SIZE;
+
+export function setBufferSize(size: number): void {
+  bufferMaxSize = Math.max(1, size);
+  if (buffer.length > bufferMaxSize) {
+    buffer = buffer.slice(buffer.length - bufferMaxSize);
+  }
+}
+
+export function getBufferSize(): number {
+  return bufferMaxSize;
+}
+
+// ---------------------------------------------------------------------------
+// File persistence (JSON Lines)
+// ---------------------------------------------------------------------------
+
+let logFilePath: string | null = null;
+let logStream: fs.WriteStream | null = null;
+
+export function initAuditFile(dataDir: string, docId: string): void {
+  const safeDocId = docId.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const auditDir = path.join(dataDir, "audit");
+  if (!fs.existsSync(auditDir)) {
+    fs.mkdirSync(auditDir, { recursive: true });
+  }
+  logFilePath = path.join(auditDir, `${safeDocId}.jsonl`);
+  // Open in append mode
+  logStream = fs.createWriteStream(logFilePath, { flags: "a", encoding: "utf8" });
+}
+
+export function closeAuditFile(): void {
+  if (logStream) {
+    logStream.end();
+    logStream = null;
+  }
+  logFilePath = null;
+}
+
+// ---------------------------------------------------------------------------
+// Core: record an entry
+// ---------------------------------------------------------------------------
+
+export function recordAudit(entry: Omit<AuditEntry, "timestamp">): AuditEntry {
+  const full: AuditEntry = {
+    timestamp: new Date().toISOString(),
+    ...entry,
+  };
+
+  // Ring buffer push
+  buffer.push(full);
+  if (buffer.length > bufferMaxSize) {
+    buffer.shift();
+  }
+
+  // File append (fire-and-forget)
+  if (logStream && !logStream.destroyed) {
+    logStream.write(JSON.stringify(full) + "\n");
+  }
+
+  return full;
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+export function getRecentAuditEntries(limit?: number): AuditEntry[] {
+  const n = limit ?? 100;
+  if (n >= buffer.length) {
+    return [...buffer];
+  }
+  return buffer.slice(buffer.length - n);
+}
+
+export function getAuditEntriesForNode(targetNodeId: string, limit?: number): AuditEntry[] {
+  const filtered = buffer.filter((e) => e.targetNodeId === targetNodeId);
+  const n = limit ?? 100;
+  if (n >= filtered.length) {
+    return filtered;
+  }
+  return filtered.slice(filtered.length - n);
+}
+
+// ---------------------------------------------------------------------------
+// Reset (for testing)
+// ---------------------------------------------------------------------------
+
+export function resetAuditLog(): void {
+  buffer = [];
+  closeAuditFile();
+}

--- a/beta/src/node/collab.ts
+++ b/beta/src/node/collab.ts
@@ -4,6 +4,7 @@ import http from "http";
 import crypto from "crypto";
 import { RapidMvpModel } from "./rapid_mvp";
 import type { TreeNode } from "../shared/types";
+import { recordAudit, type OperationType } from "./audit_log";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -349,6 +350,7 @@ export function mergeScopePush(
   const nodes = model.state.nodes;
   const rootId = model.state.rootId;
   const hasVersionConflict = baseVersion !== docVersion;
+  const originalNodeIds = new Set(Object.keys(nodes));
 
   const applied: string[] = [];
   const rejected: string[] = [];
@@ -425,6 +427,27 @@ export function mergeScopePush(
   // Save + version bump
   validationModel.saveToSqlite(sqlitePath, docId);
   const newVersion = ++docVersion;
+
+  // Audit log for each applied change
+  for (const nodeId of applied) {
+    const change = changedNodes[nodeId];
+    let opType: OperationType;
+    if (change === null) {
+      opType = "delete";
+    } else if (nodes[nodeId] && change.parentId !== nodes[nodeId]?.parentId) {
+      opType = "move";
+    } else if (!originalNodeIds.has(nodeId)) {
+      opType = "add";
+    } else {
+      opType = "edit";
+    }
+    recordAudit({
+      userId: entity.entityId,
+      operationType: opType,
+      targetNodeId: nodeId,
+      details: { docId, version: newVersion, scopeId },
+    });
+  }
 
   broadcastSseEvent("state_update", { docId, version: newVersion, entityId: entity.entityId, applied, rejected, conflicts });
 

--- a/beta/src/node/presence.ts
+++ b/beta/src/node/presence.ts
@@ -1,0 +1,97 @@
+"use strict";
+
+// ---------------------------------------------------------------------------
+// Presence tracking — per-document connected user state
+// ---------------------------------------------------------------------------
+
+export interface PresenceEntry {
+  entityId: string;
+  displayName: string;
+  role: string;
+  status: "active" | "inactive";
+  lastOperationAt: string;   // ISO 8601
+  connectedAt: string;       // ISO 8601
+}
+
+// docId -> entityId -> entry
+const presenceMap = new Map<string, Map<string, PresenceEntry>>();
+
+const INACTIVE_THRESHOLD_MS = 60_000; // 1 minute without activity -> inactive
+
+// ---------------------------------------------------------------------------
+// Core operations
+// ---------------------------------------------------------------------------
+
+export function touchPresence(
+  docId: string,
+  entityId: string,
+  displayName: string,
+  role: string,
+): PresenceEntry {
+  let docPresence = presenceMap.get(docId);
+  if (!docPresence) {
+    docPresence = new Map();
+    presenceMap.set(docId, docPresence);
+  }
+
+  const now = new Date().toISOString();
+  const existing = docPresence.get(entityId);
+
+  if (existing) {
+    existing.lastOperationAt = now;
+    existing.status = "active";
+    existing.displayName = displayName;
+    existing.role = role;
+    return existing;
+  }
+
+  const entry: PresenceEntry = {
+    entityId,
+    displayName,
+    role,
+    status: "active",
+    lastOperationAt: now,
+    connectedAt: now,
+  };
+  docPresence.set(entityId, entry);
+  return entry;
+}
+
+export function removePresence(docId: string, entityId: string): boolean {
+  const docPresence = presenceMap.get(docId);
+  if (!docPresence) return false;
+  const deleted = docPresence.delete(entityId);
+  if (docPresence.size === 0) {
+    presenceMap.delete(docId);
+  }
+  return deleted;
+}
+
+export function getPresenceList(docId: string): PresenceEntry[] {
+  const docPresence = presenceMap.get(docId);
+  if (!docPresence) return [];
+
+  const now = Date.now();
+  const result: PresenceEntry[] = [];
+
+  for (const entry of docPresence.values()) {
+    // Update status based on inactivity threshold
+    const lastOp = new Date(entry.lastOperationAt).getTime();
+    if (now - lastOp > INACTIVE_THRESHOLD_MS) {
+      entry.status = "inactive";
+    } else {
+      entry.status = "active";
+    }
+    result.push({ ...entry });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Reset (for testing)
+// ---------------------------------------------------------------------------
+
+export function resetPresence(): void {
+  presenceMap.clear();
+}

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -52,6 +52,52 @@ const cloudSyncConfig = loadCloudSyncConfig();
 const CLOUD_SYNC_ENABLED = cloudSyncConfig.enabled;
 let cloudTransport: CloudSyncTransport | null = cloudSyncConfig.transport;
 
+// ---------------------------------------------------------------------------
+// Doc-watch SSE (standalone, independent of collab SSE)
+// ---------------------------------------------------------------------------
+
+interface DocWatchClient {
+  docId: string;
+  res: http.ServerResponse;
+}
+
+const docWatchClients: DocWatchClient[] = [];
+
+function addDocWatchClient(docId: string, res: http.ServerResponse): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  res.write(": connected\n\n");
+  docWatchClients.push({ docId, res });
+  res.on("close", () => {
+    const idx = docWatchClients.findIndex((c) => c.res === res);
+    if (idx !== -1) docWatchClients.splice(idx, 1);
+  });
+}
+
+function broadcastDocUpdate(docId: string, savedAt: string, sourceTabId: string | null): void {
+  const payload = JSON.stringify({ docId, savedAt, sourceTabId });
+  const frame = `event: doc_updated\ndata: ${payload}\n\n`;
+  for (let i = docWatchClients.length - 1; i >= 0; i--) {
+    if (docWatchClients[i].docId === docId) {
+      try {
+        docWatchClients[i].res.write(frame);
+      } catch {
+        docWatchClients.splice(i, 1);
+      }
+    }
+  }
+}
+
+function parseDocWatchRoute(urlPath: string): string | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  const match = pathname.match(/^\/api\/docs\/([^/]+)\/watch$/);
+  if (!match) return null;
+  return decodeURIComponent(match[1]);
+}
+
 const MIME_BY_EXT: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
   ".js": "application/javascript; charset=utf-8",
@@ -246,7 +292,10 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse, do
       }
 
       model.saveToSqlite(SQLITE_DB_PATH, docId);
-      sendJson(res, 200, { ok: true, savedAt: new Date().toISOString(), documentId: docId });
+      const savedAt = new Date().toISOString();
+      const sourceTabId = (req.headers["x-m3e-tab-id"] as string) || null;
+      broadcastDocUpdate(docId, savedAt, sourceTabId);
+      sendJson(res, 200, { ok: true, savedAt, documentId: docId });
     } catch (err) {
       const message = (err as Error).message || "Unknown error";
       if (err instanceof SyntaxError) {
@@ -561,6 +610,18 @@ function startServer(): void {
       startAutoBackup(SQLITE_DB_PATH, BACKUP_DIR);
     }
     console.log("Press Ctrl+C to stop the server.");
+
+    // Keep SSE connections alive through proxies
+    setInterval(() => {
+      const ping = ": heartbeat\n\n";
+      for (let i = docWatchClients.length - 1; i >= 0; i--) {
+        try {
+          docWatchClients[i].res.write(ping);
+        } catch {
+          docWatchClients.splice(i, 1);
+        }
+      }
+    }, 15_000);
   });
 }
 
@@ -727,6 +788,16 @@ export function createAppServer(): http.Server {
     const syncRoute = parseSyncRoute(req.url ?? "/");
     if (syncRoute) {
       await handleSyncApi(req, res, syncRoute);
+      return;
+    }
+
+    const watchDocId = parseDocWatchRoute(req.url ?? "/");
+    if (watchDocId !== null) {
+      if (req.method !== "GET") {
+        sendJson(res, 405, { error: "Method not allowed." });
+        return;
+      }
+      addDocWatchClient(watchDocId, res);
       return;
     }
 

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -35,6 +35,8 @@ import {
   setDocVersion,
   type CollabRole,
 } from "./collab";
+import { initAuditFile, recordAudit, getRecentAuditEntries } from "./audit_log";
+import { getPresenceList, touchPresence, removePresence } from "./presence";
 import type { AiSubagentRequest, AppState, LinearTransformRequest, SavedDoc } from "../shared/types";
 
 // After compilation, this file lives at dist/node/start_viewer.js.
@@ -94,6 +96,20 @@ function broadcastDocUpdate(docId: string, savedAt: string, sourceTabId: string 
 function parseDocWatchRoute(urlPath: string): string | null {
   const pathname = new URL(urlPath, "http://localhost").pathname;
   const match = pathname.match(/^\/api\/docs\/([^/]+)\/watch$/);
+  if (!match) return null;
+  return decodeURIComponent(match[1]);
+}
+
+function parseDocAuditRoute(urlPath: string): string | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  const match = pathname.match(/^\/api\/docs\/([^/]+)\/audit$/);
+  if (!match) return null;
+  return decodeURIComponent(match[1]);
+}
+
+function parseDocPresenceRoute(urlPath: string): string | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  const match = pathname.match(/^\/api\/docs\/([^/]+)\/presence$/);
   if (!match) return null;
   return decodeURIComponent(match[1]);
 }
@@ -589,6 +605,9 @@ async function handleAiApi(req: http.IncomingMessage, res: http.ServerResponse):
 }
 
 function startServer(): void {
+  // Initialize audit log file for the default document
+  initAuditFile(DATA_DIR, "rapid-main");
+
   const server = createAppServer();
 
   server.listen(PORT, () => {
@@ -682,6 +701,8 @@ async function handleCollabApi(
       return;
     }
     const entity = registerEntity(body.displayName, body.role, body.capabilities ?? ["read", "write"]);
+    // Track presence for default doc on register
+    touchPresence("rapid-main", entity.entityId, body.displayName, body.role);
     sendJson(res, 200, { ok: true, entityId: entity.entityId, token: entity.token, priority: entity.priority });
     return;
   }
@@ -696,13 +717,17 @@ async function handleCollabApi(
     case "heartbeat": {
       if (req.method !== "POST") { sendJson(res, 405, { ok: false, error: "Method not allowed." }); return; }
       const rawBody = await readRequestBody(req);
-      const body = JSON.parse(rawBody) as { lockIds?: string[] };
+      const body = JSON.parse(rawBody) as { lockIds?: string[]; docId?: string };
       heartbeat(entity.entityId, body.lockIds ?? []);
+      // Refresh presence on heartbeat
+      touchPresence(body.docId ?? "rapid-main", entity.entityId, entity.displayName, entity.role);
       sendJson(res, 200, { ok: true });
       return;
     }
     case "unregister": {
       if (req.method !== "DELETE") { sendJson(res, 405, { ok: false, error: "Method not allowed." }); return; }
+      // Remove from all doc presence (use default doc for now)
+      removePresence("rapid-main", entity.entityId);
       unregisterEntity(entity.entityId);
       sendJson(res, 200, { ok: true });
       return;
@@ -752,6 +777,8 @@ async function handleCollabApi(
           return;
         }
         const result = mergeScopePush(docId, body.scopeId, entity, body.lockId, body.baseVersion, body.changes.nodes as never, SQLITE_DB_PATH);
+        // Update presence on push
+        touchPresence(docId, entity.entityId, entity.displayName, entity.role);
         if (!result.ok && result.error === "Scope lock not held.") {
           sendJson(res, 403, result);
         } else {
@@ -798,6 +825,33 @@ export function createAppServer(): http.Server {
         return;
       }
       addDocWatchClient(watchDocId, res);
+      return;
+    }
+
+    // Audit log endpoint
+    const auditDocId = parseDocAuditRoute(req.url ?? "/");
+    if (auditDocId !== null) {
+      if (req.method !== "GET") {
+        sendJson(res, 405, { error: "Method not allowed." });
+        return;
+      }
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const limitParam = url.searchParams.get("limit");
+      const limit = limitParam ? Math.max(1, Math.min(1000, Number(limitParam) || 100)) : 100;
+      const entries = getRecentAuditEntries(limit);
+      sendJson(res, 200, { ok: true, documentId: auditDocId, count: entries.length, entries });
+      return;
+    }
+
+    // Presence endpoint
+    const presenceDocId = parseDocPresenceRoute(req.url ?? "/");
+    if (presenceDocId !== null) {
+      if (req.method !== "GET") {
+        sendJson(res, 405, { error: "Method not allowed." });
+        return;
+      }
+      const list = getPresenceList(presenceDocId);
+      sendJson(res, 200, { ok: true, documentId: presenceDocId, count: list.length, users: list });
       return;
     }
 

--- a/beta/tests/unit/audit_log.test.js
+++ b/beta/tests/unit/audit_log.test.js
@@ -1,0 +1,66 @@
+// @ts-check
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { recordAudit, getRecentAuditEntries, getAuditEntriesForNode, resetAuditLog, setBufferSize } = require("../../dist/node/audit_log.js");
+
+test("recordAudit adds entry with timestamp", () => {
+  resetAuditLog();
+  const entry = recordAudit({
+    userId: "e_test1",
+    operationType: "add",
+    targetNodeId: "n_123",
+    details: { text: "hello" },
+  });
+  assert.ok(entry.timestamp);
+  assert.equal(entry.userId, "e_test1");
+  assert.equal(entry.operationType, "add");
+  assert.equal(entry.targetNodeId, "n_123");
+});
+
+test("getRecentAuditEntries returns entries in order", () => {
+  resetAuditLog();
+  recordAudit({ userId: "u1", operationType: "add", targetNodeId: "n_1", details: {} });
+  recordAudit({ userId: "u2", operationType: "edit", targetNodeId: "n_2", details: {} });
+  recordAudit({ userId: "u1", operationType: "delete", targetNodeId: "n_3", details: {} });
+
+  const entries = getRecentAuditEntries(10);
+  assert.equal(entries.length, 3);
+  assert.equal(entries[0].operationType, "add");
+  assert.equal(entries[2].operationType, "delete");
+});
+
+test("ring buffer enforces max size", () => {
+  resetAuditLog();
+  setBufferSize(3);
+  for (let i = 0; i < 5; i++) {
+    recordAudit({ userId: "u1", operationType: "add", targetNodeId: `n_${i}`, details: {} });
+  }
+  const entries = getRecentAuditEntries(10);
+  assert.equal(entries.length, 3);
+  assert.equal(entries[0].targetNodeId, "n_2");
+  assert.equal(entries[2].targetNodeId, "n_4");
+  setBufferSize(500); // restore default
+});
+
+test("getAuditEntriesForNode filters by nodeId", () => {
+  resetAuditLog();
+  recordAudit({ userId: "u1", operationType: "add", targetNodeId: "n_a", details: {} });
+  recordAudit({ userId: "u2", operationType: "edit", targetNodeId: "n_b", details: {} });
+  recordAudit({ userId: "u1", operationType: "edit", targetNodeId: "n_a", details: {} });
+
+  const entries = getAuditEntriesForNode("n_a");
+  assert.equal(entries.length, 2);
+  entries.forEach((e) => assert.equal(e.targetNodeId, "n_a"));
+});
+
+test("limit parameter caps returned entries", () => {
+  resetAuditLog();
+  for (let i = 0; i < 10; i++) {
+    recordAudit({ userId: "u1", operationType: "add", targetNodeId: `n_${i}`, details: {} });
+  }
+  const entries = getRecentAuditEntries(3);
+  assert.equal(entries.length, 3);
+  assert.equal(entries[0].targetNodeId, "n_7");
+});

--- a/beta/tests/unit/presence.test.js
+++ b/beta/tests/unit/presence.test.js
@@ -1,0 +1,59 @@
+// @ts-check
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { touchPresence, removePresence, getPresenceList, resetPresence } = require("../../dist/node/presence.js");
+
+test("touchPresence creates entry and getPresenceList returns it", () => {
+  resetPresence();
+  touchPresence("doc1", "e_1", "Alice", "human");
+  const list = getPresenceList("doc1");
+  assert.equal(list.length, 1);
+  assert.equal(list[0].entityId, "e_1");
+  assert.equal(list[0].displayName, "Alice");
+  assert.equal(list[0].role, "human");
+  assert.equal(list[0].status, "active");
+});
+
+test("touchPresence updates existing entry", () => {
+  resetPresence();
+  touchPresence("doc1", "e_1", "Alice", "human");
+  touchPresence("doc1", "e_1", "Alice Updated", "owner");
+  const list = getPresenceList("doc1");
+  assert.equal(list.length, 1);
+  assert.equal(list[0].displayName, "Alice Updated");
+  assert.equal(list[0].role, "owner");
+});
+
+test("removePresence removes entry", () => {
+  resetPresence();
+  touchPresence("doc1", "e_1", "Alice", "human");
+  touchPresence("doc1", "e_2", "Bob", "ai");
+  assert.ok(removePresence("doc1", "e_1"));
+  const list = getPresenceList("doc1");
+  assert.equal(list.length, 1);
+  assert.equal(list[0].entityId, "e_2");
+});
+
+test("removePresence returns false for unknown entity", () => {
+  resetPresence();
+  assert.equal(removePresence("doc1", "e_unknown"), false);
+});
+
+test("getPresenceList returns empty for unknown doc", () => {
+  resetPresence();
+  const list = getPresenceList("nonexistent");
+  assert.equal(list.length, 0);
+});
+
+test("multiple docs are tracked independently", () => {
+  resetPresence();
+  touchPresence("doc1", "e_1", "Alice", "human");
+  touchPresence("doc2", "e_2", "Bob", "ai");
+
+  assert.equal(getPresenceList("doc1").length, 1);
+  assert.equal(getPresenceList("doc2").length, 1);
+  assert.equal(getPresenceList("doc1")[0].entityId, "e_1");
+  assert.equal(getPresenceList("doc2")[0].entityId, "e_2");
+});

--- a/dev-docs/03_Spec/REST_API.md
+++ b/dev-docs/03_Spec/REST_API.md
@@ -33,6 +33,8 @@ M3E_ROOT=C:\Users\chiec\dev\M3E
 | `POST` | `/api/ai/subagent/{name}` | AI subagent 実行 | AI_Common_API.md |
 | `GET` | `/api/linear-transform/status` | Linear transform ステータス | AI_Common_API.md |
 | `POST` | `/api/linear-transform/convert` | Linear transform 実行 | AI_Common_API.md |
+| `GET` | `/api/docs/{docId}/audit` | 操作監査ログ取得 | 本文書 |
+| `GET` | `/api/docs/{docId}/presence` | 接続ユーザー一覧取得 | 本文書 |
 | `GET` | `/{path}` | 静的ファイル配信 | — |
 
 ---
@@ -146,6 +148,102 @@ Body:
 - Link の `direction` / `style` の値域
 - ツリーの循環検出（DFS）
 - 孤立ノードの検出
+
+---
+
+## Audit Log API
+
+操作監査ログを取得する。ユーザーのノード操作（追加/編集/削除/移動）をタイムスタンプ付きで記録し、直近 N 件をメモリ上のリングバッファに保持する。ファイル永続化は JSON Lines 形式で `{M3E_DATA_DIR}/audit/{docId}.jsonl` に出力される。
+
+### `GET /api/docs/{docId}/audit`
+
+直近の操作監査ログを取得する。
+
+#### リクエスト
+
+パスパラメータ:
+
+- `docId` (string, 必須): ドキュメント識別子
+
+クエリパラメータ:
+
+- `limit` (number, 任意): 取得件数の上限（1-1000、既定: 100）
+
+#### 成功レスポンス (200)
+
+```json
+{
+  "ok": true,
+  "documentId": "rapid-main",
+  "count": 3,
+  "entries": [
+    {
+      "timestamp": "2026-04-10T12:00:00.000Z",
+      "userId": "e_abc123",
+      "operationType": "add",
+      "targetNodeId": "n_1234567890_abc123",
+      "details": { "docId": "rapid-main", "version": 5, "scopeId": "n_root" }
+    }
+  ]
+}
+```
+
+#### AuditEntry フィールド
+
+| フィールド | 型 | 説明 |
+|------------|------|------|
+| `timestamp` | string (ISO 8601) | 操作日時 |
+| `userId` | string | 操作者の entityId |
+| `operationType` | `"add"` \| `"edit"` \| `"delete"` \| `"move"` | 操作種別 |
+| `targetNodeId` | string | 対象ノード ID |
+| `details` | object | 操作の追加情報 |
+
+---
+
+## Presence API
+
+接続中ユーザーの一覧とアクティブ/非アクティブ状態を取得する。Collab API の register/heartbeat/push 操作に連動して自動更新される。60 秒以上操作がないユーザーは `inactive` 状態となる。
+
+### `GET /api/docs/{docId}/presence`
+
+指定ドキュメントの接続ユーザー一覧を取得する。
+
+#### リクエスト
+
+パスパラメータ:
+
+- `docId` (string, 必須): ドキュメント識別子
+
+#### 成功レスポンス (200)
+
+```json
+{
+  "ok": true,
+  "documentId": "rapid-main",
+  "count": 2,
+  "users": [
+    {
+      "entityId": "e_abc123",
+      "displayName": "Alice",
+      "role": "human",
+      "status": "active",
+      "lastOperationAt": "2026-04-10T12:00:00.000Z",
+      "connectedAt": "2026-04-10T11:50:00.000Z"
+    }
+  ]
+}
+```
+
+#### PresenceEntry フィールド
+
+| フィールド | 型 | 説明 |
+|------------|------|------|
+| `entityId` | string | ユーザー識別子 |
+| `displayName` | string | 表示名 |
+| `role` | string | ロール（owner, human, ai 等） |
+| `status` | `"active"` \| `"inactive"` | 状態（60 秒で inactive に遷移） |
+| `lastOperationAt` | string (ISO 8601) | 最終操作日時 |
+| `connectedAt` | string (ISO 8601) | 接続開始日時 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add operation audit log module (`audit_log.ts`) with in-memory ring buffer (500 entries) and JSON Lines file persistence under `{DATA_DIR}/audit/`
- Add presence tracking module (`presence.ts`) for per-document connected user state with active/inactive detection (60s threshold)
- Integrate audit logging into `collab.ts` `mergeScopePush` to record add/edit/delete/move operations
- Integrate presence tracking into collab register/heartbeat/unregister/push flows in `start_viewer.ts`
- Expose `GET /api/docs/:id/audit` and `GET /api/docs/:id/presence` endpoints
- Update REST API spec with full documentation for both new endpoints
- Add unit tests for both modules (5 audit tests + 6 presence tests, all passing)

## Test plan
- [x] TypeScript compiles cleanly (`tsc -p tsconfig.node.json --noEmit`)
- [x] All 5 audit_log unit tests pass
- [x] All 6 presence unit tests pass
- [x] Existing tests unaffected (17/17 rapid_mvp + cloud_sync tests pass)
- [ ] Manual test: start server with `M3E_COLLAB=1`, register entity, push changes, verify audit entries appear at `/api/docs/rapid-main/audit`
- [ ] Manual test: verify presence list at `/api/docs/rapid-main/presence` shows connected users

Generated with [Claude Code](https://claude.com/claude-code)