### PR TITLE
Add Windows installer automation scripts

### DIFF
--- a/install/windows/collect_report.bat
+++ b/install/windows/collect_report.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal EnableExtensions
+call "%~dp0common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+call "%~dp0scripts\collect_report_internal.bat" %*
+exit /b %errorlevel%

--- a/install/windows/common_env.bat
+++ b/install/windows/common_env.bat
@@ -1,0 +1,85 @@
+@echo off
+setlocal EnableExtensions
+
+if "%LOCALAPPDATA%"=="" (
+  echo [ERROR] LOCALAPPDATA is not defined.
+  exit /b 10
+)
+
+set "M3E_APP_NAME=M3E"
+set "M3E_HOME=%LOCALAPPDATA%\M3E"
+set "M3E_RUNTIME=%M3E_HOME%\runtime"
+set "M3E_APP=%M3E_HOME%\app"
+set "M3E_DATA=%M3E_HOME%\data"
+set "M3E_LOGS=%M3E_HOME%\logs"
+set "M3E_BACKUP=%M3E_HOME%\backup"
+set "M3E_TMP=%M3E_HOME%\tmp"
+set "M3E_REPORTS=%M3E_HOME%\reports"
+set "M3E_LOCK_FILE=%M3E_TMP%\app.lock"
+set "M3E_CONF=%M3E_HOME%\m3e.conf"
+set "M3E_VERSION_JSON=%M3E_HOME%\version.json"
+set "M3E_DB=%M3E_DATA%\M3E_dataV1.sqlite"
+set "M3E_FIRST_RUN_MARKER=%M3E_DATA%\first_run.marker"
+set "M3E_NODE_EXE=%M3E_RUNTIME%\node.exe"
+set "M3E_START_JS=%M3E_APP%\dist\node\start_viewer.js"
+set "M3E_SETUP_LOG=%M3E_LOGS%\setup.log"
+set "M3E_STARTUP_LOG=%M3E_LOGS%\startup.log"
+set "M3E_VERIFY_LOG=%M3E_LOGS%\verify.log"
+set "M3E_REPORT_LOG=%M3E_LOGS%\report.log"
+set "M3E_MIGRATION_LOG=%M3E_LOGS%\migration.log"
+set "M3E_CRASH_LOG=%M3E_LOGS%\crash.log"
+set "M3E_DEFAULT_PORT=38482"
+set "M3E_HOST=127.0.0.1"
+
+set "M3E_SCRIPT_ROOT=%~dp0"
+if "%M3E_SCRIPT_ROOT:~-1%"=="\" set "M3E_SCRIPT_ROOT=%M3E_SCRIPT_ROOT:~0,-1%"
+
+set "M3E_PACKAGE_ROOT="
+if exist "%M3E_SCRIPT_ROOT%\payload\" set "M3E_PACKAGE_ROOT=%M3E_SCRIPT_ROOT%"
+
+if not defined M3E_PACKAGE_ROOT if exist "%M3E_SCRIPT_ROOT%\..\payload\" (
+  for %%I in ("%M3E_SCRIPT_ROOT%\..") do set "M3E_PACKAGE_ROOT=%%~fI"
+)
+
+if defined M3E_PACKAGE_ROOT (
+  set "M3E_PAYLOAD=%M3E_PACKAGE_ROOT%\payload"
+  set "M3E_PAYLOAD_RUNTIME=%M3E_PAYLOAD%\runtime"
+  set "M3E_PAYLOAD_APP=%M3E_PAYLOAD%\app"
+  set "M3E_PAYLOAD_SCRIPTS=%M3E_PAYLOAD%\scripts"
+  set "M3E_MANIFEST=%M3E_PACKAGE_ROOT%\manifest.json"
+)
+
+endlocal & (
+  set "M3E_APP_NAME=%M3E_APP_NAME%"
+  set "M3E_HOME=%M3E_HOME%"
+  set "M3E_RUNTIME=%M3E_RUNTIME%"
+  set "M3E_APP=%M3E_APP%"
+  set "M3E_DATA=%M3E_DATA%"
+  set "M3E_LOGS=%M3E_LOGS%"
+  set "M3E_BACKUP=%M3E_BACKUP%"
+  set "M3E_TMP=%M3E_TMP%"
+  set "M3E_REPORTS=%M3E_REPORTS%"
+  set "M3E_LOCK_FILE=%M3E_LOCK_FILE%"
+  set "M3E_CONF=%M3E_CONF%"
+  set "M3E_VERSION_JSON=%M3E_VERSION_JSON%"
+  set "M3E_DB=%M3E_DB%"
+  set "M3E_FIRST_RUN_MARKER=%M3E_FIRST_RUN_MARKER%"
+  set "M3E_NODE_EXE=%M3E_NODE_EXE%"
+  set "M3E_START_JS=%M3E_START_JS%"
+  set "M3E_SETUP_LOG=%M3E_SETUP_LOG%"
+  set "M3E_STARTUP_LOG=%M3E_STARTUP_LOG%"
+  set "M3E_VERIFY_LOG=%M3E_VERIFY_LOG%"
+  set "M3E_REPORT_LOG=%M3E_REPORT_LOG%"
+  set "M3E_MIGRATION_LOG=%M3E_MIGRATION_LOG%"
+  set "M3E_CRASH_LOG=%M3E_CRASH_LOG%"
+  set "M3E_DEFAULT_PORT=%M3E_DEFAULT_PORT%"
+  set "M3E_HOST=%M3E_HOST%"
+  set "M3E_SCRIPT_ROOT=%M3E_SCRIPT_ROOT%"
+  set "M3E_PACKAGE_ROOT=%M3E_PACKAGE_ROOT%"
+  set "M3E_PAYLOAD=%M3E_PAYLOAD%"
+  set "M3E_PAYLOAD_RUNTIME=%M3E_PAYLOAD_RUNTIME%"
+  set "M3E_PAYLOAD_APP=%M3E_PAYLOAD_APP%"
+  set "M3E_PAYLOAD_SCRIPTS=%M3E_PAYLOAD_SCRIPTS%"
+  set "M3E_MANIFEST=%M3E_MANIFEST%"
+)
+exit /b 0

--- a/install/windows/launch.bat
+++ b/install/windows/launch.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal EnableExtensions
+call "%~dp0common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+call "%~dp0scripts\launch_node.bat" %*
+exit /b %errorlevel%

--- a/install/windows/manifest.json
+++ b/install/windows/manifest.json
@@ -1,0 +1,15 @@
+{
+  "app": {
+    "name": "M3E",
+    "version": "0.1.0"
+  },
+  "node": {
+    "version": "22.14.0",
+    "platform": "win32",
+    "arch": "x64"
+  },
+  "build": {
+    "timestamp": "2026-04-10T00:00:00+09:00",
+    "channel": "windows"
+  }
+}

--- a/install/windows/scripts/collect_report_internal.bat
+++ b/install/windows/scripts/collect_report_internal.bat
@@ -1,0 +1,201 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+set "REPORT_REASON=%~1"
+if "%REPORT_REASON%"=="" set "REPORT_REASON=manual"
+
+call :ensure_dirs
+if errorlevel 1 exit /b %errorlevel%
+
+for /f %%T in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "TS=%%T"
+if "%TS%"=="" set "TS=%date:~0,4%%date:~5,2%%date:~8,2%_%time:~0,2%%time:~3,2%%time:~6,2%"
+set "REPORT_DIR=%M3E_REPORTS%\M3E_report_%TS%"
+set "REPORT_ZIP=%M3E_REPORTS%\M3E_report_%TS%.zip"
+
+mkdir "%REPORT_DIR%" >nul 2>&1
+mkdir "%REPORT_DIR%\logs" >nul 2>&1
+mkdir "%REPORT_DIR%\config" >nul 2>&1
+mkdir "%REPORT_DIR%\data" >nul 2>&1
+
+if not exist "%REPORT_DIR%\" call :fail 71 "Failed to create report directory"
+
+call :log_info "Collect report start: %REPORT_DIR%"
+
+call :write_summary
+call :write_env
+call :write_paths
+call :write_process
+call :write_network
+call :write_files
+call :write_errors
+call :write_sqlite_info
+
+call :copy_if_exists "%M3E_SETUP_LOG%" "%REPORT_DIR%\logs\setup.log"
+call :copy_if_exists "%M3E_STARTUP_LOG%" "%REPORT_DIR%\logs\startup.log"
+call :copy_if_exists "%M3E_VERIFY_LOG%" "%REPORT_DIR%\logs\verify.log"
+call :copy_if_exists "%M3E_MIGRATION_LOG%" "%REPORT_DIR%\logs\migration.log"
+call :copy_if_exists "%M3E_CRASH_LOG%" "%REPORT_DIR%\logs\crash.log"
+call :copy_if_exists "%M3E_REPORT_LOG%" "%REPORT_DIR%\logs\report.log"
+call :copy_if_exists "%M3E_VERSION_JSON%" "%REPORT_DIR%\config\version.json"
+call :copy_if_exists "%M3E_LOCK_FILE%" "%REPORT_DIR%\config\app.lock"
+
+if exist "%M3E_CONF%" (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$in=Get-Content -Path '%M3E_CONF%' -ErrorAction Stop;" ^
+    "$out=$in -replace '^(?i)(.*(API_KEY|TOKEN|PASSWORD|SECRET).*=).*$','$1***MASKED***';" ^
+    "Set-Content -Path '%REPORT_DIR%\config\m3e.conf' -Value $out -Encoding UTF8"
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "if(Test-Path '%REPORT_ZIP%'){ Remove-Item -LiteralPath '%REPORT_ZIP%' -Force }" >nul 2>&1
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "Compress-Archive -Path '%REPORT_DIR%\*' -DestinationPath '%REPORT_ZIP%' -Force" >nul 2>&1
+
+if exist "%REPORT_ZIP%" (
+  call :log_info "Report zip created: %REPORT_ZIP%"
+  echo Report created: %REPORT_ZIP%
+  echo Send this zip to the developer.
+  exit /b 0
+)
+
+call :log_error "Zip creation failed, fallback to directory"
+echo Zip creation failed. Send this directory to the developer:
+echo %REPORT_DIR%
+exit /b 0
+
+:ensure_dirs
+for %%D in ("%M3E_HOME%" "%M3E_DATA%" "%M3E_LOGS%" "%M3E_BACKUP%" "%M3E_TMP%" "%M3E_REPORTS%") do (
+  if not exist "%%~D" mkdir "%%~D"
+  if errorlevel 1 exit /b 11
+)
+if not exist "%M3E_REPORT_LOG%" type nul > "%M3E_REPORT_LOG%"
+if errorlevel 1 exit /b 12
+exit /b 0
+
+:write_summary
+> "%REPORT_DIR%\summary.txt" (
+  echo M3E Diagnostic Report
+  echo createdAt=%date% %time%
+  echo reason=%REPORT_REASON%
+  echo reportDir=%REPORT_DIR%
+  echo reportZip=%REPORT_ZIP%
+  echo sendToDeveloper=1
+)
+exit /b 0
+
+:write_env
+> "%REPORT_DIR%\env.txt" (
+  echo ComputerName=%COMPUTERNAME%
+  echo UserName=%USERNAME%
+  echo LocalAppData=%LOCALAPPDATA%
+  echo ProcessorArch=%PROCESSOR_ARCHITECTURE%
+  ver
+)
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$os=Get-CimInstance Win32_OperatingSystem;" ^
+  "'OSCaption='+$os.Caption | Out-File -FilePath '%REPORT_DIR%\env.txt' -Append -Encoding utf8;" ^
+  "'OSVersion='+$os.Version | Out-File -FilePath '%REPORT_DIR%\env.txt' -Append -Encoding utf8;" ^
+  "'OSBuild='+$os.BuildNumber | Out-File -FilePath '%REPORT_DIR%\env.txt' -Append -Encoding utf8;" ^
+  "'MemoryMB='+[int]($os.TotalVisibleMemorySize/1024) | Out-File -FilePath '%REPORT_DIR%\env.txt' -Append -Encoding utf8" >nul 2>&1
+exit /b 0
+
+:write_paths
+> "%REPORT_DIR%\paths.txt" (
+  echo M3E_HOME=%M3E_HOME%
+  echo M3E_RUNTIME=%M3E_RUNTIME%
+  echo M3E_APP=%M3E_APP%
+  echo M3E_DATA=%M3E_DATA%
+  echo M3E_LOGS=%M3E_LOGS%
+  echo M3E_BACKUP=%M3E_BACKUP%
+  echo M3E_TMP=%M3E_TMP%
+  echo M3E_REPORTS=%M3E_REPORTS%
+  echo M3E_NODE_EXE=%M3E_NODE_EXE%
+  echo M3E_START_JS=%M3E_START_JS%
+  echo M3E_DB=%M3E_DB%
+)
+exit /b 0
+
+:write_process
+tasklist /v > "%REPORT_DIR%\process_all.txt" 2>nul
+findstr /I "node.exe start_viewer.js" "%REPORT_DIR%\process_all.txt" > "%REPORT_DIR%\process.txt" 2>nul
+del /q "%REPORT_DIR%\process_all.txt" >nul 2>&1
+if exist "%M3E_LOCK_FILE%" (
+  echo.>> "%REPORT_DIR%\process.txt"
+  echo [lock]>> "%REPORT_DIR%\process.txt"
+  type "%M3E_LOCK_FILE%" >> "%REPORT_DIR%\process.txt"
+)
+exit /b 0
+
+:write_network
+netstat -ano > "%REPORT_DIR%\network_all.txt" 2>nul
+findstr /I "LISTENING" "%REPORT_DIR%\network_all.txt" > "%REPORT_DIR%\network.txt" 2>nul
+del /q "%REPORT_DIR%\network_all.txt" >nul 2>&1
+if exist "%M3E_CONF%" (
+  for /f "usebackq tokens=1* delims==" %%A in ("%M3E_CONF%") do (
+    if /I "%%~A"=="M3E_PORT" echo ConfigPort=%%~B>> "%REPORT_DIR%\network.txt"
+  )
+)
+exit /b 0
+
+:write_files
+> "%REPORT_DIR%\files.txt" (
+  if exist "%M3E_NODE_EXE%" (echo runtime_node=FOUND) else (echo runtime_node=MISSING)
+  if exist "%M3E_START_JS%" (echo start_viewer=FOUND) else (echo start_viewer=MISSING)
+  if exist "%M3E_APP%\node_modules\better-sqlite3\build\Release\better_sqlite3.node" (echo better_sqlite3=FOUND) else (echo better_sqlite3=MISSING)
+  if exist "%M3E_DB%" (echo sqlite_db=FOUND) else (echo sqlite_db=MISSING)
+  if exist "%M3E_CONF%" (echo conf=FOUND) else (echo conf=MISSING)
+)
+exit /b 0
+
+:write_errors
+if exist "%M3E_SETUP_LOG%" type "%M3E_SETUP_LOG%" > "%REPORT_DIR%\all_logs.tmp"
+if exist "%M3E_STARTUP_LOG%" type "%M3E_STARTUP_LOG%" >> "%REPORT_DIR%\all_logs.tmp"
+if exist "%M3E_VERIFY_LOG%" type "%M3E_VERIFY_LOG%" >> "%REPORT_DIR%\all_logs.tmp"
+if exist "%M3E_MIGRATION_LOG%" type "%M3E_MIGRATION_LOG%" >> "%REPORT_DIR%\all_logs.tmp"
+if exist "%M3E_CRASH_LOG%" type "%M3E_CRASH_LOG%" >> "%REPORT_DIR%\all_logs.tmp"
+if exist "%REPORT_DIR%\all_logs.tmp" (
+  findstr /I "EPERM EADDRINUSE SQLITE_BUSY MODULE_NOT_FOUND Cannot find failed error" "%REPORT_DIR%\all_logs.tmp" > "%REPORT_DIR%\errors.txt" 2>nul
+  del /q "%REPORT_DIR%\all_logs.tmp" >nul 2>&1
+) else (
+  > "%REPORT_DIR%\errors.txt" echo no_logs_found=1
+)
+exit /b 0
+
+:write_sqlite_info
+> "%REPORT_DIR%\data\sqlite_info.txt" (
+  if exist "%M3E_DB%" (
+    echo sqlite.exists=1
+    for %%F in ("%M3E_DB%") do (
+      echo sqlite.size=%%~zF
+      echo sqlite.modified=%%~tF
+    )
+  ) else (
+    echo sqlite.exists=0
+  )
+)
+exit /b 0
+
+:copy_if_exists
+if exist "%~1" copy /y "%~1" "%~2" >nul
+exit /b 0
+
+:log_info
+>> "%M3E_REPORT_LOG%" echo [%date% %time%] [INFO] %~1
+echo [INFO] %~1
+exit /b 0
+
+:log_error
+>> "%M3E_REPORT_LOG%" echo [%date% %time%] [ERROR] %~1
+echo [ERROR] %~1
+exit /b 0
+
+:fail
+set "CODE=%~1"
+set "MSG=%~2"
+call :log_error "%MSG%"
+echo Log: %M3E_REPORT_LOG%
+exit /b %CODE%

--- a/install/windows/scripts/launch_node.bat
+++ b/install/windows/scripts/launch_node.bat
@@ -1,0 +1,169 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+call :ensure_dirs
+if errorlevel 1 exit /b %errorlevel%
+
+set "M3E_PORT=%M3E_DEFAULT_PORT%"
+set "M3E_DATA_DIR=%M3E_DATA%"
+set "M3E_DB_FILE=M3E_dataV1.sqlite"
+call :read_conf
+
+call :log_info "Launch start"
+call :log_info "App path: %M3E_APP%"
+
+if not exist "%M3E_NODE_EXE%" call :fail 41 "Missing runtime: %M3E_NODE_EXE%"
+if not exist "%M3E_START_JS%" call :fail 42 "Missing start script: %M3E_START_JS%"
+
+set "LOCK_PID="
+set "LOCK_PORT="
+if exist "%M3E_LOCK_FILE%" call :read_lock
+
+if defined LOCK_PID (
+  tasklist /FI "PID eq !LOCK_PID!" | find " !LOCK_PID! " >nul 2>&1
+  if not errorlevel 1 (
+    if not defined LOCK_PORT set "LOCK_PORT=%M3E_PORT%"
+    call :probe_port "!LOCK_PORT!"
+    if not errorlevel 1 (
+      call :log_info "M3E is already running on port !LOCK_PORT!"
+      start "" "http://127.0.0.1:!LOCK_PORT!/viewer.html"
+      exit /b 0
+    )
+  )
+  call :log_info "Stale lock detected, removing"
+  del /q "%M3E_LOCK_FILE%" >nul 2>&1
+)
+
+call :select_port "%M3E_PORT%"
+if errorlevel 1 call :fail 43 "No available port"
+set "M3E_PORT=%SELECTED_PORT%"
+
+set "M3E_DB_FILE=%M3E_DB_FILE%"
+set "M3E_DATA_DIR=%M3E_DATA_DIR%"
+set "M3E_PORT=%M3E_PORT%"
+
+for /f %%P in ('powershell -NoProfile -ExecutionPolicy Bypass -Command "$p=Start-Process -FilePath '%M3E_NODE_EXE%' -ArgumentList '%M3E_START_JS%' -WorkingDirectory '%M3E_APP%' -WindowStyle Hidden -PassThru; $p.Id"') do set "NODE_PID=%%P"
+if not defined NODE_PID call :fail 44 "Failed to start Node process"
+
+> "%M3E_LOCK_FILE%" (
+  echo pid=%NODE_PID%
+  echo port=%M3E_PORT%
+  for /f %%T in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do echo startedAt=%%T
+)
+
+set /a WAIT_COUNT=0
+:wait_server
+call :probe_port "%M3E_PORT%"
+if not errorlevel 1 goto :server_ready
+if %WAIT_COUNT% GEQ 25 goto :server_timeout
+set /a WAIT_COUNT+=1
+timeout /t 1 /nobreak >nul
+goto :wait_server
+
+:server_ready
+call :set_conf "M3E_PORT" "%M3E_PORT%"
+call :log_info "Server started. PID=%NODE_PID% PORT=%M3E_PORT%"
+exit /b 0
+
+:server_timeout
+call :log_error "Server did not respond on port %M3E_PORT%"
+taskkill /PID %NODE_PID% /T /F >nul 2>&1
+del /q "%M3E_LOCK_FILE%" >nul 2>&1
+call :fail 45 "Startup timeout"
+
+:ensure_dirs
+for %%D in ("%M3E_HOME%" "%M3E_DATA%" "%M3E_LOGS%" "%M3E_BACKUP%" "%M3E_TMP%" "%M3E_REPORTS%") do (
+  if not exist "%%~D" mkdir "%%~D"
+  if errorlevel 1 exit /b 11
+)
+if not exist "%M3E_STARTUP_LOG%" type nul > "%M3E_STARTUP_LOG%"
+if errorlevel 1 exit /b 12
+if not exist "%M3E_FIRST_RUN_MARKER%" type nul > "%M3E_FIRST_RUN_MARKER%"
+exit /b 0
+
+:read_conf
+if not exist "%M3E_CONF%" (
+  > "%M3E_CONF%" (
+    echo M3E_DATA_DIR=%M3E_DATA%
+    echo M3E_DB_FILE=M3E_dataV1.sqlite
+    echo M3E_PORT=%M3E_DEFAULT_PORT%
+    echo M3E_HOST=%M3E_HOST%
+  )
+)
+for /f "usebackq tokens=1* delims==" %%A in ("%M3E_CONF%") do (
+  if /I "%%~A"=="M3E_PORT" set "M3E_PORT=%%~B"
+  if /I "%%~A"=="M3E_DATA_DIR" set "M3E_DATA_DIR=%%~B"
+  if /I "%%~A"=="M3E_DB_FILE" set "M3E_DB_FILE=%%~B"
+)
+if "%M3E_PORT%"=="" set "M3E_PORT=%M3E_DEFAULT_PORT%"
+exit /b 0
+
+:read_lock
+for /f "usebackq tokens=1* delims==" %%A in ("%M3E_LOCK_FILE%") do (
+  if /I "%%~A"=="pid" set "LOCK_PID=%%~B"
+  if /I "%%~A"=="port" set "LOCK_PORT=%%~B"
+)
+exit /b 0
+
+:select_port
+set "BASE_PORT=%~1"
+if "%BASE_PORT%"=="" set "BASE_PORT=%M3E_DEFAULT_PORT%"
+set /a TRY_PORT=%BASE_PORT%
+set /a MAX_TRY=40
+:port_loop
+call :port_in_use "!TRY_PORT!"
+if errorlevel 1 (
+  set /a TRY_PORT+=1
+  set /a MAX_TRY-=1
+  if !MAX_TRY! LEQ 0 exit /b 1
+  goto :port_loop
+)
+set "SELECTED_PORT=!TRY_PORT!"
+exit /b 0
+
+:port_in_use
+netstat -ano | findstr /R /C:":%~1 .*LISTENING" >nul 2>&1
+if errorlevel 1 (
+  exit /b 0
+) else (
+  exit /b 1
+)
+
+:probe_port
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$client = New-Object System.Net.Sockets.TcpClient;" ^
+  "try { $client.Connect('127.0.0.1', %~1); exit 0 } catch { exit 1 } finally { if($client){$client.Dispose()} }" >nul 2>&1
+exit /b %errorlevel%
+
+:set_conf
+set "CONF_KEY=%~1"
+set "CONF_VAL=%~2"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$path='%M3E_CONF%'; $k='%CONF_KEY%'; $v='%CONF_VAL%';" ^
+  "$lines=@(); if(Test-Path $path){$lines=Get-Content -Path $path -ErrorAction Stop};" ^
+  "$updated=$false; $out=@();" ^
+  "foreach($line in $lines){ if($line -match ('^'+[regex]::Escape($k)+'=')){ $out += ($k+'='+$v); $updated=$true } else { $out += $line }}" ^
+  "if(-not $updated){ $out += ($k+'='+$v) }" ^
+  "Set-Content -Path $path -Value $out -Encoding UTF8"
+exit /b %errorlevel%
+
+:log_info
+>> "%M3E_STARTUP_LOG%" echo [%date% %time%] [INFO] %~1
+echo [INFO] %~1
+exit /b 0
+
+:log_error
+>> "%M3E_STARTUP_LOG%" echo [%date% %time%] [ERROR] %~1
+echo [ERROR] %~1
+exit /b 0
+
+:fail
+set "CODE=%~1"
+set "MSG=%~2"
+call :log_error "%MSG%"
+echo Log: %M3E_STARTUP_LOG%
+echo For diagnostics run: "%M3E_HOME%\collect_report.bat"
+exit /b %CODE%

--- a/install/windows/scripts/migrate_db.bat
+++ b/install/windows/scripts/migrate_db.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal EnableExtensions
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+if not exist "%M3E_LOGS%" mkdir "%M3E_LOGS%" >nul 2>&1
+if not exist "%M3E_BACKUP%" mkdir "%M3E_BACKUP%" >nul 2>&1
+
+>> "%M3E_MIGRATION_LOG%" echo [%date% %time%] [INFO] migrate_db start
+
+if not exist "%M3E_DB%" (
+  >> "%M3E_MIGRATION_LOG%" echo [%date% %time%] [INFO] no database; skip
+  exit /b 0
+)
+
+for /f %%T in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "TS=%%T"
+set "BACKUP_FILE=%M3E_BACKUP%\pre_migration_%TS%.sqlite"
+copy /y "%M3E_DB%" "%BACKUP_FILE%" >nul
+if errorlevel 1 (
+  >> "%M3E_MIGRATION_LOG%" echo [%date% %time%] [ERROR] backup failed
+  exit /b 1
+)
+
+if exist "%M3E_APP%\dist\node\migrate.js" (
+  pushd "%M3E_APP%" >nul
+  "%M3E_NODE_EXE%" "%M3E_APP%\dist\node\migrate.js" >> "%M3E_MIGRATION_LOG%" 2>&1
+  set "RC=%errorlevel%"
+  popd >nul
+  if not "%RC%"=="0" (
+    copy /y "%BACKUP_FILE%" "%M3E_DB%" >nul
+    >> "%M3E_MIGRATION_LOG%" echo [%date% %time%] [ERROR] migration failed, rollback done
+    exit /b %RC%
+  )
+)
+
+>> "%M3E_MIGRATION_LOG%" echo [%date% %time%] [INFO] migrate_db done
+exit /b 0

--- a/install/windows/scripts/setup_internal.bat
+++ b/install/windows/scripts/setup_internal.bat
@@ -1,0 +1,197 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+set "CREATE_DESKTOP_SHORTCUT=0"
+set "RUN_VERIFY=1"
+
+:parse_args
+if "%~1"=="" goto :args_done
+if /I "%~1"=="--desktop" set "CREATE_DESKTOP_SHORTCUT=1" & shift & goto :parse_args
+if /I "%~1"=="--no-verify" set "RUN_VERIFY=0" & shift & goto :parse_args
+if /I "%~1"=="--help" goto :usage
+shift
+goto :parse_args
+
+:args_done
+if not defined M3E_PACKAGE_ROOT (
+  echo [ERROR] setup.bat must run from install package root.
+  exit /b 2
+)
+
+call :ensure_dirs
+if errorlevel 1 exit /b %errorlevel%
+
+call :log_info "============================================================"
+call :log_info "M3E setup start"
+call :log_info "Package root: %M3E_PACKAGE_ROOT%"
+call :log_info "Install home: %M3E_HOME%"
+call :log_info "============================================================"
+
+if not exist "%M3E_PAYLOAD_RUNTIME%\node.exe" (
+  call :fail 21 "Missing payload runtime: %M3E_PAYLOAD_RUNTIME%\node.exe"
+)
+if not exist "%M3E_PAYLOAD_APP%\dist\node\start_viewer.js" (
+  call :fail 22 "Missing payload app: %M3E_PAYLOAD_APP%\dist\node\start_viewer.js"
+)
+
+if exist "%M3E_HOME%\scripts\stop_running.bat" (
+  call :log_info "Stopping existing M3E process if running"
+  call "%M3E_HOME%\scripts\stop_running.bat" --wait 20 >> "%M3E_SETUP_LOG%" 2>&1
+  if errorlevel 1 call :fail 23 "Failed to stop running process"
+)
+
+if exist "%M3E_RUNTIME%" (
+  call :log_info "Removing existing runtime directory"
+  rmdir /s /q "%M3E_RUNTIME%" >> "%M3E_SETUP_LOG%" 2>&1
+)
+if exist "%M3E_APP%" (
+  call :log_info "Removing existing app directory"
+  rmdir /s /q "%M3E_APP%" >> "%M3E_SETUP_LOG%" 2>&1
+)
+
+call :copy_tree "%M3E_PAYLOAD_RUNTIME%" "%M3E_RUNTIME%"
+if errorlevel 1 call :fail 24 "Runtime copy failed"
+
+call :copy_tree "%M3E_PAYLOAD_APP%" "%M3E_APP%"
+if errorlevel 1 call :fail 25 "App copy failed"
+
+if exist "%M3E_PAYLOAD_SCRIPTS%\" (
+  call :copy_tree "%M3E_PAYLOAD_SCRIPTS%" "%M3E_HOME%\scripts"
+  if errorlevel 1 call :fail 26 "Payload scripts copy failed"
+)
+
+for %%F in (common_env.bat launch.bat verify.bat collect_report.bat) do (
+  if exist "%M3E_PACKAGE_ROOT%\%%F" (
+    copy /y "%M3E_PACKAGE_ROOT%\%%F" "%M3E_HOME%\%%F" >nul
+    if errorlevel 1 call :fail 27 "Failed to copy %%F"
+  )
+)
+
+if exist "%M3E_PACKAGE_ROOT%\scripts\" (
+  call :copy_tree "%M3E_PACKAGE_ROOT%\scripts" "%M3E_HOME%\scripts"
+  if errorlevel 1 call :fail 28 "Failed to copy scripts directory"
+)
+
+if not exist "%M3E_CONF%" (
+  call :log_info "Creating m3e.conf"
+  > "%M3E_CONF%" (
+    echo M3E_DATA_DIR=%M3E_DATA%
+    echo M3E_DB_FILE=M3E_dataV1.sqlite
+    echo M3E_PORT=%M3E_DEFAULT_PORT%
+    echo M3E_HOST=%M3E_HOST%
+  )
+  if errorlevel 1 call :fail 29 "Failed to create m3e.conf"
+)
+
+call :set_conf "M3E_DATA_DIR" "%M3E_DATA%"
+call :set_conf "M3E_DB_FILE" "M3E_dataV1.sqlite"
+call :set_conf "M3E_PORT" "%M3E_DEFAULT_PORT%"
+call :set_conf "M3E_HOST" "%M3E_HOST%"
+if errorlevel 1 call :fail 30 "Failed to update m3e.conf"
+
+if exist "%M3E_MANIFEST%" (
+  copy /y "%M3E_MANIFEST%" "%M3E_VERSION_JSON%" >nul
+  if errorlevel 1 call :fail 31 "Failed to copy version manifest"
+) else (
+  > "%M3E_VERSION_JSON%" (
+    echo {"app":{"version":"unknown"},"generatedAt":"%date% %time%"}
+  )
+)
+
+call :create_start_menu_shortcut
+if errorlevel 1 call :fail 32 "Failed to create Start Menu shortcut"
+
+if "%CREATE_DESKTOP_SHORTCUT%"=="1" (
+  call :create_desktop_shortcut
+  if errorlevel 1 call :fail 33 "Failed to create Desktop shortcut"
+)
+
+if "%RUN_VERIFY%"=="1" (
+  call :log_info "Running verify.bat"
+  call "%M3E_HOME%\verify.bat" --post-setup >> "%M3E_SETUP_LOG%" 2>&1
+  if errorlevel 1 call :fail 34 "verify.bat failed"
+)
+
+call :log_info "Setup completed successfully"
+echo Setup completed successfully.
+exit /b 0
+
+:usage
+echo Usage: setup.bat [--desktop] [--no-verify]
+exit /b 0
+
+:ensure_dirs
+for %%D in ("%M3E_HOME%" "%M3E_DATA%" "%M3E_LOGS%" "%M3E_BACKUP%" "%M3E_TMP%" "%M3E_REPORTS%") do (
+  if not exist "%%~D" mkdir "%%~D"
+  if errorlevel 1 exit /b 11
+)
+if not exist "%M3E_SETUP_LOG%" type nul > "%M3E_SETUP_LOG%"
+if errorlevel 1 exit /b 12
+exit /b 0
+
+:copy_tree
+set "SRC=%~1"
+set "DST=%~2"
+if not exist "%SRC%\" exit /b 1
+if not exist "%DST%" mkdir "%DST%"
+xcopy "%SRC%\*" "%DST%\" /E /I /Y /Q >nul
+if errorlevel 1 exit /b 1
+exit /b 0
+
+:set_conf
+set "CONF_KEY=%~1"
+set "CONF_VAL=%~2"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$path='%M3E_CONF%'; $k='%CONF_KEY%'; $v='%CONF_VAL%';" ^
+  "$lines=@(); if(Test-Path $path){$lines=Get-Content -Path $path -ErrorAction Stop};" ^
+  "$updated=$false; $out=@();" ^
+  "foreach($line in $lines){ if($line -match ('^'+[regex]::Escape($k)+'=')){ $out += ($k+'='+$v); $updated=$true } else { $out += $line }}" ^
+  "if(-not $updated){ $out += ($k+'='+$v) }" ^
+  "Set-Content -Path $path -Value $out -Encoding UTF8"
+if errorlevel 1 exit /b 1
+exit /b 0
+
+:create_start_menu_shortcut
+set "START_MENU_DIR=%APPDATA%\Microsoft\Windows\Start Menu\Programs\M3E"
+if not exist "%START_MENU_DIR%" mkdir "%START_MENU_DIR%"
+set "SHORTCUT_PATH=%START_MENU_DIR%\M3E.lnk"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$ws=New-Object -ComObject WScript.Shell;" ^
+  "$sc=$ws.CreateShortcut('%SHORTCUT_PATH%');" ^
+  "$sc.TargetPath='%M3E_HOME%\launch.bat';" ^
+  "$sc.WorkingDirectory='%M3E_HOME%';" ^
+  "$sc.Description='M3E';" ^
+  "$sc.Save()"
+if errorlevel 1 exit /b 1
+exit /b 0
+
+:create_desktop_shortcut
+for /f "usebackq tokens=*" %%D in (`powershell -NoProfile -Command "[Environment]::GetFolderPath('Desktop')"`) do set "DESKTOP_DIR=%%D"
+if "%DESKTOP_DIR%"=="" exit /b 1
+set "SHORTCUT_PATH=%DESKTOP_DIR%\M3E.lnk"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$ws=New-Object -ComObject WScript.Shell;" ^
+  "$sc=$ws.CreateShortcut('%SHORTCUT_PATH%');" ^
+  "$sc.TargetPath='%M3E_HOME%\launch.bat';" ^
+  "$sc.WorkingDirectory='%M3E_HOME%';" ^
+  "$sc.Description='M3E';" ^
+  "$sc.Save()"
+if errorlevel 1 exit /b 1
+exit /b 0
+
+:log_info
+>> "%M3E_SETUP_LOG%" echo [%date% %time%] [INFO] %~1
+echo [INFO] %~1
+exit /b 0
+
+:fail
+set "CODE=%~1"
+set "MSG=%~2"
+>> "%M3E_SETUP_LOG%" echo [%date% %time%] [ERROR] %MSG%
+echo [ERROR] %MSG%
+echo Log: %M3E_SETUP_LOG%
+echo For diagnostics run: "%M3E_HOME%\collect_report.bat"
+exit /b %CODE%

--- a/install/windows/scripts/stop_running.bat
+++ b/install/windows/scripts/stop_running.bat
@@ -1,0 +1,46 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+set "WAIT_SEC=15"
+if /I "%~1"=="--wait" if not "%~2"=="" set "WAIT_SEC=%~2"
+
+set "LOCK_PID="
+set "LOCK_PORT="
+if exist "%M3E_LOCK_FILE%" (
+  for /f "usebackq tokens=1* delims==" %%A in ("%M3E_LOCK_FILE%") do (
+    if /I "%%~A"=="pid" set "LOCK_PID=%%~B"
+    if /I "%%~A"=="port" set "LOCK_PORT=%%~B"
+  )
+)
+
+if not defined LOCK_PID (
+  exit /b 0
+)
+
+tasklist /FI "PID eq %LOCK_PID%" | find " %LOCK_PID% " >nul 2>&1
+if errorlevel 1 (
+  del /q "%M3E_LOCK_FILE%" >nul 2>&1
+  exit /b 0
+)
+
+taskkill /PID %LOCK_PID% /T /F >nul 2>&1
+if errorlevel 1 exit /b 1
+
+set /a ELAPSED=0
+:wait_loop
+tasklist /FI "PID eq %LOCK_PID%" | find " %LOCK_PID% " >nul 2>&1
+if errorlevel 1 goto :done
+if %ELAPSED% GEQ %WAIT_SEC% exit /b 2
+timeout /t 1 /nobreak >nul
+set /a ELAPSED+=1
+goto :wait_loop
+
+:done
+del /q "%M3E_LOCK_FILE%" >nul 2>&1
+if defined LOCK_PORT (
+  timeout /t 1 /nobreak >nul
+)
+exit /b 0

--- a/install/windows/scripts/verify_internal.bat
+++ b/install/windows/scripts/verify_internal.bat
@@ -1,0 +1,88 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+call :ensure_dirs
+if errorlevel 1 exit /b %errorlevel%
+
+call :log_info "Verify start"
+
+call :check_file "%M3E_NODE_EXE%" "runtime node.exe" || call :fail 51 "Missing runtime node.exe"
+call :check_file "%M3E_START_JS%" "start_viewer.js" || call :fail 52 "Missing start_viewer.js"
+call :check_file "%M3E_APP%\node_modules\better-sqlite3\build\Release\better_sqlite3.node" "better_sqlite3.node" || call :fail 53 "Missing better_sqlite3.node"
+
+call :touch_test "%M3E_DATA%\verify_data.tmp" || call :fail 54 "Data directory is not writable"
+call :touch_test "%M3E_LOGS%\verify_logs.tmp" || call :fail 55 "Logs directory is not writable"
+call :touch_test "%M3E_TMP%\verify_tmp.tmp" || call :fail 56 "Tmp directory is not writable"
+
+pushd "%M3E_APP%" >nul
+"%M3E_NODE_EXE%" -e "require('better-sqlite3'); console.log('better-sqlite3-ok')" >> "%M3E_VERIFY_LOG%" 2>&1
+if errorlevel 1 (
+  popd >nul
+  call :fail 57 "Failed to load better-sqlite3"
+)
+popd >nul
+
+> "%M3E_TMP%\verify_lock.tmp" (
+  echo pid=0
+  echo port=%M3E_DEFAULT_PORT%
+  echo startedAt=verify
+)
+if errorlevel 1 call :fail 58 "Failed to write key=value lock"
+
+set "V_PID="
+set "V_PORT="
+for /f "usebackq tokens=1* delims==" %%A in ("%M3E_TMP%\verify_lock.tmp") do (
+  if /I "%%~A"=="pid" set "V_PID=%%~B"
+  if /I "%%~A"=="port" set "V_PORT=%%~B"
+)
+if not "%V_PID%"=="0" call :fail 59 "Lock parse failed (pid)"
+if not "%V_PORT%"=="%M3E_DEFAULT_PORT%" call :fail 60 "Lock parse failed (port)"
+del /q "%M3E_TMP%\verify_lock.tmp" >nul 2>&1
+
+call :log_info "Verify completed successfully"
+echo Verify completed successfully.
+exit /b 0
+
+:ensure_dirs
+for %%D in ("%M3E_HOME%" "%M3E_DATA%" "%M3E_LOGS%" "%M3E_BACKUP%" "%M3E_TMP%" "%M3E_REPORTS%") do (
+  if not exist "%%~D" mkdir "%%~D"
+  if errorlevel 1 exit /b 11
+)
+if not exist "%M3E_VERIFY_LOG%" type nul > "%M3E_VERIFY_LOG%"
+if errorlevel 1 exit /b 12
+exit /b 0
+
+:check_file
+if exist "%~1" (
+  call :log_info "FOUND %~2"
+  exit /b 0
+)
+call :log_error "MISSING %~2 (%~1)"
+exit /b 1
+
+:touch_test
+> "%~1" echo verify
+if errorlevel 1 exit /b 1
+del /q "%~1" >nul 2>&1
+exit /b 0
+
+:log_info
+>> "%M3E_VERIFY_LOG%" echo [%date% %time%] [INFO] %~1
+echo [INFO] %~1
+exit /b 0
+
+:log_error
+>> "%M3E_VERIFY_LOG%" echo [%date% %time%] [ERROR] %~1
+echo [ERROR] %~1
+exit /b 0
+
+:fail
+set "CODE=%~1"
+set "MSG=%~2"
+call :log_error "%MSG%"
+echo Log: %M3E_VERIFY_LOG%
+echo For diagnostics run: "%M3E_HOME%\collect_report.bat"
+exit /b %CODE%

--- a/install/windows/setup.bat
+++ b/install/windows/setup.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal EnableExtensions
+call "%~dp0common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+call "%~dp0scripts\setup_internal.bat" %*
+exit /b %errorlevel%

--- a/install/windows/verify.bat
+++ b/install/windows/verify.bat
@@ -1,0 +1,6 @@
+@echo off
+setlocal EnableExtensions
+call "%~dp0common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+call "%~dp0scripts\verify_internal.bat" %*
+exit /b %errorlevel%


### PR DESCRIPTION
Summary
- add install/windows distribution entrypoints: setup.bat, launch.bat, verify.bat, collect_report.bat
- add shared env and internal orchestration scripts under install/windows/scripts
- implement key=value lock handling, startup/verify/report logging, and report zip fallback
- add Windows manifest and migration orchestration script for DB backup/rollback flow

Notes
- this PR contains only Windows installer automation changes
- unrelated local uncommitted files are not part of this PR