### PR TITLE
visual: entity list left sidebar, scope list, presence badges

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -45,6 +45,7 @@ const entityListPanelEl = document.getElementById("entity-list-panel") as HTMLEl
 const entityListTreeEl = document.getElementById("entity-list-tree") as HTMLElement | null;
 const entityListSearchEl = document.getElementById("entity-list-search") as HTMLInputElement | null;
 const entityListCloseBtn = document.getElementById("entity-list-close") as HTMLButtonElement | null;
+const entityScopeListEl = document.getElementById("entity-scope-list") as HTMLElement | null;
 const conflictPanelEl = document.getElementById("conflict-panel") as HTMLElement | null;
 const conflictLocalTreeEl = document.getElementById("conflict-local-tree") as HTMLElement | null;
 const conflictRemoteTreeEl = document.getElementById("conflict-remote-tree") as HTMLElement | null;
@@ -133,6 +134,9 @@ let linearAdjustMenuOpen = false;
 let linearMenuVisible = false;
 let homeScreenVisible = false;
 let entityListVisible = false;
+let presenceMap: Map<string, { userId: string; color: string; nodeId: string }[]> = new Map();
+let presenceEs: EventSource | null = null;
+let changedNodeIds: Set<string> = new Set();
 let conflictPanelVisible = false;
 let conflictRemoteState: AppState | null = null;
 const DRAG_CENTER_BAND_HALF = 20;
@@ -3187,6 +3191,8 @@ function buildEntityList(query = ""): void {
   const filtered = filterEntityTree(allNodes, query);
   const forceExpand = Boolean(query);
   renderEntityTree(entityListTreeEl, filtered, query, forceExpand);
+  applyPresenceBadges();
+  applyChangeHighlights();
 }
 
 function showEntityListPanel(): void {
@@ -3198,7 +3204,11 @@ function showEntityListPanel(): void {
   if (entityListSearchEl) {
     entityListSearchEl.value = "";
   }
+  buildEntityScopeList();
   buildEntityList();
+  startPresenceWatch();
+  applyPresenceBadges();
+  fetchChangedNodes();
 }
 
 function hideEntityListPanel(): void {
@@ -3207,6 +3217,7 @@ function hideEntityListPanel(): void {
   }
   entityListVisible = false;
   entityListPanelEl.hidden = true;
+  stopPresenceWatch();
   board.focus();
 }
 
@@ -3230,6 +3241,210 @@ if (entityListSearchEl) {
 if (entityListCloseBtn) {
   entityListCloseBtn.addEventListener("click", () => {
     hideEntityListPanel();
+  });
+}
+
+// ---- Entity Scope List (Frames-style) ----
+
+function buildEntityScopeList(): void {
+  if (!entityScopeListEl || !doc) {
+    return;
+  }
+  entityScopeListEl.innerHTML = "";
+
+  const rootId = doc.state.rootId;
+  const folders = collectFolderTree(rootId);
+  const currentScope = currentScopeRootId();
+
+  // Add root scope entry
+  const rootRow = document.createElement("div");
+  rootRow.className = "entity-scope-row" + (currentScope === rootId ? " is-current-scope" : "");
+  rootRow.dataset.scopeId = rootId;
+
+  const rootIcon = document.createElement("span");
+  rootIcon.className = "entity-scope-icon";
+  rootIcon.textContent = "\u25C6";
+
+  const rootName = document.createElement("span");
+  rootName.className = "entity-scope-name";
+  rootName.textContent = uiLabel(doc.state.nodes[rootId]) || "Root";
+
+  rootRow.appendChild(rootIcon);
+  rootRow.appendChild(rootName);
+  entityScopeListEl.appendChild(rootRow);
+
+  rootRow.addEventListener("click", () => {
+    EnterScopeCommand(rootId);
+    buildEntityScopeList();
+    buildEntityList(entityListSearchEl?.value.trim() || "");
+  });
+
+  // Add folder scopes recursively
+  renderEntityScopeItems(entityScopeListEl, folders, currentScope, 1);
+}
+
+function renderEntityScopeItems(
+  container: HTMLElement,
+  folders: ReturnType<typeof collectFolderTree>,
+  currentScope: string,
+  depth: number,
+): void {
+  for (const folder of folders) {
+    const row = document.createElement("div");
+    row.className = "entity-scope-row" + (currentScope === folder.id ? " is-current-scope" : "");
+    row.dataset.scopeId = folder.id;
+    row.style.paddingLeft = `${8 + depth * 12}px`;
+
+    const icon = document.createElement("span");
+    icon.className = "entity-scope-icon";
+    icon.textContent = "\u25C7";
+
+    const name = document.createElement("span");
+    name.className = "entity-scope-name";
+    name.textContent = folder.label;
+
+    const count = document.createElement("span");
+    count.className = "entity-scope-count";
+    count.textContent = `${folder.childCount}`;
+
+    row.appendChild(icon);
+    row.appendChild(name);
+    row.appendChild(count);
+    container.appendChild(row);
+
+    row.addEventListener("click", () => {
+      EnterScopeCommand(folder.id);
+      buildEntityScopeList();
+      buildEntityList(entityListSearchEl?.value.trim() || "");
+    });
+
+    if (folder.subFolders.length > 0) {
+      renderEntityScopeItems(container, folder.subFolders, currentScope, depth + 1);
+    }
+  }
+}
+
+// ---- Presence Badges ----
+
+function startPresenceWatch(): void {
+  if (presenceEs) {
+    return;
+  }
+  const url = `/api/docs/${encodeURIComponent(LOCAL_DOC_ID)}/presence`;
+  presenceEs = new EventSource(url);
+  presenceEs.addEventListener("message", (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data && typeof data === "object") {
+        updatePresenceMap(data);
+        if (entityListVisible) {
+          applyPresenceBadges();
+        }
+      }
+    } catch {
+      // ignore parse errors
+    }
+  });
+  presenceEs.addEventListener("error", () => {
+    stopPresenceWatch();
+  });
+}
+
+function stopPresenceWatch(): void {
+  if (presenceEs) {
+    presenceEs.close();
+    presenceEs = null;
+  }
+}
+
+function updatePresenceMap(data: Record<string, unknown>): void {
+  presenceMap.clear();
+  const users = (data as { users?: { userId: string; color?: string; nodeId?: string }[] }).users;
+  if (!Array.isArray(users)) {
+    return;
+  }
+  for (const user of users) {
+    if (!user.nodeId) {
+      continue;
+    }
+    const existing = presenceMap.get(user.nodeId) || [];
+    existing.push({
+      userId: user.userId,
+      color: user.color || "#ff6b6b",
+      nodeId: user.nodeId,
+    });
+    presenceMap.set(user.nodeId, existing);
+  }
+}
+
+function applyPresenceBadges(): void {
+  if (!entityListTreeEl) {
+    return;
+  }
+  // Remove existing badges
+  const existingBadges = entityListTreeEl.querySelectorAll(".presence-badges");
+  existingBadges.forEach((el) => el.remove());
+
+  // Apply new badges
+  presenceMap.forEach((users, nodeId) => {
+    const row = entityListTreeEl!.querySelector(`[data-node-id="${nodeId}"]`);
+    if (!row) {
+      return;
+    }
+    const badgesContainer = document.createElement("span");
+    badgesContainer.className = "presence-badges";
+    for (const user of users.slice(0, 3)) {
+      const badge = document.createElement("span");
+      badge.className = "presence-badge";
+      badge.style.backgroundColor = user.color;
+      badge.title = user.userId;
+      badgesContainer.appendChild(badge);
+    }
+    if (users.length > 3) {
+      const more = document.createElement("span");
+      more.className = "presence-badge";
+      more.style.backgroundColor = "#999";
+      more.title = `+${users.length - 3} more`;
+      badgesContainer.appendChild(more);
+    }
+    row.appendChild(badgesContainer);
+  });
+}
+
+// ---- Away Changes (audit infrastructure) ----
+
+function fetchChangedNodes(): void {
+  const url = `/api/docs/${encodeURIComponent(LOCAL_DOC_ID)}/audit?since=last-session`;
+  fetch(url, { cache: "no-store" })
+    .then((r) => {
+      if (!r.ok) {
+        return null;
+      }
+      return r.json();
+    })
+    .then((data) => {
+      if (!data || !Array.isArray(data.changedNodeIds)) {
+        return;
+      }
+      changedNodeIds = new Set(data.changedNodeIds as string[]);
+      if (entityListVisible) {
+        applyChangeHighlights();
+      }
+    })
+    .catch(() => {
+      // audit endpoint may not exist yet
+    });
+}
+
+function applyChangeHighlights(): void {
+  if (!entityListTreeEl || changedNodeIds.size === 0) {
+    return;
+  }
+  changedNodeIds.forEach((nodeId) => {
+    const row = entityListTreeEl!.querySelector(`[data-node-id="${nodeId}"]`);
+    if (row) {
+      row.classList.add("has-changes");
+    }
   });
 }
 

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -632,11 +632,11 @@
         margin: 0;
       }
 
-      /* ── Entity List Panel ── */
+      /* ── Entity List Panel (left sidebar, Miro Frames-style) ── */
       .entity-list-panel {
         position: absolute;
         top: 60px;
-        right: 14px;
+        left: 14px;
         z-index: 12;
         width: 320px;
         max-height: calc(100vh - 90px);
@@ -805,6 +805,90 @@
         border-radius: 2px;
       }
 
+      /* ── Entity Scope List (Frames-style) ── */
+      .entity-scope-list {
+        padding: 6px 10px 2px;
+        border-bottom: 1px solid #e8e8e8;
+        flex-shrink: 0;
+        max-height: 160px;
+        overflow-y: auto;
+      }
+
+      .entity-scope-list:empty {
+        display: none;
+      }
+
+      .entity-scope-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 8px;
+        border-radius: 6px;
+        cursor: pointer;
+        user-select: none;
+        transition: background 0.08s ease;
+        font-size: 12px;
+        color: var(--ink);
+        line-height: 1.4;
+      }
+
+      .entity-scope-row:hover {
+        background: rgba(122, 53, 255, 0.06);
+      }
+
+      .entity-scope-row.is-current-scope {
+        background: var(--accent-soft);
+        color: #5221b2;
+        font-weight: 600;
+      }
+
+      .entity-scope-icon {
+        flex-shrink: 0;
+        font-size: 11px;
+        color: #9a6b1f;
+      }
+
+      .entity-scope-name {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .entity-scope-count {
+        font-size: 10px;
+        color: #999;
+        flex-shrink: 0;
+      }
+
+      /* ── Presence Badge ── */
+      .presence-badge {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+        border: 1.5px solid #fff;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+        margin-left: 2px;
+      }
+
+      .presence-badges {
+        display: inline-flex;
+        align-items: center;
+        gap: 2px;
+        flex-shrink: 0;
+        margin-left: auto;
+        padding-left: 4px;
+      }
+
+      /* ── Change Highlight (away changes) ── */
+      .entity-row.has-changes {
+        border-left: 3px solid #e0a35c;
+        padding-left: 11px;
+      }
+
       /* ── Conflict Panel ── */
       .conflict-panel {
         position: absolute;
@@ -968,7 +1052,7 @@
       @media (max-width: 900px) {
         .entity-list-panel {
           width: 280px;
-          right: 10px;
+          left: 10px;
           top: 56px;
         }
 

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -89,6 +89,7 @@
           <span class="entity-list-title">Entities</span>
           <button id="entity-list-close" class="entity-list-close" type="button" aria-label="Close entity list">&times;</button>
         </div>
+        <div id="entity-scope-list" class="entity-scope-list"></div>
         <div class="entity-list-search-wrap">
           <input id="entity-list-search" class="entity-list-search" type="text" placeholder="Filter nodes..." spellcheck="false" />
         </div>


### PR DESCRIPTION
## Summary
- Moves Entity List panel (Alt+E) from right sidebar to left sidebar, matching Miro's Frames panel position
- Adds a scope list section at the top of the panel for quick navigation between scopes (folders), with current scope highlighted
- Adds presence badge system: SSE-based real-time colored dots next to nodes being edited by other users (via `/api/docs/:id/presence`)
- Adds infrastructure for away-change highlights via `/api/docs/:id/audit` endpoint (display deferred to future PR)

## Test plan
- [ ] Open viewer, press Alt+E -- panel appears on the LEFT side
- [ ] Scope list shows all folder scopes with current scope highlighted
- [ ] Click a scope in the list -- navigates to that scope, entity tree updates
- [ ] Search filter still works as before
- [ ] Click a node row -- focuses that node on canvas
- [ ] Escape closes the panel
- [ ] Mobile viewport (< 900px) -- panel positioned correctly at left
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Pre-existing unit tests pass (176/177, mm_exporter failure is pre-existing)

Generated with [Claude Code](https://claude.com/claude-code)