### PR TITLE
visual: add blended depth offset for parent-grouped subtree indentation

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -1974,7 +1974,14 @@ function buildLayout(state: AppState): LayoutResult {
   const pos: Record<string, NodePosition> = {};
   const order: string[] = [];
 
-  function place(nodeId: string, topY: number): number {
+  const depthOffsetFactor = VIEWER_TUNING.layout.depthOffsetFactor;
+
+  function place(
+    nodeId: string,
+    topY: number,
+    parentX: number | null,
+    parentW: number | null,
+  ): number {
     const node = state.nodes[nodeId];
     if (!node) {
       return VIEWER_TUNING.layout.leafHeight;
@@ -1984,8 +1991,18 @@ function buildLayout(state: AppState): LayoutResult {
     const h = subtreeHeight(nodeId);
     const centerY = topY + h / 2;
 
+    // Blend between depth-aligned X (legacy) and parent-relative X
+    const baseX = xByDepth[depth]!;
+    let nodeX: number;
+    if (parentX === null || parentW === null) {
+      nodeX = baseX; // root node
+    } else {
+      const parentRelX = parentX + parentW + VIEWER_TUNING.layout.columnGap;
+      nodeX = baseX + (parentRelX - baseX) * depthOffsetFactor;
+    }
+
     pos[nodeId] = {
-      x: xByDepth[depth]!,
+      x: nodeX,
       y: centerY,
       depth,
       w: metrics[nodeId]!.w,
@@ -1995,7 +2012,7 @@ function buildLayout(state: AppState): LayoutResult {
 
     let placeCursorY = topY;
     visibleChildren(node).forEach((childId, i, arr) => {
-      const childH = place(childId, placeCursorY);
+      const childH = place(childId, placeCursorY, nodeX, metrics[nodeId]!.w);
       placeCursorY += childH;
       if (i < arr.length - 1) {
         placeCursorY += VIEWER_TUNING.layout.siblingGap;
@@ -2005,12 +2022,20 @@ function buildLayout(state: AppState): LayoutResult {
     return h;
   }
 
-  const totalHeight = place(displayRootId, VIEWER_TUNING.layout.topPad);
+  const totalHeight = place(displayRootId, VIEWER_TUNING.layout.topPad, null, null);
+
+  // Compute totalWidth from placed node positions (parent-relative X may exceed cursorX)
+  let maxRight = VIEWER_TUNING.layout.minCanvasWidth;
+  for (const nodeId of order) {
+    const p = pos[nodeId]!;
+    maxRight = Math.max(maxRight, p.x + p.w + VIEWER_TUNING.layout.nodeRightPad);
+  }
+
   return {
     pos,
     order,
     totalHeight,
-    totalWidth: cursorX + VIEWER_TUNING.layout.canvasRightPad,
+    totalWidth: Math.max(maxRight + VIEWER_TUNING.layout.canvasRightPad, cursorX + VIEWER_TUNING.layout.canvasRightPad),
   };
 }
 

--- a/beta/src/browser/viewer.tuning.ts
+++ b/beta/src/browser/viewer.tuning.ts
@@ -25,6 +25,7 @@ interface ViewerTuning {
     edgeEndPad: number;
     rootIndicatorPad: number;
     nodeIndicatorPad: number;
+    depthOffsetFactor: number;
   };
   zoom: {
     min: number;
@@ -93,6 +94,9 @@ const VIEWER_TUNING: ViewerTuning = {
     rootIndicatorPad: 16,
     // Spacing for non-root expand/collapse or status indicators.
     nodeIndicatorPad: 10,
+    // Blend factor for depth offset: 0.0 = depth-aligned columns (legacy),
+    // 1.0 = fully parent-relative positioning. Intermediate values blend.
+    depthOffsetFactor: 0.5,
   },
   zoom: {
     // Minimum zoom-out level allowed in the viewer.


### PR DESCRIPTION
## Summary
- Add `depthOffsetFactor` tuning parameter (default 0.5) to blend between depth-aligned columns and parent-relative positioning
- Update `place()` in `buildLayout` to compute blended X based on parent position
- Recalculate `totalWidth` from actual placed node positions to handle parent-relative offsets

## Changed files
- `beta/src/browser/viewer.tuning.ts` — new `depthOffsetFactor` field in layout config
- `beta/src/browser/viewer.ts` — `place()` signature + logic, `totalWidth` calculation

## Test plan
- [ ] Visual check: open viewer with nested subtrees, verify indentation blends correctly
- [ ] Adjust `depthOffsetFactor` to 0.0 and 1.0, verify legacy and full parent-relative modes
- [ ] TypeScript compile check passes