### PR TITLE
data: Flash ingest pipeline Phase 1

### DIFF
--- a/beta/src/node/flash_ingest.ts
+++ b/beta/src/node/flash_ingest.ts
@@ -1,0 +1,510 @@
+"use strict";
+
+import { RapidMvpModel } from "./rapid_mvp";
+import type {
+  FlashSourceType,
+  FlashDraftStatus,
+  DraftNode,
+  StructuredDraft,
+  FlashDraft,
+  FlashIngestRequest,
+  FlashApproveRequest,
+  TreeNode,
+} from "../shared/types";
+
+// ---------------------------------------------------------------------------
+// Flash attribute keys (m3e: namespace)
+// ---------------------------------------------------------------------------
+
+export const FLASH_ATTR = {
+  BAND: "m3e:band",
+  SOURCE_TYPE: "m3e:sourceType",
+  SOURCE_URL: "m3e:sourceUrl",
+  CAPTURED_AT: "m3e:capturedAt",
+  CONFIDENCE: "m3e:confidence",
+  STATUS: "m3e:status",
+} as const;
+
+// ---------------------------------------------------------------------------
+// ID generation
+// ---------------------------------------------------------------------------
+
+let _idCounter = 0;
+
+function newDraftId(): string {
+  _idCounter++;
+  return `d_${Date.now()}_${_idCounter.toString(36)}`;
+}
+
+function newTempId(index: number): string {
+  return `t_${String(index + 1).padStart(3, "0")}`;
+}
+
+/** Reset counter (for tests). */
+export function _resetIdCounter(): void {
+  _idCounter = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Draft Store (in-memory Map)
+// ---------------------------------------------------------------------------
+
+const drafts = new Map<string, FlashDraft>();
+
+export function getDrafts(): Map<string, FlashDraft> {
+  return drafts;
+}
+
+export function clearDrafts(): void {
+  drafts.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Text -> tree conversion (no AI)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse Markdown text into a flat list of DraftNode.
+ *
+ * Rules:
+ * - Markdown headings (# ... ######) create parent-child hierarchy.
+ * - Bullet list items (- or *) under a heading become children of that heading.
+ * - Plain text with no structure becomes a single node.
+ */
+export function parseMarkdownToNodes(
+  text: string,
+  sourceRef: string,
+  maxDepth: number = 4,
+): DraftNode[] {
+  const lines = text.split(/\r?\n/);
+  const nodes: DraftNode[] = [];
+
+  // Stack tracks [tempId, headingLevel]. Root is virtual level 0.
+  const stack: Array<{ tempId: string | null; level: number }> = [
+    { tempId: null, level: 0 },
+  ];
+
+  let nodeIndex = 0;
+  let currentHeadingId: string | null = null;
+  let pendingPlainLines: string[] = [];
+
+  function flushPlainLines(): void {
+    if (pendingPlainLines.length === 0) return;
+    const combined = pendingPlainLines.join("\n").trim();
+    if (!combined) {
+      pendingPlainLines = [];
+      return;
+    }
+
+    const parentId = currentHeadingId ?? stack[stack.length - 1].tempId;
+    const id = newTempId(nodeIndex++);
+    nodes.push({
+      tempId: id,
+      parentTempId: parentId,
+      text: combined,
+      details: "",
+      note: "",
+      confidence: 0.7,  // manual input confidence
+      sourceRef,
+      attributes: {},
+    });
+    pendingPlainLines = [];
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine;
+
+    // Check for heading
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      flushPlainLines();
+
+      const level = Math.min(headingMatch[1].length, maxDepth);
+      const headingText = headingMatch[2].trim();
+
+      // Pop stack until we find a parent with level < current
+      while (stack.length > 1 && stack[stack.length - 1].level >= level) {
+        stack.pop();
+      }
+
+      const parentTempId = stack[stack.length - 1].tempId;
+      const id = newTempId(nodeIndex++);
+      nodes.push({
+        tempId: id,
+        parentTempId: parentTempId,
+        text: headingText,
+        details: "",
+        note: "",
+        confidence: 0.7,
+        sourceRef,
+        attributes: {},
+      });
+
+      stack.push({ tempId: id, level });
+      currentHeadingId = id;
+      continue;
+    }
+
+    // Check for bullet item
+    const bulletMatch = line.match(/^\s*[-*]\s+(.+)$/);
+    if (bulletMatch) {
+      flushPlainLines();
+
+      const bulletText = bulletMatch[1].trim();
+      const parentId = currentHeadingId ?? stack[stack.length - 1].tempId;
+      const id = newTempId(nodeIndex++);
+      nodes.push({
+        tempId: id,
+        parentTempId: parentId,
+        text: bulletText,
+        details: "",
+        note: "",
+        confidence: 0.7,
+        sourceRef,
+        attributes: {},
+      });
+      continue;
+    }
+
+    // Plain text line -- accumulate
+    if (line.trim()) {
+      pendingPlainLines.push(line.trim());
+    } else if (pendingPlainLines.length > 0) {
+      // Empty line flushes accumulated plain text
+      flushPlainLines();
+    }
+  }
+
+  flushPlainLines();
+
+  // If no structure was found, create a single node
+  if (nodes.length === 0 && text.trim()) {
+    nodes.push({
+      tempId: newTempId(nodeIndex),
+      parentTempId: null,
+      text: text.trim(),
+      details: "",
+      note: "",
+      confidence: 0.7,
+      sourceRef,
+      attributes: {},
+    });
+  }
+
+  return nodes;
+}
+
+/**
+ * Parse plain text into nodes.
+ * Line breaks create separate nodes under a common root.
+ */
+export function parsePlainTextToNodes(
+  text: string,
+  sourceRef: string,
+): DraftNode[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const lines = trimmed.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+
+  if (lines.length === 1) {
+    return [
+      {
+        tempId: newTempId(0),
+        parentTempId: null,
+        text: lines[0],
+        details: "",
+        note: "",
+        confidence: 0.7,
+        sourceRef,
+        attributes: {},
+      },
+    ];
+  }
+
+  // Multiple lines: first line becomes root, rest become children
+  const nodes: DraftNode[] = [];
+  const rootId = newTempId(0);
+  nodes.push({
+    tempId: rootId,
+    parentTempId: null,
+    text: lines[0],
+    details: "",
+    note: "",
+    confidence: 0.7,
+    sourceRef,
+    attributes: {},
+  });
+
+  for (let i = 1; i < lines.length; i++) {
+    nodes.push({
+      tempId: newTempId(i),
+      parentTempId: rootId,
+      text: lines[i],
+      details: "",
+      note: "",
+      confidence: 0.7,
+      sourceRef,
+      attributes: {},
+    });
+  }
+
+  return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Extract title from content
+// ---------------------------------------------------------------------------
+
+function extractTitle(sourceType: FlashSourceType, content: string): string {
+  if (sourceType === "markdown") {
+    const match = content.match(/^#\s+(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  // Use first non-empty line, truncated
+  const firstLine = content.split(/\r?\n/).find((l) => l.trim());
+  if (firstLine) {
+    const trimmed = firstLine.trim();
+    return trimmed.length > 60 ? trimmed.slice(0, 57) + "..." : trimmed;
+  }
+  return "(untitled)";
+}
+
+// ---------------------------------------------------------------------------
+// Ingest
+// ---------------------------------------------------------------------------
+
+export function ingestSingle(request: FlashIngestRequest): FlashDraft {
+  const { docId, sourceType, content, options } = request;
+
+  if (!docId || !content || !content.trim()) {
+    throw new Error("docId and content are required.");
+  }
+
+  if (sourceType !== "text" && sourceType !== "markdown") {
+    throw new Error(`Unsupported sourceType: ${sourceType}. Phase 1 supports "text" and "markdown".`);
+  }
+
+  const maxDepth = options?.maxDepth ?? 4;
+  const sourceRef = `${sourceType}:inline`;
+
+  // Parse content into nodes
+  let draftNodes: DraftNode[];
+  if (sourceType === "markdown") {
+    draftNodes = parseMarkdownToNodes(content, sourceRef, maxDepth);
+  } else {
+    draftNodes = parsePlainTextToNodes(content, sourceRef);
+  }
+
+  const title = extractTitle(sourceType, content);
+  const now = new Date().toISOString();
+  const draftId = newDraftId();
+
+  const draft: FlashDraft = {
+    id: draftId,
+    docId,
+    sourceType,
+    sourceRef,
+    title,
+    extractedText: content,
+    structured: {
+      nodes: draftNodes,
+      suggestedParentId: options?.targetNodeId ?? null,
+    },
+    status: "pending",
+    approvedNodeIds: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  drafts.set(draftId, draft);
+  return draft;
+}
+
+export function ingestBatch(
+  items: FlashIngestRequest[],
+): FlashDraft[] {
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error("items array is required and must not be empty.");
+  }
+  return items.map((item) => ingestSingle(item));
+}
+
+// ---------------------------------------------------------------------------
+// Draft queries
+// ---------------------------------------------------------------------------
+
+export function listDrafts(filters?: {
+  docId?: string;
+  status?: FlashDraftStatus;
+}): FlashDraft[] {
+  let result = Array.from(drafts.values());
+
+  if (filters?.docId) {
+    result = result.filter((d) => d.docId === filters.docId);
+  }
+  if (filters?.status) {
+    result = result.filter((d) => d.status === filters.status);
+  }
+
+  // Sort by createdAt descending
+  result.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return result;
+}
+
+export function getDraft(draftId: string): FlashDraft | undefined {
+  return drafts.get(draftId);
+}
+
+export function deleteDraft(draftId: string): boolean {
+  return drafts.delete(draftId);
+}
+
+// ---------------------------------------------------------------------------
+// Approve
+// ---------------------------------------------------------------------------
+
+/**
+ * Approve a draft and commit its nodes to the model.
+ *
+ * Returns the list of committed node IDs.
+ */
+export function approveDraft(
+  draftId: string,
+  request: FlashApproveRequest,
+  model: RapidMvpModel,
+): { committedNodeIds: string[]; parentId: string } {
+  const draft = drafts.get(draftId);
+  if (!draft) {
+    throw new Error(`Draft not found: ${draftId}`);
+  }
+  if (draft.status !== "pending") {
+    throw new Error(`Draft ${draftId} is not pending (status: ${draft.status}).`);
+  }
+
+  const { mode, selectedNodeIds, targetParentId, edits } = request;
+
+  // Determine which nodes to commit
+  let nodesToCommit: DraftNode[];
+  if (mode === "all") {
+    nodesToCommit = [...draft.structured.nodes];
+  } else if (mode === "partial") {
+    if (!selectedNodeIds || selectedNodeIds.length === 0) {
+      throw new Error("selectedNodeIds is required for partial approval.");
+    }
+    const selected = new Set(selectedNodeIds);
+    nodesToCommit = draft.structured.nodes.filter((n) => selected.has(n.tempId));
+
+    // Auto-include ancestor nodes that are needed for hierarchy
+    const allTempIds = new Set(draft.structured.nodes.map((n) => n.tempId));
+    const nodeByTempId = new Map(draft.structured.nodes.map((n) => [n.tempId, n]));
+    const finalSet = new Set(nodesToCommit.map((n) => n.tempId));
+
+    for (const node of nodesToCommit) {
+      let current = node;
+      while (current.parentTempId && allTempIds.has(current.parentTempId) && !finalSet.has(current.parentTempId)) {
+        finalSet.add(current.parentTempId);
+        current = nodeByTempId.get(current.parentTempId)!;
+      }
+    }
+
+    nodesToCommit = draft.structured.nodes.filter((n) => finalSet.has(n.tempId));
+  } else {
+    throw new Error(`Invalid mode: ${mode}. Must be "all" or "partial".`);
+  }
+
+  // Apply edits
+  if (edits) {
+    for (const node of nodesToCommit) {
+      const edit = edits[node.tempId];
+      if (edit) {
+        if (edit.text !== undefined) node.text = edit.text;
+        if (edit.details !== undefined) node.details = edit.details;
+        if (edit.note !== undefined) node.note = edit.note;
+        // Editing = confidence 0.8
+        node.confidence = 0.8;
+      }
+    }
+  }
+
+  // Determine parent in the model
+  const parentId = targetParentId
+    ?? draft.structured.suggestedParentId
+    ?? model.state.rootId;
+
+  // Ensure parent exists in model
+  if (!model.state.nodes[parentId]) {
+    throw new Error(`Target parent node not found: ${parentId}`);
+  }
+
+  // Ensure _inbox scope exists
+  const inboxNodeId = ensureInboxNode(model, parentId);
+
+  // Map tempId -> real nodeId
+  const tempToReal = new Map<string, string>();
+  const committedNodeIds: string[] = [];
+  const now = new Date().toISOString();
+
+  // Process in order (parents before children)
+  for (const draftNode of nodesToCommit) {
+    let realParentId: string;
+    if (draftNode.parentTempId && tempToReal.has(draftNode.parentTempId)) {
+      realParentId = tempToReal.get(draftNode.parentTempId)!;
+    } else {
+      realParentId = inboxNodeId;
+    }
+
+    const nodeId = model.addNode(realParentId, draftNode.text);
+    tempToReal.set(draftNode.tempId, nodeId);
+    committedNodeIds.push(nodeId);
+
+    // Set node properties via direct mutation (model exposes state)
+    const node = model.state.nodes[nodeId];
+    if (node) {
+      node.details = draftNode.details;
+      node.note = draftNode.note;
+      node.attributes = {
+        ...draftNode.attributes,
+        [FLASH_ATTR.BAND]: "flash",
+        [FLASH_ATTR.SOURCE_TYPE]: draft.sourceType,
+        [FLASH_ATTR.SOURCE_URL]: draft.sourceRef,
+        [FLASH_ATTR.CAPTURED_AT]: now,
+        [FLASH_ATTR.CONFIDENCE]: String(draftNode.confidence),
+        [FLASH_ATTR.STATUS]: "draft",
+      };
+    }
+  }
+
+  // Update draft status
+  if (mode === "all") {
+    draft.status = "approved";
+  } else {
+    draft.status = "partial";
+    draft.approvedNodeIds = committedNodeIds;
+  }
+  draft.updatedAt = new Date().toISOString();
+
+  return { committedNodeIds, parentId: inboxNodeId };
+}
+
+// ---------------------------------------------------------------------------
+// _inbox node helper
+// ---------------------------------------------------------------------------
+
+const INBOX_TEXT = "_inbox";
+
+function ensureInboxNode(model: RapidMvpModel, fallbackParentId: string): string {
+  // Look for existing _inbox node under root
+  const root = model.state.nodes[model.state.rootId];
+  if (root) {
+    for (const childId of root.children) {
+      const child = model.state.nodes[childId];
+      if (child && child.text === INBOX_TEXT) {
+        return childId;
+      }
+    }
+  }
+
+  // Create _inbox node under root
+  return model.addNode(model.state.rootId, INBOX_TEXT);
+}

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -37,7 +37,24 @@ import {
 } from "./collab";
 import { initAuditFile, recordAudit, getRecentAuditEntries } from "./audit_log";
 import { getPresenceList, touchPresence, removePresence } from "./presence";
-import type { AiSubagentRequest, AppState, LinearTransformRequest, SavedDoc } from "../shared/types";
+import {
+  ingestSingle,
+  ingestBatch,
+  listDrafts,
+  getDraft,
+  deleteDraft,
+  approveDraft,
+} from "./flash_ingest";
+import type {
+  AiSubagentRequest,
+  AppState,
+  LinearTransformRequest,
+  SavedDoc,
+  FlashIngestRequest,
+  FlashIngestBatchRequest,
+  FlashApproveRequest,
+  FlashDraftStatus,
+} from "../shared/types";
 
 // After compilation, this file lives at dist/node/start_viewer.js.
 // ROOT must point two levels up to the mvp/ directory.
@@ -319,6 +336,162 @@ function parseAiSubagentRoute(urlPath: string): { subagent: string } | null {
 function isAiStatusRoute(urlPath: string): boolean {
   const pathname = new URL(urlPath, "http://localhost").pathname;
   return pathname === "/api/ai/status";
+}
+
+// ---------------------------------------------------------------------------
+// Flash API route parsing
+// ---------------------------------------------------------------------------
+
+type FlashRoute =
+  | { action: "ingest" }
+  | { action: "drafts" }
+  | { action: "draft"; draftId: string }
+  | { action: "approve"; draftId: string }
+  | { action: "delete"; draftId: string }
+  | null;
+
+function parseFlashRoute(urlPath: string, method: string): FlashRoute {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  if (!pathname.startsWith("/api/flash/")) return null;
+
+  if (pathname === "/api/flash/ingest" && method === "POST") {
+    return { action: "ingest" };
+  }
+
+  if (pathname === "/api/flash/drafts" && method === "GET") {
+    return { action: "drafts" };
+  }
+
+  const draftMatch = pathname.match(/^\/api\/flash\/draft\/([^/]+)$/);
+  if (draftMatch) {
+    const draftId = decodeURIComponent(draftMatch[1]);
+    if (method === "GET") return { action: "draft", draftId };
+    if (method === "DELETE") return { action: "delete", draftId };
+  }
+
+  const approveMatch = pathname.match(/^\/api\/flash\/draft\/([^/]+)\/approve$/);
+  if (approveMatch && method === "POST") {
+    return { action: "approve", draftId: decodeURIComponent(approveMatch[1]) };
+  }
+
+  return null;
+}
+
+async function handleFlashApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: Exclude<FlashRoute, null>,
+): Promise<void> {
+  try {
+    switch (route.action) {
+      case "ingest": {
+        const rawBody = await readRequestBody(req);
+        const parsed = JSON.parse(rawBody);
+
+        // Support batch: { items: [...] }
+        if (parsed && Array.isArray(parsed.items)) {
+          const results = ingestBatch(parsed.items as FlashIngestRequest[]);
+          sendJson(res, 202, {
+            ok: true,
+            drafts: results.map((d) => ({
+              draftId: d.id,
+              status: d.status,
+              title: d.title,
+              nodeCount: d.structured.nodes.length,
+            })),
+            message: `${results.length} draft(s) created.`,
+          });
+          return;
+        }
+
+        // Single ingest
+        const request = parsed as FlashIngestRequest;
+        const draft = ingestSingle(request);
+        sendJson(res, 202, {
+          ok: true,
+          draftId: draft.id,
+          status: draft.status,
+          title: draft.title,
+          nodeCount: draft.structured.nodes.length,
+          message: "Draft created.",
+        });
+        return;
+      }
+
+      case "drafts": {
+        const url = new URL(req.url ?? "/", "http://localhost");
+        const docId = url.searchParams.get("docId") ?? undefined;
+        const status = url.searchParams.get("status") as FlashDraftStatus | undefined;
+        const results = listDrafts({ docId, status: status || undefined });
+        sendJson(res, 200, {
+          ok: true,
+          drafts: results.map((d) => ({
+            id: d.id,
+            docId: d.docId,
+            sourceType: d.sourceType,
+            sourceRef: d.sourceRef,
+            title: d.title,
+            nodeCount: d.structured.nodes.length,
+            status: d.status,
+            createdAt: d.createdAt,
+          })),
+        });
+        return;
+      }
+
+      case "draft": {
+        const draft = getDraft(route.draftId);
+        if (!draft) {
+          sendJson(res, 404, { ok: false, error: `Draft not found: ${route.draftId}` });
+          return;
+        }
+        sendJson(res, 200, { ok: true, draft });
+        return;
+      }
+
+      case "approve": {
+        const rawBody = await readRequestBody(req);
+        const request = JSON.parse(rawBody) as FlashApproveRequest;
+        const draft = getDraft(route.draftId);
+        if (!draft) {
+          sendJson(res, 404, { ok: false, error: `Draft not found: ${route.draftId}` });
+          return;
+        }
+
+        // Load model to commit nodes
+        const model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, draft.docId);
+        const result = approveDraft(route.draftId, request, model);
+
+        // Save updated model
+        model.saveToSqlite(SQLITE_DB_PATH, draft.docId);
+
+        sendJson(res, 200, {
+          ok: true,
+          committedNodeIds: result.committedNodeIds,
+          parentId: result.parentId,
+          message: `${result.committedNodeIds.length} nodes committed to ${draft.docId}`,
+        });
+        return;
+      }
+
+      case "delete": {
+        const deleted = deleteDraft(route.draftId);
+        if (!deleted) {
+          sendJson(res, 404, { ok: false, error: `Draft not found: ${route.draftId}` });
+          return;
+        }
+        sendJson(res, 200, { ok: true, message: `Draft ${route.draftId} deleted` });
+        return;
+      }
+    }
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      sendJson(res, 400, { ok: false, error: "Invalid JSON body." });
+      return;
+    }
+    const message = (err as Error).message || "Flash API error.";
+    sendJson(res, 400, { ok: false, error: message });
+  }
 }
 
 // Cloud sync helpers removed — now handled by CloudSyncTransport implementations
@@ -987,6 +1160,12 @@ export function createAppServer(): http.Server {
 
     if (isLinearTransformRoute(req.url ?? "/")) {
       await handleLinearTransformApi(req, res);
+      return;
+    }
+
+    const flashRoute = parseFlashRoute(req.url ?? "/", req.method ?? "GET");
+    if (flashRoute) {
+      await handleFlashApi(req, res, flashRoute);
       return;
     }
 

--- a/beta/src/shared/types.ts
+++ b/beta/src/shared/types.ts
@@ -151,6 +151,65 @@ export interface CloudSyncTransport {
   status(docId: string): Promise<SyncStatus>;
 }
 
+// ---------------------------------------------------------------------------
+// Flash Ingest Pipeline
+// ---------------------------------------------------------------------------
+
+export type FlashSourceType = "text" | "markdown";
+
+export type FlashDraftStatus = "pending" | "approved" | "partial" | "rejected";
+
+export interface DraftNode {
+  tempId: string;
+  parentTempId: string | null;
+  text: string;
+  details: string;
+  note: string;
+  confidence: number;
+  sourceRef: string;
+  attributes: Record<string, string>;
+}
+
+export interface StructuredDraft {
+  nodes: DraftNode[];
+  suggestedParentId: string | null;
+}
+
+export interface FlashDraft {
+  id: string;
+  docId: string;
+  sourceType: FlashSourceType;
+  sourceRef: string;
+  title: string;
+  extractedText: string;
+  structured: StructuredDraft;
+  status: FlashDraftStatus;
+  approvedNodeIds: string[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FlashIngestRequest {
+  docId: string;
+  sourceType: FlashSourceType;
+  content: string;
+  options?: {
+    maxDepth?: number;
+    targetNodeId?: string;
+  };
+}
+
+export interface FlashIngestBatchRequest {
+  items: FlashIngestRequest[];
+}
+
+export interface FlashApproveRequest {
+  mode: "all" | "partial";
+  selectedNodeIds?: string[];
+  targetParentId?: string;
+  edits?: Record<string, { text?: string; details?: string; note?: string }>;
+}
+
 export interface AiSubagentRequest {
   documentId: string;
   scopeId: string;

--- a/beta/tests/unit/flash_ingest.test.js
+++ b/beta/tests/unit/flash_ingest.test.js
@@ -1,0 +1,463 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  parseMarkdownToNodes,
+  parsePlainTextToNodes,
+  ingestSingle,
+  ingestBatch,
+  listDrafts,
+  getDraft,
+  deleteDraft,
+  approveDraft,
+  clearDrafts,
+  _resetIdCounter,
+  FLASH_ATTR,
+} = require("../../dist/node/flash_ingest.js");
+
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+test.beforeEach(() => {
+  clearDrafts();
+  _resetIdCounter();
+});
+
+// ---------------------------------------------------------------------------
+// parseMarkdownToNodes
+// ---------------------------------------------------------------------------
+
+test("parseMarkdownToNodes: single heading", () => {
+  const nodes = parseMarkdownToNodes("# Hello World", "md:inline");
+  assert.equal(nodes.length, 1);
+  assert.equal(nodes[0].text, "Hello World");
+  assert.equal(nodes[0].parentTempId, null);
+  assert.equal(nodes[0].confidence, 0.7);
+});
+
+test("parseMarkdownToNodes: nested headings", () => {
+  const md = `# Root
+## Child A
+### Grandchild
+## Child B`;
+  const nodes = parseMarkdownToNodes(md, "md:inline");
+  assert.equal(nodes.length, 4);
+
+  // Root
+  assert.equal(nodes[0].text, "Root");
+  assert.equal(nodes[0].parentTempId, null);
+
+  // Child A -> parent is Root
+  assert.equal(nodes[1].text, "Child A");
+  assert.equal(nodes[1].parentTempId, nodes[0].tempId);
+
+  // Grandchild -> parent is Child A
+  assert.equal(nodes[2].text, "Grandchild");
+  assert.equal(nodes[2].parentTempId, nodes[1].tempId);
+
+  // Child B -> parent is Root (sibling of Child A)
+  assert.equal(nodes[3].text, "Child B");
+  assert.equal(nodes[3].parentTempId, nodes[0].tempId);
+});
+
+test("parseMarkdownToNodes: bullet items under heading", () => {
+  const md = `# Topics
+- Item A
+- Item B
+- Item C`;
+  const nodes = parseMarkdownToNodes(md, "md:inline");
+  assert.equal(nodes.length, 4);
+  assert.equal(nodes[0].text, "Topics");
+  assert.equal(nodes[1].text, "Item A");
+  assert.equal(nodes[1].parentTempId, nodes[0].tempId);
+  assert.equal(nodes[2].text, "Item B");
+  assert.equal(nodes[3].text, "Item C");
+});
+
+test("parseMarkdownToNodes: plain text with no structure", () => {
+  const nodes = parseMarkdownToNodes("Just some text here", "md:inline");
+  assert.equal(nodes.length, 1);
+  assert.equal(nodes[0].text, "Just some text here");
+  assert.equal(nodes[0].parentTempId, null);
+});
+
+test("parseMarkdownToNodes: empty input", () => {
+  const nodes = parseMarkdownToNodes("", "md:inline");
+  assert.equal(nodes.length, 0);
+});
+
+test("parseMarkdownToNodes: respects maxDepth", () => {
+  const md = `# Level 1
+## Level 2
+### Level 3
+#### Level 4
+##### Level 5`;
+  const nodes = parseMarkdownToNodes(md, "md:inline", 3);
+  // Levels 4 and 5 get clamped to level 3
+  assert.equal(nodes.length, 5);
+  // Level 4 (clamped to 3) becomes sibling of Level 3
+  assert.equal(nodes[3].parentTempId, nodes[1].tempId);
+});
+
+test("parseMarkdownToNodes: asterisk bullets", () => {
+  const md = `# List
+* First
+* Second`;
+  const nodes = parseMarkdownToNodes(md, "md:inline");
+  assert.equal(nodes.length, 3);
+  assert.equal(nodes[1].text, "First");
+  assert.equal(nodes[2].text, "Second");
+});
+
+// ---------------------------------------------------------------------------
+// parsePlainTextToNodes
+// ---------------------------------------------------------------------------
+
+test("parsePlainTextToNodes: single line", () => {
+  const nodes = parsePlainTextToNodes("Hello", "text:inline");
+  assert.equal(nodes.length, 1);
+  assert.equal(nodes[0].text, "Hello");
+  assert.equal(nodes[0].parentTempId, null);
+});
+
+test("parsePlainTextToNodes: multiple lines", () => {
+  const nodes = parsePlainTextToNodes("Title\nLine 2\nLine 3", "text:inline");
+  assert.equal(nodes.length, 3);
+  assert.equal(nodes[0].text, "Title");
+  assert.equal(nodes[0].parentTempId, null);
+  assert.equal(nodes[1].text, "Line 2");
+  assert.equal(nodes[1].parentTempId, nodes[0].tempId);
+  assert.equal(nodes[2].text, "Line 3");
+  assert.equal(nodes[2].parentTempId, nodes[0].tempId);
+});
+
+test("parsePlainTextToNodes: empty input", () => {
+  const nodes = parsePlainTextToNodes("", "text:inline");
+  assert.equal(nodes.length, 0);
+});
+
+test("parsePlainTextToNodes: whitespace only", () => {
+  const nodes = parsePlainTextToNodes("   \n  \n  ", "text:inline");
+  assert.equal(nodes.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// ingestSingle
+// ---------------------------------------------------------------------------
+
+test("ingestSingle: creates draft from text", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "Quick note",
+  });
+
+  assert.ok(draft.id.startsWith("d_"));
+  assert.equal(draft.docId, "test-doc");
+  assert.equal(draft.sourceType, "text");
+  assert.equal(draft.status, "pending");
+  assert.equal(draft.structured.nodes.length, 1);
+  assert.equal(draft.structured.nodes[0].text, "Quick note");
+  assert.equal(draft.title, "Quick note");
+});
+
+test("ingestSingle: creates draft from markdown", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "markdown",
+    content: "# My Doc\n## Section A\n- point 1\n- point 2",
+  });
+
+  assert.equal(draft.sourceType, "markdown");
+  assert.equal(draft.title, "My Doc");
+  assert.equal(draft.structured.nodes.length, 4);
+});
+
+test("ingestSingle: throws on empty content", () => {
+  assert.throws(
+    () => ingestSingle({ docId: "test", sourceType: "text", content: "" }),
+    { message: "docId and content are required." },
+  );
+});
+
+test("ingestSingle: throws on unsupported sourceType", () => {
+  assert.throws(
+    () => ingestSingle({ docId: "test", sourceType: "pdf", content: "data" }),
+    /Unsupported sourceType/,
+  );
+});
+
+test("ingestSingle: stores draft in memory", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "Test",
+  });
+
+  const retrieved = getDraft(draft.id);
+  assert.ok(retrieved);
+  assert.equal(retrieved.id, draft.id);
+});
+
+test("ingestSingle: uses targetNodeId as suggestedParentId", () => {
+  const draft = ingestSingle({
+    docId: "test",
+    sourceType: "text",
+    content: "Note",
+    options: { targetNodeId: "n_existing_123" },
+  });
+
+  assert.equal(draft.structured.suggestedParentId, "n_existing_123");
+});
+
+// ---------------------------------------------------------------------------
+// ingestBatch
+// ---------------------------------------------------------------------------
+
+test("ingestBatch: creates multiple drafts", () => {
+  const results = ingestBatch([
+    { docId: "doc1", sourceType: "text", content: "First" },
+    { docId: "doc1", sourceType: "text", content: "Second" },
+    { docId: "doc2", sourceType: "markdown", content: "# Third" },
+  ]);
+
+  assert.equal(results.length, 3);
+  assert.equal(results[0].title, "First");
+  assert.equal(results[2].title, "Third");
+});
+
+test("ingestBatch: throws on empty array", () => {
+  assert.throws(
+    () => ingestBatch([]),
+    /items array is required/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// listDrafts / getDraft / deleteDraft
+// ---------------------------------------------------------------------------
+
+test("listDrafts: returns all drafts", () => {
+  ingestSingle({ docId: "a", sourceType: "text", content: "One" });
+  ingestSingle({ docId: "b", sourceType: "text", content: "Two" });
+
+  const all = listDrafts();
+  assert.equal(all.length, 2);
+});
+
+test("listDrafts: filters by docId", () => {
+  ingestSingle({ docId: "a", sourceType: "text", content: "One" });
+  ingestSingle({ docId: "b", sourceType: "text", content: "Two" });
+
+  const filtered = listDrafts({ docId: "a" });
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].docId, "a");
+});
+
+test("deleteDraft: removes draft", () => {
+  const draft = ingestSingle({ docId: "a", sourceType: "text", content: "Del" });
+  assert.ok(getDraft(draft.id));
+
+  const result = deleteDraft(draft.id);
+  assert.equal(result, true);
+  assert.equal(getDraft(draft.id), undefined);
+});
+
+test("deleteDraft: returns false for nonexistent", () => {
+  assert.equal(deleteDraft("nonexistent"), false);
+});
+
+// ---------------------------------------------------------------------------
+// approveDraft
+// ---------------------------------------------------------------------------
+
+test("approveDraft: full approval adds nodes to model", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "markdown",
+    content: "# Topic\n- Point A\n- Point B",
+  });
+
+  const model = new RapidMvpModel("Root");
+  const result = approveDraft(draft.id, { mode: "all" }, model);
+
+  assert.equal(result.committedNodeIds.length, 3); // Topic + Point A + Point B
+  assert.ok(result.parentId); // _inbox node id
+
+  // Verify nodes exist in model
+  for (const nodeId of result.committedNodeIds) {
+    const node = model.state.nodes[nodeId];
+    assert.ok(node, `Node ${nodeId} should exist in model`);
+    assert.equal(node.attributes["m3e:band"], "flash");
+    assert.equal(node.attributes["m3e:sourceType"], "markdown");
+    assert.ok(node.attributes["m3e:confidence"]);
+  }
+
+  // Verify draft status updated
+  const updatedDraft = getDraft(draft.id);
+  assert.equal(updatedDraft.status, "approved");
+});
+
+test("approveDraft: partial approval with ancestor auto-include", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "markdown",
+    content: "# Root Topic\n## Sub Topic\n- Detail",
+  });
+
+  // Select only the leaf node "Detail" -- should auto-include ancestors
+  const detailNode = draft.structured.nodes.find((n) => n.text === "Detail");
+  assert.ok(detailNode);
+
+  const model = new RapidMvpModel("Root");
+  const result = approveDraft(
+    draft.id,
+    { mode: "partial", selectedNodeIds: [detailNode.tempId] },
+    model,
+  );
+
+  // Should include Detail + Sub Topic + Root Topic (ancestors)
+  assert.equal(result.committedNodeIds.length, 3);
+
+  const updatedDraft = getDraft(draft.id);
+  assert.equal(updatedDraft.status, "partial");
+});
+
+test("approveDraft: with edits adjusts text and confidence", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "Original text",
+  });
+
+  const tempId = draft.structured.nodes[0].tempId;
+  const model = new RapidMvpModel("Root");
+  const result = approveDraft(
+    draft.id,
+    {
+      mode: "all",
+      edits: { [tempId]: { text: "Edited text" } },
+    },
+    model,
+  );
+
+  const nodeId = result.committedNodeIds[0];
+  const node = model.state.nodes[nodeId];
+  assert.equal(node.text, "Edited text");
+  assert.equal(node.attributes["m3e:confidence"], "0.8"); // edited -> 0.8
+});
+
+test("approveDraft: throws for non-pending draft", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "Test",
+  });
+
+  const model = new RapidMvpModel("Root");
+  approveDraft(draft.id, { mode: "all" }, model);
+
+  // Try to approve again
+  assert.throws(
+    () => approveDraft(draft.id, { mode: "all" }, model),
+    /not pending/,
+  );
+});
+
+test("approveDraft: throws for nonexistent draft", () => {
+  const model = new RapidMvpModel("Root");
+  assert.throws(
+    () => approveDraft("fake_id", { mode: "all" }, model),
+    /Draft not found/,
+  );
+});
+
+test("approveDraft: _inbox node is created once and reused", () => {
+  const draft1 = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "First",
+  });
+  const draft2 = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "Second",
+  });
+
+  const model = new RapidMvpModel("Root");
+  const result1 = approveDraft(draft1.id, { mode: "all" }, model);
+  const result2 = approveDraft(draft2.id, { mode: "all" }, model);
+
+  // Both should use the same _inbox parent
+  assert.equal(result1.parentId, result2.parentId);
+
+  // The _inbox node should be a child of root
+  const root = model.state.nodes[model.state.rootId];
+  const inboxChildren = root.children.filter((id) => {
+    const n = model.state.nodes[id];
+    return n && n.text === "_inbox";
+  });
+  assert.equal(inboxChildren.length, 1);
+});
+
+test("approveDraft: confidence is 0.7 for manual input", () => {
+  const draft = ingestSingle({
+    docId: "test-doc",
+    sourceType: "text",
+    content: "Manual note",
+  });
+
+  const model = new RapidMvpModel("Root");
+  const result = approveDraft(draft.id, { mode: "all" }, model);
+
+  const node = model.state.nodes[result.committedNodeIds[0]];
+  assert.equal(node.attributes["m3e:confidence"], "0.7");
+});
+
+// ---------------------------------------------------------------------------
+// Flash API integration (via createAppServer)
+// ---------------------------------------------------------------------------
+
+test("Flash API: POST /api/flash/ingest returns 202", async () => {
+  const { createAppServer } = require("../../dist/node/start_viewer.js");
+  const server = createAppServer();
+
+  const body = JSON.stringify({
+    docId: "api-test",
+    sourceType: "text",
+    content: "API test content",
+  });
+
+  const response = await new Promise((resolve) => {
+    const req = {
+      url: "/api/flash/ingest",
+      method: "POST",
+      headers: {},
+      on(event, cb) {
+        if (event === "data") cb(Buffer.from(body));
+        if (event === "end") cb();
+      },
+    };
+
+    const res = {
+      statusCode: 0,
+      headers: {},
+      body: "",
+      setHeader(k, v) { this.headers[k] = v; },
+      end(data) {
+        this.body = data;
+        resolve(this);
+      },
+    };
+
+    // Emit the request event
+    server.emit("request", req, res);
+  });
+
+  assert.equal(response.statusCode, 202);
+  const data = JSON.parse(response.body);
+  assert.equal(data.ok, true);
+  assert.ok(data.draftId);
+
+  server.close();
+  clearDrafts();
+});


### PR DESCRIPTION
## Summary
- Implement Flash input pipeline Phase 1: text and Markdown ingest with in-memory draft store
- Add 5 REST API endpoints: POST /api/flash/ingest, GET /api/flash/drafts, GET /api/flash/draft/:id, POST /api/flash/draft/:id/approve, DELETE /api/flash/draft/:id
- Markdown parsing converts headings to parent-child hierarchy and bullets to child nodes; plain text creates flat/grouped nodes
- Approve flow commits draft nodes to model under `_inbox` with Flash attributes (m3e:band, m3e:confidence, m3e:sourceType, etc.)
- Supports batch ingest, partial approval with ancestor auto-inclusion, and pre-approval text edits

## Files changed
- `beta/src/node/flash_ingest.ts` -- new: draft store, parsers, approve logic
- `beta/src/node/start_viewer.ts` -- Flash API route parsing and handler
- `beta/src/shared/types.ts` -- Flash-related type definitions
- `beta/tests/unit/flash_ingest.test.js` -- 31 tests (all passing)
- `dev-docs/03_Spec/REST_API.md` -- Flash API endpoint documentation

## Test plan
- [x] 31 unit tests covering parsing, ingest, batch, CRUD, approve, partial approve, edits
- [x] All 272 existing tests still pass (1 pre-existing failure in mm_exporter unrelated)
- [x] TypeScript type-check passes with --noEmit
- [ ] Manual API testing with running server (visual team)

🤖 Generated with [Claude Code](https://claude.com/claude-code)