### PR TITLE
data: Cloud Sync Phase 1 - docVersion, conflict backup, auto sync, retry

### DIFF
--- a/beta/src/node/cloud_sync.ts
+++ b/beta/src/node/cloud_sync.ts
@@ -8,19 +8,37 @@ import type {
   SavedDoc,
   SyncStatus,
 } from "../shared/types";
+import { createConflictBackup } from "./conflict_backup";
 
 // ---------------------------------------------------------------------------
 // Conflict detection (shared logic)
 // ---------------------------------------------------------------------------
 
+/**
+ * Detect cloud conflict using docVersion (monotonic integer) as primary,
+ * with savedAt timestamp as fallback for backward compatibility.
+ *
+ * Returns true when the cloud document has been modified since the client
+ * last pulled (i.e., the client's base version/timestamp does not match
+ * the cloud's current version/timestamp).
+ */
 export function detectCloudConflict(
   existingCloudSavedAt: string | null,
   baseSavedAt: string | null,
   forcePush: boolean,
+  cloudDocVersion?: number | null,
+  baseDocVersion?: number | null,
 ): boolean {
   if (forcePush) {
     return false;
   }
+
+  // Prefer docVersion-based comparison when both sides provide it
+  if (cloudDocVersion != null && baseDocVersion != null) {
+    return cloudDocVersion !== baseDocVersion;
+  }
+
+  // Fallback to savedAt timestamp comparison
   if (!existingCloudSavedAt || !baseSavedAt) {
     return false;
   }
@@ -28,8 +46,60 @@ export function detectCloudConflict(
 }
 
 // ---------------------------------------------------------------------------
+// Retry helper — exponential backoff
+// ---------------------------------------------------------------------------
+
+export interface RetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+const DEFAULT_RETRY: Required<RetryOptions> = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 30000,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry an async function with exponential backoff.
+ * Does NOT retry on conflict (409-like) errors — only on transient failures.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  isRetryable: (error: unknown) => boolean,
+  opts?: RetryOptions,
+): Promise<T> {
+  const { maxRetries, initialDelayMs, maxDelayMs } = { ...DEFAULT_RETRY, ...opts };
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= maxRetries || !isRetryable(err)) {
+        throw err;
+      }
+      const delay = Math.min(initialDelayMs * Math.pow(2, attempt), maxDelayMs);
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}
+
+// ---------------------------------------------------------------------------
 // FileTransport — file-based cloud sync (existing behaviour, now a class)
 // ---------------------------------------------------------------------------
+
+interface FileDoc extends SavedDoc {
+  docVersion?: number;
+}
 
 export class FileTransport implements CloudSyncTransport {
   readonly mode = "file-mirror";
@@ -45,22 +115,28 @@ export class FileTransport implements CloudSyncTransport {
     return path.join(this.dir, `${safeId}.json`);
   }
 
-  private readDoc(filePath: string): SavedDoc | null {
+  private readDoc(filePath: string): FileDoc | null {
     if (!fs.existsSync(filePath)) {
       return null;
     }
-    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as SavedDoc;
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as FileDoc;
     if (!parsed || parsed.version !== 1 || !parsed.state) {
       return null;
     }
     return parsed;
   }
 
-  async push(docId: string, doc: SavedDoc, baseSavedAt: string | null, force: boolean): Promise<PushResult> {
+  async push(docId: string, doc: SavedDoc, baseSavedAt: string | null, force: boolean, baseDocVersion?: number | null): Promise<PushResult> {
     const filePath = this.docPath(docId);
     const existing = this.readDoc(filePath);
 
-    if (detectCloudConflict(existing?.savedAt ?? null, baseSavedAt, force)) {
+    if (detectCloudConflict(
+      existing?.savedAt ?? null,
+      baseSavedAt,
+      force,
+      existing?.docVersion ?? null,
+      baseDocVersion ?? null,
+    )) {
       return {
         ok: false,
         savedAt: existing?.savedAt ?? "",
@@ -68,14 +144,20 @@ export class FileTransport implements CloudSyncTransport {
         forced: false,
         conflict: true,
         cloudSavedAt: existing?.savedAt ?? null,
+        cloudDocVersion: existing?.docVersion ?? undefined,
+        remoteState: existing?.state ?? undefined,
         error: "Cloud conflict detected.",
       };
     }
 
-    const payload: SavedDoc = {
+    // Increment docVersion: if existing has one, increment it; otherwise start at 1
+    const nextDocVersion = (existing?.docVersion ?? 0) + 1;
+
+    const payload: FileDoc = {
       version: 1,
       savedAt: doc.savedAt || new Date().toISOString(),
       state: doc.state,
+      docVersion: nextDocVersion,
     };
     fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf8");
     return {
@@ -83,6 +165,7 @@ export class FileTransport implements CloudSyncTransport {
       savedAt: payload.savedAt,
       documentId: docId,
       forced: force,
+      cloudDocVersion: nextDocVersion,
     };
   }
 
@@ -99,7 +182,7 @@ export class FileTransport implements CloudSyncTransport {
       };
     }
 
-    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as SavedDoc;
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as FileDoc;
     if (!parsed || parsed.version !== 1 || !parsed.state) {
       return {
         ok: false,
@@ -117,6 +200,7 @@ export class FileTransport implements CloudSyncTransport {
       savedAt: parsed.savedAt || fs.statSync(filePath).mtime.toISOString(),
       state: parsed.state,
       documentId: docId,
+      docVersion: parsed.docVersion ?? undefined,
     };
   }
 
@@ -131,6 +215,7 @@ export class FileTransport implements CloudSyncTransport {
       documentId: docId,
       exists,
       cloudSavedAt: cloudDoc?.savedAt ?? null,
+      cloudDocVersion: cloudDoc?.docVersion ?? null,
       lastSyncedAt: exists ? fs.statSync(filePath).mtime.toISOString() : null,
     };
   }
@@ -147,6 +232,7 @@ export class FileTransport implements CloudSyncTransport {
 interface SupabaseRow {
   id: string;
   version: number;
+  doc_version: number;
   saved_at: string;
   state: Record<string, unknown>;
   created_at?: string;
@@ -198,29 +284,37 @@ export class SupabaseTransport implements CloudSyncTransport {
     return this.client;
   }
 
-  async push(docId: string, doc: SavedDoc, baseSavedAt: string | null, force: boolean): Promise<PushResult> {
+  async push(docId: string, doc: SavedDoc, baseSavedAt: string | null, force: boolean, baseDocVersion?: number | null): Promise<PushResult> {
     const client = await this.getClient();
     const savedAt = doc.savedAt || new Date().toISOString();
 
-    // Check for conflict if not forcing
-    if (!force && baseSavedAt) {
-      const { data: existing, error: fetchErr } = await client
-        .from(this.tableName)
-        .select("saved_at")
-        .eq("id", docId)
-        .maybeSingle();
+    // Fetch existing for conflict check and version increment
+    const { data: existing, error: fetchErr } = await client
+      .from(this.tableName)
+      .select("saved_at,doc_version,state")
+      .eq("id", docId)
+      .maybeSingle();
 
-      if (fetchErr) {
-        return {
-          ok: false,
-          savedAt: "",
-          documentId: docId,
-          forced: false,
-          error: `Supabase fetch error: ${fetchErr.message}`,
-        };
-      }
+    if (fetchErr) {
+      return {
+        ok: false,
+        savedAt: "",
+        documentId: docId,
+        forced: false,
+        error: `Supabase fetch error: ${fetchErr.message}`,
+      };
+    }
 
-      if (existing && detectCloudConflict(existing.saved_at, baseSavedAt, false)) {
+    // Conflict check (unless forcing)
+    if (!force && existing) {
+      const hasConflict = detectCloudConflict(
+        existing.saved_at,
+        baseSavedAt,
+        false,
+        existing.doc_version ?? null,
+        baseDocVersion ?? null,
+      );
+      if (hasConflict) {
         return {
           ok: false,
           savedAt: existing.saved_at,
@@ -228,10 +322,15 @@ export class SupabaseTransport implements CloudSyncTransport {
           forced: false,
           conflict: true,
           cloudSavedAt: existing.saved_at,
+          cloudDocVersion: existing.doc_version ?? undefined,
+          remoteState: existing.state as unknown as AppState,
           error: "Cloud conflict detected.",
         };
       }
     }
+
+    // Increment docVersion
+    const nextDocVersion = ((existing?.doc_version as number) ?? 0) + 1;
 
     // Upsert the document
     const { error: upsertErr } = await client
@@ -240,6 +339,7 @@ export class SupabaseTransport implements CloudSyncTransport {
         {
           id: docId,
           version: doc.version,
+          doc_version: nextDocVersion,
           saved_at: savedAt,
           state: doc.state as unknown as Record<string, unknown>,
           updated_at: new Date().toISOString(),
@@ -264,6 +364,7 @@ export class SupabaseTransport implements CloudSyncTransport {
       savedAt,
       documentId: docId,
       forced: force,
+      cloudDocVersion: nextDocVersion,
     };
   }
 
@@ -304,6 +405,7 @@ export class SupabaseTransport implements CloudSyncTransport {
       savedAt: data.saved_at,
       state: data.state as unknown as AppState,
       documentId: docId,
+      docVersion: data.doc_version ?? undefined,
     };
   }
 
@@ -312,7 +414,7 @@ export class SupabaseTransport implements CloudSyncTransport {
 
     const { data, error } = await client
       .from(this.tableName)
-      .select("saved_at")
+      .select("saved_at,doc_version")
       .eq("id", docId)
       .maybeSingle();
 
@@ -335,6 +437,7 @@ export class SupabaseTransport implements CloudSyncTransport {
       documentId: docId,
       exists: !!data,
       cloudSavedAt: data?.saved_at ?? null,
+      cloudDocVersion: data?.doc_version ?? null,
       lastSyncedAt: data?.saved_at ?? null,
     };
   }
@@ -347,12 +450,17 @@ export class SupabaseTransport implements CloudSyncTransport {
 export interface CloudSyncConfig {
   enabled: boolean;
   transport: CloudSyncTransport | null;
+  autoSync: boolean;
+  autoSyncIntervalMs: number;
 }
 
 export function loadCloudSyncConfig(): CloudSyncConfig {
   const enabled = process.env.M3E_CLOUD_SYNC === "1";
+  const autoSync = process.env.M3E_AUTO_SYNC === "1";
+  const autoSyncIntervalMs = Number(process.env.M3E_AUTO_SYNC_INTERVAL_MS) || 30000;
+
   if (!enabled) {
-    return { enabled: false, transport: null };
+    return { enabled: false, transport: null, autoSync: false, autoSyncIntervalMs };
   }
 
   const transportType = (process.env.M3E_CLOUD_TRANSPORT || "file").toLowerCase();
@@ -364,14 +472,182 @@ export function loadCloudSyncConfig(): CloudSyncConfig {
       console.warn(
         "[cloud_sync] M3E_CLOUD_TRANSPORT=supabase but M3E_SUPABASE_URL or M3E_SUPABASE_ANON_KEY is missing. Falling back to disabled.",
       );
-      return { enabled: false, transport: null };
+      return { enabled: false, transport: null, autoSync: false, autoSyncIntervalMs };
     }
-    return { enabled: true, transport: new SupabaseTransport(url, anonKey) };
+    return { enabled: true, transport: new SupabaseTransport(url, anonKey), autoSync, autoSyncIntervalMs };
   }
 
   // Default: file transport
   const dir = process.env.M3E_CLOUD_DIR
     ? path.resolve(process.env.M3E_CLOUD_DIR)
     : path.join(process.env.M3E_DATA_DIR || ".", "cloud-sync");
-  return { enabled: true, transport: new FileTransport(dir) };
+  return { enabled: true, transport: new FileTransport(dir), autoSync, autoSyncIntervalMs };
+}
+
+// ---------------------------------------------------------------------------
+// Auto Sync — periodic push with debounce
+// ---------------------------------------------------------------------------
+
+export interface AutoSyncHandle {
+  stop(): void;
+  /** Force an immediate push (resets the interval timer). */
+  triggerNow(): void;
+}
+
+export interface AutoSyncCallbacks {
+  /** Return the current local state to be pushed. */
+  getLocalState: () => Promise<SavedDoc | null>;
+  /** Return the current document ID. */
+  getDocId: () => string;
+  /** Return the current baseSavedAt for conflict detection. */
+  getBaseSavedAt: () => string | null;
+  /** Return the current baseDocVersion for conflict detection. */
+  getBaseDocVersion: () => number | null;
+  /** Called when a push succeeds. */
+  onPushSuccess?: (result: PushResult) => void;
+  /** Called when a push fails with conflict. */
+  onConflict?: (result: PushResult) => void;
+  /** Called when a push fails with non-conflict error. */
+  onError?: (error: string) => void;
+  /** Called when initial pull succeeds. */
+  onPullSuccess?: (result: PullResult) => void;
+  /** Data directory for conflict backups. */
+  dataDir?: string;
+}
+
+/**
+ * Start automatic sync: pull on startup, then push at regular intervals.
+ */
+export function startAutoSync(
+  transport: CloudSyncTransport,
+  intervalMs: number,
+  callbacks: AutoSyncCallbacks,
+): AutoSyncHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  const doPush = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      const doc = await callbacks.getLocalState();
+      if (!doc) return;
+
+      const docId = callbacks.getDocId();
+      const baseSavedAt = callbacks.getBaseSavedAt();
+      const baseDocVersion = callbacks.getBaseDocVersion();
+
+      const result = await withRetry(
+        () => transport.push(docId, doc, baseSavedAt, false, baseDocVersion),
+        (err) => {
+          const msg = (err as Error)?.message ?? "";
+          // Do not retry conflicts
+          return !msg.includes("conflict") && !msg.includes("Conflict");
+        },
+      );
+
+      if (result.ok) {
+        callbacks.onPushSuccess?.(result);
+      } else if (result.conflict) {
+        // Create conflict backup before notifying
+        if (callbacks.dataDir) {
+          createConflictBackup(
+            callbacks.dataDir,
+            callbacks.getDocId(),
+            doc.state,
+            "auto-sync conflict",
+          );
+        }
+        callbacks.onConflict?.(result);
+      } else {
+        callbacks.onError?.(result.error || "Push failed.");
+      }
+    } catch (err) {
+      callbacks.onError?.((err as Error).message || "Auto-sync push error.");
+    }
+  };
+
+  // Initial pull on startup
+  const initialPull = async (): Promise<void> => {
+    try {
+      const docId = callbacks.getDocId();
+      const result = await withRetry(
+        () => transport.pull(docId),
+        () => true, // retry all transient errors on pull
+      );
+      if (result.ok) {
+        callbacks.onPullSuccess?.(result);
+      }
+    } catch (err) {
+      callbacks.onError?.(`Initial pull failed: ${(err as Error).message}`);
+    }
+  };
+
+  // Start: pull first, then begin periodic push
+  initialPull().then(() => {
+    if (stopped) return;
+    timer = setInterval(doPush, intervalMs);
+  });
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    triggerNow() {
+      // Reset timer and push immediately
+      if (timer) {
+        clearInterval(timer);
+      }
+      doPush().then(() => {
+        if (!stopped) {
+          timer = setInterval(doPush, intervalMs);
+        }
+      });
+    },
+  };
+}
+
+/**
+ * Stop auto sync.
+ */
+export function stopAutoSync(handle: AutoSyncHandle): void {
+  handle.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Push with conflict backup — convenience wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Push with automatic conflict backup creation.
+ * When push returns a conflict (409), saves the local state as a backup
+ * and returns the conflict result with remoteState for the caller to
+ * decide how to proceed.
+ */
+export async function pushWithConflictBackup(
+  transport: CloudSyncTransport,
+  docId: string,
+  doc: SavedDoc,
+  baseSavedAt: string | null,
+  force: boolean,
+  dataDir: string,
+  baseDocVersion?: number | null,
+): Promise<PushResult> {
+  const result = await withRetry(
+    () => transport.push(docId, doc, baseSavedAt, force, baseDocVersion),
+    (err) => {
+      const msg = (err as Error)?.message ?? "";
+      return !msg.includes("conflict") && !msg.includes("Conflict");
+    },
+  );
+
+  if (!result.ok && result.conflict) {
+    // Save local state as conflict backup before caller pulls remote
+    createConflictBackup(dataDir, docId, doc.state, "cloud-conflict-push");
+  }
+
+  return result;
 }

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -6,7 +6,7 @@ import path from "path";
 import http from "http";
 import { spawnSync, exec } from "child_process";
 import { RapidMvpModel } from "./rapid_mvp";
-import { detectCloudConflict, loadCloudSyncConfig } from "./cloud_sync";
+import { loadCloudSyncConfig, pushWithConflictBackup, startAutoSync, type AutoSyncHandle } from "./cloud_sync";
 import type { CloudSyncTransport } from "../shared/types";
 import { createBackup, pruneOldBackups, startAutoBackup } from "./backup";
 import {
@@ -53,6 +53,7 @@ const TUTORIAL_SCOPE_ID = "n_1775650869381_rns0cp";
 const cloudSyncConfig = loadCloudSyncConfig();
 const CLOUD_SYNC_ENABLED = cloudSyncConfig.enabled;
 let cloudTransport: CloudSyncTransport | null = cloudSyncConfig.transport;
+let autoSyncHandle: AutoSyncHandle | null = null;
 
 // ---------------------------------------------------------------------------
 // Doc-watch SSE (standalone, independent of collab SSE)
@@ -221,6 +222,84 @@ function parseSyncRoute(urlPath: string): { action: "status" | "push" | "pull"; 
   };
 }
 
+function parseBackupRoute(urlPath: string): { docId: string; backupId?: string; action?: "restore" } | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  // /api/sync/backups/{docId}/restore/{backupId}
+  const restoreMatch = pathname.match(/^\/api\/sync\/backups\/([^/]+)\/restore\/([^/]+)$/);
+  if (restoreMatch) {
+    return { docId: decodeURIComponent(restoreMatch[1]), backupId: decodeURIComponent(restoreMatch[2]), action: "restore" };
+  }
+  // /api/sync/backups/{docId}/{backupId}
+  const singleMatch = pathname.match(/^\/api\/sync\/backups\/([^/]+)\/([^/]+)$/);
+  if (singleMatch) {
+    return { docId: decodeURIComponent(singleMatch[1]), backupId: decodeURIComponent(singleMatch[2]) };
+  }
+  // /api/sync/backups/{docId}
+  const listMatch = pathname.match(/^\/api\/sync\/backups\/([^/]+)$/);
+  if (listMatch) {
+    return { docId: decodeURIComponent(listMatch[1]) };
+  }
+  return null;
+}
+
+async function handleBackupApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: { docId: string; backupId?: string; action?: "restore" },
+): Promise<void> {
+  // Restore endpoint
+  if (route.action === "restore" && route.backupId) {
+    if (req.method !== "POST") {
+      sendJson(res, 405, { ok: false, error: "Method not allowed." });
+      return;
+    }
+    const backup = getConflictBackup(DATA_DIR, route.docId, route.backupId);
+    if (!backup) {
+      sendJson(res, 404, { ok: false, error: "Backup not found." });
+      return;
+    }
+    // Save the backup state to SQLite
+    const model = RapidMvpModel.fromJSON(backup.state as never);
+    const errors = model.validate();
+    if (errors.length > 0) {
+      sendJson(res, 400, { ok: false, error: `Invalid backup state: ${errors.join(" | ")}` });
+      return;
+    }
+    model.saveToSqlite(SQLITE_DB_PATH, route.docId);
+    const savedAt = new Date().toISOString();
+    sendJson(res, 200, { ok: true, restored: true, backupId: route.backupId, documentId: route.docId, savedAt });
+    return;
+  }
+
+  // Single backup get/delete
+  if (route.backupId) {
+    if (req.method === "GET") {
+      const backup = getConflictBackup(DATA_DIR, route.docId, route.backupId);
+      if (!backup) {
+        sendJson(res, 404, { ok: false, error: "Backup not found." });
+        return;
+      }
+      sendJson(res, 200, { ok: true, backup });
+      return;
+    }
+    if (req.method === "DELETE") {
+      const deleted = deleteConflictBackup(DATA_DIR, route.docId, route.backupId);
+      sendJson(res, deleted ? 200 : 404, { ok: deleted, deleted, ...(deleted ? {} : { error: "Backup not found." }) });
+      return;
+    }
+    sendJson(res, 405, { ok: false, error: "Method not allowed." });
+    return;
+  }
+
+  // List backups
+  if (req.method !== "GET") {
+    sendJson(res, 405, { ok: false, error: "Method not allowed." });
+    return;
+  }
+  const backups = listConflictBackups(DATA_DIR, route.docId);
+  sendJson(res, 200, { ok: true, documentId: route.docId, backups });
+}
+
 function isLinearTransformRoute(urlPath: string): boolean {
   const pathname = new URL(urlPath, "http://localhost").pathname;
   return pathname === "/api/linear-transform/status" || pathname === "/api/linear-transform/convert";
@@ -362,9 +441,24 @@ async function handleSyncApi(
 
   if (route.action === "pull" && req.method === "POST") {
     try {
+      // Parse body to check for localState (for conflict backup)
+      let localState: AppState | null = null;
+      try {
+        const rawBody = await readRequestBody(req);
+        const body = JSON.parse(rawBody) as { localState?: AppState };
+        if (body.localState && typeof body.localState === "object") {
+          localState = body.localState;
+        }
+      } catch {
+        // Empty or invalid body is fine for pull
+      }
+
       const result = await transport.pull(route.docId);
       if (!result.ok) {
-        sendSyncError(res, 404, "SYNC_CLOUD_NOT_FOUND", result.error || "Cloud document not found.", route.docId);
+        const isUnsupported = result.error?.includes("unsupported");
+        const statusCode = isUnsupported ? 400 : 404;
+        const code = isUnsupported ? "SYNC_CLOUD_UNSUPPORTED_FORMAT" : "SYNC_CLOUD_NOT_FOUND";
+        sendSyncError(res, statusCode, code, result.error || "Cloud document not found.", route.docId);
         return true;
       }
       const model = RapidMvpModel.fromJSON(result.state);
@@ -373,6 +467,14 @@ async function handleSyncApi(
         sendSyncError(res, 400, "SYNC_CLOUD_INVALID_MODEL", `Cloud document is invalid: ${errors.join(" | ")}`, route.docId);
         return true;
       }
+
+      // Create conflict backup of local state if provided
+      let backup: { backupId: string; reason: string; createdAt: string } | undefined;
+      if (localState) {
+        const entry = createConflictBackup(DATA_DIR, route.docId, localState, "cloud-sync-pull");
+        backup = { backupId: entry.backupId, reason: entry.reason, createdAt: entry.createdAt };
+      }
+
       sendJson(res, 200, {
         ok: true,
         mode: modeLabel,
@@ -380,6 +482,8 @@ async function handleSyncApi(
         savedAt: result.savedAt,
         state: model.toJSON(),
         documentId: route.docId,
+        docVersion: result.docVersion ?? undefined,
+        ...(backup ? { backup } : {}),
       });
     } catch (err) {
       sendSyncError(res, 500, "SYNC_PULL_FAILED", (err as Error).message || "Cloud pull failed.", route.docId);
@@ -390,7 +494,7 @@ async function handleSyncApi(
   if (route.action === "push" && req.method === "POST") {
     try {
       const rawBody = await readRequestBody(req);
-      const parsed = JSON.parse(rawBody) as { state?: unknown; savedAt?: string; baseSavedAt?: string | null; force?: boolean };
+      const parsed = JSON.parse(rawBody) as { state?: unknown; savedAt?: string; baseSavedAt?: string | null; baseDocVersion?: number | null; force?: boolean };
       const candidate = parsed && parsed.state ? parsed : { state: parsed, savedAt: new Date().toISOString() };
       if (!candidate.state || typeof candidate.state !== "object") {
         sendSyncError(res, 400, "SYNC_INVALID_JSON_FORMAT", "Invalid JSON format.", route.docId);
@@ -413,10 +517,37 @@ async function handleSyncApi(
         savedAt: String(candidate.savedAt || new Date().toISOString()),
         state: model.toJSON(),
       };
-      const result = await transport.push(route.docId, payload, parsed.baseSavedAt ?? null, Boolean(parsed.force));
+      // Use pushWithConflictBackup for automatic conflict backup creation
+      const result = await pushWithConflictBackup(
+        transport,
+        route.docId,
+        payload,
+        parsed.baseSavedAt ?? null,
+        Boolean(parsed.force),
+        DATA_DIR,
+        parsed.baseDocVersion ?? null,
+      );
       if (!result.ok) {
-        const statusCode = result.error?.includes("conflict") || result.error?.includes("Conflict") ? 409 : 500;
-        sendSyncError(res, statusCode, "SYNC_PUSH_FAILED", result.error || "Cloud push failed.", route.docId);
+        const statusCode = result.conflict ? 409 : 500;
+        const code = result.conflict ? "CLOUD_CONFLICT" : "SYNC_PUSH_FAILED";
+        const extra: Record<string, unknown> = {};
+        if (result.conflict) {
+          extra.cloudSavedAt = result.cloudSavedAt ?? null;
+          extra.cloudDocVersion = result.cloudDocVersion ?? null;
+          if (result.remoteState) {
+            extra.remoteState = result.remoteState;
+          }
+          // pushWithConflictBackup already created a backup; list the latest one
+          const backups = listConflictBackups(DATA_DIR, route.docId);
+          if (backups.length > 0) {
+            extra.backup = {
+              backupId: backups[0].backupId,
+              reason: backups[0].reason,
+              createdAt: backups[0].createdAt,
+            };
+          }
+        }
+        sendSyncError(res, statusCode, code, result.error || "Cloud push failed.", route.docId, extra);
         return true;
       }
       sendJson(res, 200, {
@@ -425,6 +556,7 @@ async function handleSyncApi(
         savedAt: result.savedAt,
         documentId: route.docId,
         forced: result.forced,
+        docVersion: result.cloudDocVersion ?? undefined,
       });
     } catch (err) {
       if (err instanceof SyntaxError) {
@@ -628,6 +760,41 @@ function startServer(): void {
         .catch((err) => { console.error(`[backup] Startup backup failed: ${(err as Error).message}`); });
       startAutoBackup(SQLITE_DB_PATH, BACKUP_DIR);
     }
+    // Auto sync setup
+    if (cloudSyncConfig.autoSync && cloudTransport) {
+      autoSyncHandle = startAutoSync(cloudTransport, cloudSyncConfig.autoSyncIntervalMs, {
+        getLocalState: async () => {
+          try {
+            const model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, "rapid-main");
+            return {
+              version: 1,
+              savedAt: new Date().toISOString(),
+              state: model.toJSON(),
+            };
+          } catch {
+            return null;
+          }
+        },
+        getDocId: () => "rapid-main",
+        getBaseSavedAt: () => null,
+        getBaseDocVersion: () => null,
+        onPushSuccess: (result) => {
+          console.log(`[auto-sync] Push succeeded: docVersion=${result.cloudDocVersion ?? "?"}`);
+        },
+        onConflict: (result) => {
+          console.warn(`[auto-sync] Conflict detected: cloudDocVersion=${result.cloudDocVersion ?? "?"}`);
+        },
+        onError: (error) => {
+          console.error(`[auto-sync] Error: ${error}`);
+        },
+        onPullSuccess: (result) => {
+          console.log(`[auto-sync] Initial pull succeeded: docVersion=${result.docVersion ?? "?"}`);
+        },
+        dataDir: DATA_DIR,
+      });
+      console.log(`[auto-sync] Started with interval ${cloudSyncConfig.autoSyncIntervalMs}ms`);
+    }
+
     console.log("Press Ctrl+C to stop the server.");
 
     // Keep SSE connections alive through proxies
@@ -809,6 +976,12 @@ export function createAppServer(): http.Server {
 
     if (isLinearTransformRoute(req.url ?? "/")) {
       await handleLinearTransformApi(req, res);
+      return;
+    }
+
+    const backupRoute = parseBackupRoute(req.url ?? "/");
+    if (backupRoute) {
+      await handleBackupApi(req, res, backupRoute);
       return;
     }
 

--- a/beta/src/shared/types.ts
+++ b/beta/src/shared/types.ts
@@ -45,6 +45,7 @@ export interface SavedDoc {
   version: 1;
   savedAt: string;
   state: AppState;
+  docVersion?: number;
 }
 
 export type LinearTransformDirection = "tree-to-linear" | "linear-to-tree";
@@ -117,6 +118,8 @@ export interface PushResult {
   forced: boolean;
   conflict?: boolean;
   cloudSavedAt?: string | null;
+  cloudDocVersion?: number;
+  remoteState?: AppState;
   error?: string;
 }
 
@@ -126,6 +129,7 @@ export interface PullResult {
   savedAt: string;
   state: AppState;
   documentId: string;
+  docVersion?: number;
   error?: string;
 }
 
@@ -136,12 +140,13 @@ export interface SyncStatus {
   documentId: string;
   exists: boolean;
   cloudSavedAt: string | null;
+  cloudDocVersion?: number | null;
   lastSyncedAt: string | null;
 }
 
 export interface CloudSyncTransport {
   readonly mode: string;
-  push(docId: string, doc: SavedDoc, baseSavedAt: string | null, force: boolean): Promise<PushResult>;
+  push(docId: string, doc: SavedDoc, baseSavedAt: string | null, force: boolean, baseDocVersion?: number | null): Promise<PushResult>;
   pull(docId: string): Promise<PullResult>;
   status(docId: string): Promise<SyncStatus>;
 }

--- a/beta/tests/unit/cloud_sync_transport.test.js
+++ b/beta/tests/unit/cloud_sync_transport.test.js
@@ -4,7 +4,7 @@ const os = require("node:os");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const { FileTransport, HttpTransport, SupabaseTransport, createTransport, loadCloudSyncConfig, detectCloudConflict } = require("../../dist/node/cloud_sync.js");
+const { FileTransport, SupabaseTransport, loadCloudSyncConfig, detectCloudConflict, withRetry } = require("../../dist/node/cloud_sync.js");
 const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
 
 function createSavedDoc(label, savedAt) {
@@ -27,10 +27,12 @@ test("FileTransport: push and pull round-trip", async () => {
     const transport = new FileTransport(dir);
     const doc = createSavedDoc("A", "2026-04-09T00:00:00.000Z");
 
-    const pushResult = await transport.push("doc1", doc);
+    const pushResult = await transport.push("doc1", doc, null, false);
     assert.equal(pushResult.ok, true);
     assert.equal(pushResult.savedAt, "2026-04-09T00:00:00.000Z");
     assert.equal(pushResult.forced, false);
+    assert.equal(typeof pushResult.cloudDocVersion, "number");
+    assert.equal(pushResult.cloudDocVersion, 1);
 
     const pullResult = await transport.pull("doc1");
     assert.equal(pullResult.ok, true);
@@ -38,6 +40,7 @@ test("FileTransport: push and pull round-trip", async () => {
     assert.equal(pullResult.savedAt, "2026-04-09T00:00:00.000Z");
     assert.ok(pullResult.state.rootId);
     assert.ok(Object.keys(pullResult.state.nodes).length > 0);
+    assert.equal(pullResult.docVersion, 1);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -50,7 +53,7 @@ test("FileTransport: status returns exists=false for missing doc", async () => {
     const result = await transport.status("nonexistent");
     assert.equal(result.ok, true);
     assert.equal(result.enabled, true);
-    assert.equal(result.mode, "file");
+    assert.equal(result.mode, "file-mirror");
     assert.equal(result.documentId, "nonexistent");
     assert.equal(result.exists, false);
     assert.equal(result.cloudSavedAt, null);
@@ -65,34 +68,60 @@ test("FileTransport: status returns exists=true after push", async () => {
   try {
     const transport = new FileTransport(dir);
     const doc = createSavedDoc("B", "2026-04-09T01:00:00.000Z");
-    await transport.push("doc2", doc);
+    await transport.push("doc2", doc, null, false);
 
     const result = await transport.status("doc2");
     assert.equal(result.ok, true);
     assert.equal(result.exists, true);
     assert.equal(result.cloudSavedAt, "2026-04-09T01:00:00.000Z");
     assert.ok(result.lastSyncedAt);
+    assert.equal(result.cloudDocVersion, 1);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("FileTransport: push detects conflict", async () => {
+test("FileTransport: push detects conflict via docVersion", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
   try {
     const transport = new FileTransport(dir);
     const doc1 = createSavedDoc("V1", "2026-04-09T00:00:00.000Z");
-    await transport.push("doc3", doc1);
+    const push1 = await transport.push("doc3", doc1, null, false);
+    assert.equal(push1.cloudDocVersion, 1);
 
-    // Update the doc
+    // Update the doc with correct base version
     const doc2 = createSavedDoc("V2", "2026-04-09T00:00:10.000Z");
-    await transport.push("doc3", doc2, { baseSavedAt: "2026-04-09T00:00:00.000Z" });
+    const push2 = await transport.push("doc3", doc2, push1.savedAt, false, push1.cloudDocVersion);
+    assert.equal(push2.ok, true);
+    assert.equal(push2.cloudDocVersion, 2);
 
-    // Conflict: stale baseSavedAt
+    // Conflict: stale baseDocVersion
     const doc3 = createSavedDoc("V3", "2026-04-09T00:00:20.000Z");
-    const result = await transport.push("doc3", doc3, { baseSavedAt: "2026-04-09T00:00:00.000Z" });
+    const result = await transport.push("doc3", doc3, push1.savedAt, false, push1.cloudDocVersion);
     assert.equal(result.ok, false);
-    assert.equal(result.code, "CLOUD_CONFLICT");
+    assert.equal(result.conflict, true);
+    assert.equal(result.cloudDocVersion, 2);
+    assert.ok(result.remoteState);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("FileTransport: push detects conflict via savedAt fallback", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const doc1 = createSavedDoc("V1", "2026-04-09T00:00:00.000Z");
+    await transport.push("doc3b", doc1, null, false);
+
+    const doc2 = createSavedDoc("V2", "2026-04-09T00:00:10.000Z");
+    await transport.push("doc3b", doc2, "2026-04-09T00:00:00.000Z", false);
+
+    // Conflict: stale baseSavedAt (no docVersion provided)
+    const doc3 = createSavedDoc("V3", "2026-04-09T00:00:20.000Z");
+    const result = await transport.push("doc3b", doc3, "2026-04-09T00:00:00.000Z", false);
+    assert.equal(result.ok, false);
+    assert.equal(result.conflict, true);
     assert.equal(result.cloudSavedAt, "2026-04-09T00:00:10.000Z");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -104,14 +133,14 @@ test("FileTransport: force push overrides conflict", async () => {
   try {
     const transport = new FileTransport(dir);
     const doc1 = createSavedDoc("V1", "2026-04-09T00:00:00.000Z");
-    await transport.push("doc4", doc1);
+    await transport.push("doc4", doc1, null, false);
 
     const doc2 = createSavedDoc("V2", "2026-04-09T00:00:10.000Z");
-    await transport.push("doc4", doc2, { baseSavedAt: "2026-04-09T00:00:00.000Z" });
+    await transport.push("doc4", doc2, "2026-04-09T00:00:00.000Z", false);
 
     // Force push with stale baseSavedAt
     const doc3 = createSavedDoc("Forced", "2026-04-09T00:00:30.000Z");
-    const result = await transport.push("doc4", doc3, { baseSavedAt: "2026-04-09T00:00:00.000Z", force: true });
+    const result = await transport.push("doc4", doc3, "2026-04-09T00:00:00.000Z", true);
     assert.equal(result.ok, true);
     assert.equal(result.forced, true);
 
@@ -130,7 +159,7 @@ test("FileTransport: pull returns error for missing doc", async () => {
     const transport = new FileTransport(dir);
     const result = await transport.pull("missing");
     assert.equal(result.ok, false);
-    assert.equal(result.code, "SYNC_CLOUD_NOT_FOUND");
+    assert.ok(result.error.includes("not found"));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -145,7 +174,7 @@ test("FileTransport: pull returns error for unsupported format", async () => {
 
     const result = await transport.pull("bad-format");
     assert.equal(result.ok, false);
-    assert.equal(result.code, "SYNC_CLOUD_UNSUPPORTED_FORMAT");
+    assert.ok(result.error.includes("unsupported"));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -164,57 +193,41 @@ test("FileTransport: creates cloud dir if it does not exist", async () => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// Stub transport tests
-// ---------------------------------------------------------------------------
+test("FileTransport: docVersion increments on each push", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-ft-"));
+  try {
+    const transport = new FileTransport(dir);
+    const doc1 = createSavedDoc("A", "2026-04-09T00:00:00.000Z");
+    const push1 = await transport.push("ver-test", doc1, null, false);
+    assert.equal(push1.cloudDocVersion, 1);
 
-test("HttpTransport: methods throw not-implemented", async () => {
-  const transport = new HttpTransport("https://example.com/sync");
-  await assert.rejects(() => transport.push("x", createSavedDoc()), /not implemented/);
-  await assert.rejects(() => transport.pull("x"), /not implemented/);
-  await assert.rejects(() => transport.status("x"), /not implemented/);
-});
+    const doc2 = createSavedDoc("B", "2026-04-09T00:00:10.000Z");
+    const push2 = await transport.push("ver-test", doc2, push1.savedAt, false, push1.cloudDocVersion);
+    assert.equal(push2.cloudDocVersion, 2);
 
-test("SupabaseTransport: methods throw not-implemented", async () => {
-  const transport = new SupabaseTransport("https://example.supabase.co");
-  await assert.rejects(() => transport.push("x", createSavedDoc()), /not implemented/);
-  await assert.rejects(() => transport.pull("x"), /not implemented/);
-  await assert.rejects(() => transport.status("x"), /not implemented/);
-});
-
-// ---------------------------------------------------------------------------
-// createTransport factory tests
-// ---------------------------------------------------------------------------
-
-test("createTransport returns FileTransport for file config", () => {
-  const transport = createTransport({ enabled: true, transport: "file", cloudDir: "/tmp/test", endpoint: null });
-  assert.equal(transport.kind, "file");
-  assert.ok(transport instanceof FileTransport);
-});
-
-test("createTransport returns HttpTransport for http config", () => {
-  const transport = createTransport({ enabled: true, transport: "http", cloudDir: "", endpoint: "https://example.com" });
-  assert.equal(transport.kind, "http");
-  assert.ok(transport instanceof HttpTransport);
-});
-
-test("createTransport returns SupabaseTransport for supabase config", () => {
-  const transport = createTransport({ enabled: true, transport: "supabase", cloudDir: "", endpoint: "https://example.supabase.co" });
-  assert.equal(transport.kind, "supabase");
-  assert.ok(transport instanceof SupabaseTransport);
-});
-
-test("createTransport throws when http transport has no endpoint", () => {
-  assert.throws(() => createTransport({ enabled: true, transport: "http", cloudDir: "", endpoint: null }), /M3E_CLOUD_ENDPOINT is required/);
-});
-
-test("createTransport throws when file transport has no cloudDir", () => {
-  assert.throws(() => createTransport({ enabled: true, transport: "file", cloudDir: "", endpoint: null }), /M3E_CLOUD_DIR is required/);
+    const doc3 = createSavedDoc("C", "2026-04-09T00:00:20.000Z");
+    const push3 = await transport.push("ver-test", doc3, push2.savedAt, false, push2.cloudDocVersion);
+    assert.equal(push3.cloudDocVersion, 3);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------
-// detectCloudConflict backward compat
+// detectCloudConflict tests
 // ---------------------------------------------------------------------------
+
+test("detectCloudConflict: docVersion takes priority over savedAt", () => {
+  // docVersions match even though savedAt differ => no conflict
+  assert.equal(detectCloudConflict("2026-04-01", "2026-04-02", false, 5, 5), false);
+  // docVersions differ even though savedAt match => conflict
+  assert.equal(detectCloudConflict("2026-04-01", "2026-04-01", false, 6, 5), true);
+});
+
+test("detectCloudConflict: falls back to savedAt when docVersion not provided", () => {
+  assert.equal(detectCloudConflict("a", "b", false), true);
+  assert.equal(detectCloudConflict("a", "a", false), false);
+});
 
 test("detectCloudConflict still works after refactor", () => {
   assert.equal(detectCloudConflict("a", "b", false), true);
@@ -222,4 +235,60 @@ test("detectCloudConflict still works after refactor", () => {
   assert.equal(detectCloudConflict("a", "b", true), false);
   assert.equal(detectCloudConflict(null, "b", false), false);
   assert.equal(detectCloudConflict("a", null, false), false);
+});
+
+// ---------------------------------------------------------------------------
+// withRetry tests
+// ---------------------------------------------------------------------------
+
+test("withRetry: succeeds on first attempt", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => { calls++; return "ok"; },
+    () => true,
+    { maxRetries: 3, initialDelayMs: 1, maxDelayMs: 10 },
+  );
+  assert.equal(result, "ok");
+  assert.equal(calls, 1);
+});
+
+test("withRetry: retries on transient error and succeeds", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw new Error("transient");
+      return "recovered";
+    },
+    () => true,
+    { maxRetries: 3, initialDelayMs: 1, maxDelayMs: 10 },
+  );
+  assert.equal(result, "recovered");
+  assert.equal(calls, 3);
+});
+
+test("withRetry: does not retry non-retryable errors", async () => {
+  let calls = 0;
+  await assert.rejects(
+    () => withRetry(
+      async () => { calls++; throw new Error("conflict"); },
+      (err) => !err.message.includes("conflict"),
+      { maxRetries: 3, initialDelayMs: 1, maxDelayMs: 10 },
+    ),
+    /conflict/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("withRetry: throws after max retries", async () => {
+  let calls = 0;
+  await assert.rejects(
+    () => withRetry(
+      async () => { calls++; throw new Error("fail"); },
+      () => true,
+      { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 10 },
+    ),
+    /fail/,
+  );
+  assert.equal(calls, 3); // 1 initial + 2 retries
 });

--- a/dev-docs/03_Spec/REST_API.md
+++ b/dev-docs/03_Spec/REST_API.md
@@ -281,12 +281,18 @@ Body:
   "state": { ... },
   "savedAt": "2026-04-07T12:00:00.000Z",
   "baseSavedAt": "2026-04-07T10:00:00.000Z",
+  "baseDocVersion": 5,
   "force": false
 }
 ```
 
-- `baseSavedAt`: 楽観的競合検出の基準時刻（null 可）
+- `baseSavedAt`: 楽観的競合検出の基準時刻（null 可、`baseDocVersion` がある場合はフォールバック）
+- `baseDocVersion`: 楽観的競合検出の基準バージョン（単調増加整数、推奨）
 - `force`: `true` で競合を無視して上書き
+
+成功レスポンスには `docVersion`（push 後のバージョン番号）が含まれる。
+Conflict (409) レスポンスには `cloudDocVersion`、`cloudSavedAt`、`remoteState` が含まれ、
+ローカル state は自動的に conflict-backup に保存される。
 
 #### エラーコード
 
@@ -311,9 +317,12 @@ Body:
   "version": 1,
   "savedAt": "2026-04-07T10:00:00.000Z",
   "state": { ... },
-  "documentId": "rapid-main"
+  "documentId": "rapid-main",
+  "docVersion": 5
 }
 ```
+
+- `docVersion`: クラウド側の現在のドキュメントバージョン（単調増加整数）。次回 push 時に `baseDocVersion` として送信する。
 
 #### エラーコード
 

--- a/dev-docs/03_Spec/supabase_schema.sql
+++ b/dev-docs/03_Spec/supabase_schema.sql
@@ -9,6 +9,7 @@
 create table if not exists public.documents (
   id          text        primary key,
   version     int         not null default 1,
+  doc_version int         not null default 0,
   saved_at    timestamptz not null default now(),
   state       jsonb       not null,
   created_at  timestamptz not null default now(),
@@ -83,3 +84,15 @@ create trigger on_documents_update
 
 -- 5. Realtime publication (for future Supabase Realtime subscriptions)
 alter publication supabase_realtime add table public.documents;
+
+-- ==========================================================================
+-- Migration: add doc_version column (if upgrading from earlier schema)
+-- ==========================================================================
+-- Run this if you already have the documents table without doc_version:
+--
+--   alter table public.documents
+--     add column if not exists doc_version int not null default 0;
+--
+--   create index if not exists idx_documents_doc_version
+--     on public.documents (doc_version);
+-- ==========================================================================


### PR DESCRIPTION
## Summary

- **A. Conflict detection**: Replace `savedAt` timestamp-only comparison with `docVersion` (monotonic integer) as primary, keeping `savedAt` as backward-compatible fallback. Both FileTransport and SupabaseTransport now increment and track `docVersion`. Push conflict (409) responses include `cloudDocVersion`, `cloudSavedAt`, and `remoteState`.
- **B. Conflict backup wiring**: `pushWithConflictBackup()` automatically calls `createConflictBackup()` on conflict. Pull with `localState` body also creates a backup. Backup API endpoints added: `/api/sync/backups/{docId}` (list), `/{backupId}` (get/delete), `/restore/{backupId}` (restore to SQLite).
- **C. Auto sync foundation**: `startAutoSync(transport, intervalMs, callbacks)` / `stopAutoSync()` with initial pull on startup and periodic push. Enabled via `M3E_AUTO_SYNC=1`, interval via `M3E_AUTO_SYNC_INTERVAL_MS` (default 30s).
- **D. Retry with backoff**: `withRetry()` helper with exponential backoff (1s initial, 30s max, 3 retries). Does not retry conflicts, only transient failures.

### Files changed
- `beta/src/shared/types.ts` - Added `docVersion` to SavedDoc/PushResult/PullResult/SyncStatus, `baseDocVersion` to transport push signature
- `beta/src/node/cloud_sync.ts` - Rewrote with docVersion logic, retry, auto sync, pushWithConflictBackup
- `beta/src/node/start_viewer.ts` - Wired backup API, conflict backup on push/pull, auto sync startup
- `beta/tests/unit/cloud_sync_transport.test.js` - Updated tests for new API, added docVersion/retry/fallback tests
- `dev-docs/03_Spec/supabase_schema.sql` - Added `doc_version` column + migration note
- `dev-docs/03_Spec/REST_API.md` - Documented `baseDocVersion`, `docVersion` in push/pull

## Test plan
- [x] All 176 existing tests pass (1 pre-existing failure: mm_exporter.test.js missing vitest)
- [x] 30 cloud sync transport/conflict tests pass
- [x] 8 conflict backup API integration tests pass
- [x] TypeScript compiles cleanly (both node and browser configs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)