### PR TITLE
team: fix Cloud Sync push failing silently with Supabase

### DIFF
--- a/beta/src/node/cloud_sync.ts
+++ b/beta/src/node/cloud_sync.ts
@@ -251,6 +251,7 @@ interface SupabaseQueryBuilder {
 
 interface SupabaseFilterBuilder {
   eq(column: string, value: unknown): SupabaseFilterBuilder;
+  select(columns?: string): SupabaseFilterBuilder;
   single(): Promise<{ data: SupabaseRow | null; error: SupabaseError | null }>;
   maybeSingle(): Promise<{ data: SupabaseRow | null; error: SupabaseError | null }>;
   then?: unknown; // allow awaiting directly
@@ -333,6 +334,9 @@ export class SupabaseTransport implements CloudSyncTransport {
     const nextDocVersion = ((existing?.doc_version as number) ?? 0) + 1;
 
     // Upsert the document
+    // Note: Do not chain .eq().single() after upsert — Supabase v2 upsert
+    // already identifies the row via onConflict, and .single() can error
+    // if the response shape doesn't contain exactly one row.
     const { error: upsertErr } = await client
       .from(this.tableName)
       .upsert(
@@ -346,7 +350,7 @@ export class SupabaseTransport implements CloudSyncTransport {
         },
         { onConflict: "id" },
       )
-      .eq("id", docId)
+      .select()
       .single();
 
     if (upsertErr) {

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -422,12 +422,18 @@ async function handleSyncApi(
   }
 
   if (!CLOUD_SYNC_ENABLED || !cloudTransport) {
-    sendJson(res, 200, {
-      ok: true,
-      enabled: false,
-      mode: "disabled",
-      documentId: route.docId,
-    });
+    if (route.action === "status") {
+      // Status endpoint: return 200 with enabled:false so browser can update UI
+      sendJson(res, 200, {
+        ok: true,
+        enabled: false,
+        mode: "disabled",
+        documentId: route.docId,
+      });
+    } else {
+      // Push/pull endpoints: return 503 so browser knows sync is unavailable
+      sendSyncError(res, 503, "SYNC_DISABLED", "Cloud sync is not enabled on this server.", route.docId);
+    }
     return true;
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `SupabaseTransport.push()` chained `.eq("id", docId).single()` after `.upsert()`. In Supabase JS v2, this caused the response to error out even when the upsert succeeded in the database, because `.eq()` without `.select()` doesn't properly return the upserted row for `.single()` to validate.
- **Effect**: Push appeared to succeed at the DB level, but the server returned a 500 error. The browser showed a brief error message (2500ms) that was easy to miss, and `cloudSavedAt` was never updated, leaving the badge at "Cloud: on (none)".
- **Fix 1**: Replace `.eq("id", docId).single()` with `.select().single()` — the correct Supabase v2 pattern for upsert with row return.
- **Fix 2**: Return HTTP 503 (not 200) for push/pull when cloud sync is disabled server-side, so the browser properly handles the error instead of treating the response as a successful empty push.

## Files changed
- `beta/src/node/cloud_sync.ts` — Fix Supabase upsert chain, add `select()` to interface
- `beta/src/node/start_viewer.ts` — Return 503 for push/pull when sync disabled

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit -p tsconfig.node.json`)
- [x] All cloud sync unit tests pass (23 tests)
- [x] All cloud sync API integration tests pass (8 tests)
- [ ] Manual: verify push button updates badge from "none" to timestamp with Supabase transport
- [ ] Manual: verify error message shown when cloud sync is disabled and push is attempted

## Browser-side note (not in scope for team role)
`pushDocToCloud()` silently returns `false` when `cloudSyncEnabled` is `false` without showing any user feedback, even when `showStatus = true`. A future improvement should show "Cloud sync is not enabled" in that case. Also, the browser does not track or send `baseDocVersion`, relying solely on `savedAt` string comparison for conflict detection — this should be addressed to prevent false conflicts from timestamp format differences.

Generated with [Claude Code](https://claude.com/claude-code)