### PR TITLE
feat(e2e): add Playwright E2E test foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ beta/.env
 beta/data/rapid-sample.json
 beta/data/*.sqlite
 beta/test-results/
+beta/tests/e2e/test-results/
 
 final/node_modules/
 final/dist/

--- a/beta/e2e_test_server.js
+++ b/beta/e2e_test_server.js
@@ -1,0 +1,67 @@
+"use strict";
+
+/**
+ * E2E test server for Playwright.
+ *
+ * Uses the full application server (createAppServer) with a temporary SQLite
+ * database so tests are isolated and do not interfere with real data.
+ *
+ * Environment variables:
+ *   M3E_PORT       – port to listen on (default 14173)
+ *   M3E_DATA_DIR   – override data directory (set automatically by this script)
+ *   M3E_DB_FILE    – override database filename (set automatically)
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { spawnSync } = require("child_process");
+
+// Create a temporary data directory for E2E tests.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-e2e-"));
+const testDbFile = "e2e_test.sqlite";
+
+// Set environment BEFORE requiring the app server so it picks up the temp paths.
+process.env.M3E_PORT = process.env.M3E_PORT || "14173";
+process.env.M3E_DATA_DIR = tmpDir;
+process.env.M3E_DB_FILE = testDbFile;
+
+// Ensure sample data is generated into the temp directory.
+const ROOT = __dirname;
+const rapidPath = path.join(ROOT, "dist", "node", "rapid_mvp.js");
+const run = spawnSync(process.execPath, [rapidPath], {
+  cwd: ROOT,
+  stdio: "inherit",
+  env: { ...process.env, M3E_DATA_DIR: tmpDir, M3E_DB_FILE: testDbFile },
+});
+
+if (run.status !== 0) {
+  console.error("Failed to generate sample data for E2E tests.");
+  process.exit(run.status || 1);
+}
+
+// Now load the compiled app server.
+const { createAppServer } = require("./dist/node/start_viewer");
+
+const PORT = Number(process.env.M3E_PORT);
+const server = createAppServer();
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`E2E test server ready: http://127.0.0.1:${PORT}/viewer.html`);
+  console.log(`  Data dir: ${tmpDir}`);
+  console.log(`  DB file:  ${testDbFile}`);
+});
+
+// Clean up temp directory on exit.
+function cleanup() {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log(`Cleaned up temp dir: ${tmpDir}`);
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => { cleanup(); process.exit(0); });
+process.on("SIGTERM", () => { cleanup(); process.exit(0); });

--- a/beta/package.json
+++ b/beta/package.json
@@ -15,7 +15,9 @@
     "test:visual": "playwright test",
     "test:visual:reparent": "playwright test -g \"viewer range select multi reparent\"",
     "test:visual:selection": "playwright test -g \"viewer shift arrow expands selection\"",
-    "test:visual:update": "playwright test --update-snapshots"
+    "test:visual:update": "playwright test --update-snapshots",
+    "test:e2e": "playwright test --config playwright.e2e.config.js",
+    "test:e2e:headed": "playwright test --config playwright.e2e.config.js --headed"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1",

--- a/beta/playwright.e2e.config.js
+++ b/beta/playwright.e2e.config.js
@@ -1,0 +1,43 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+const PORT = process.env.M3E_PORT || "14173";
+
+/**
+ * Playwright config for E2E tests.
+ *
+ * Separate from the visual test config (playwright.config.js) to avoid
+ * interference. Uses a dedicated port (14173) and temp SQLite database.
+ */
+module.exports = defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  outputDir: "./tests/e2e/test-results",
+  webServer: {
+    command: "node ./e2e_test_server.js",
+    url: `http://127.0.0.1:${PORT}/viewer.html`,
+    reuseExistingServer: false,
+    cwd: __dirname,
+    timeout: 30_000,
+    env: {
+      M3E_PORT: PORT,
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/beta/tests/e2e/e2e.spec.js
+++ b/beta/tests/e2e/e2e.spec.js
@@ -1,0 +1,170 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+const BASE = process.env.M3E_PORT
+  ? `http://127.0.0.1:${process.env.M3E_PORT}`
+  : "http://127.0.0.1:14173";
+
+/**
+ * Helper: navigate to viewer.html with a unique doc ID to isolate each test.
+ * Waits for the meta panel to show node count, indicating the document loaded.
+ */
+async function loadViewer(page) {
+  const isolatedDocId = `e2e-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+  const qs = `localDocId=${encodeURIComponent(isolatedDocId)}&cloudDocId=${encodeURIComponent(isolatedDocId)}`;
+  await page.goto(`/viewer.html?${qs}`);
+  // Wait for the viewer to finish loading: the meta element should contain "nodes:".
+  await expect(page.locator("#meta")).toContainText("nodes:", { timeout: 15_000 });
+  return { docId: isolatedDocId };
+}
+
+/**
+ * Helper: parse node count from the meta panel.
+ */
+async function getNodeCount(page) {
+  const metaText = await page.locator("#meta").textContent();
+  const match = (metaText || "").match(/nodes:\s*(\d+)/);
+  if (!match) {
+    throw new Error(`Unable to parse node count from meta: ${metaText}`);
+  }
+  return Number(match[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Page load - viewer.html returns 200
+// ---------------------------------------------------------------------------
+test("viewer.html loads successfully with HTTP 200", async ({ page }) => {
+  const response = await page.goto("/viewer.html");
+  expect(response).not.toBeNull();
+  expect(response.status()).toBe(200);
+
+  // Verify essential page structure exists.
+  await expect(page.locator("#board")).toBeVisible();
+  await expect(page.locator("#canvas")).toBeVisible();
+  // Title is dynamic: "M3E" or "M3E - {root node text}".
+  const title = await page.title();
+  expect(title).toMatch(/^M3E/);
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Root node displays after document load
+// ---------------------------------------------------------------------------
+test("root node is displayed after document load", async ({ page }) => {
+  await loadViewer(page);
+
+  // The meta panel should show at least 1 node.
+  const nodeCount = await getNodeCount(page);
+  expect(nodeCount).toBeGreaterThanOrEqual(1);
+
+  // A root label element should be visible in the SVG canvas.
+  const rootLabels = page.locator("text.label-root");
+  await expect(rootLabels.first()).toBeVisible({ timeout: 5_000 });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Add a child node via Tab key
+// ---------------------------------------------------------------------------
+test("Tab key adds a child node under the selected node", async ({ page }) => {
+  await loadViewer(page);
+  await page.click("#board");
+
+  const initialCount = await getNodeCount(page);
+
+  // Tab adds a child node under the currently selected node.
+  await page.keyboard.press("Tab");
+
+  // Wait for node count to increase.
+  await expect(page.locator("#meta")).toContainText(`nodes: ${initialCount + 1}`, { timeout: 5_000 });
+
+  // The new node should be selected and an inline editor should appear.
+  const editor = page.locator("textarea.inline-node-editor");
+  await expect(editor).toBeVisible({ timeout: 3_000 });
+
+  // Press Escape to cancel editing.
+  await page.keyboard.press("Escape");
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Double-click a node to edit its text
+// ---------------------------------------------------------------------------
+test("select a node and edit its text via Enter key", async ({ page }) => {
+  await loadViewer(page);
+
+  // First click the root node to select it, then use keyboard Enter to edit.
+  // Direct dblclick on SVG elements is unreliable due to pointer intercept,
+  // so we click-to-select then Enter (which triggers inline edit).
+  const rootLabel = page.locator("text.label-root").first();
+  await expect(rootLabel).toBeVisible();
+  await rootLabel.click({ force: true });
+  await page.keyboard.press("Enter");
+
+  // An inline text editor (textarea) should appear.
+  const editor = page.locator("textarea.inline-node-editor");
+  await expect(editor).toBeVisible({ timeout: 3_000 });
+
+  // Type new text and confirm with Escape (commit edit).
+  await editor.fill("E2E Edited Root");
+  await page.keyboard.press("Escape");
+
+  // The meta panel should reflect the new text in the selection.
+  await expect(page.locator("#meta")).toContainText("selected: E2E Edited Root", { timeout: 5_000 });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: API round-trip - POST /api/docs/:id then GET /api/docs/:id
+// ---------------------------------------------------------------------------
+test("API round-trip: POST a document then GET it back", async ({ request }) => {
+  const testDocId = `e2e-api-${Date.now()}`;
+
+  const docPayload = {
+    version: 1,
+    savedAt: new Date().toISOString(),
+    state: {
+      rootId: "root",
+      nodes: {
+        root: {
+          id: "root",
+          parentId: null,
+          children: ["child1"],
+          nodeType: "text",
+          text: "API Test Root",
+          collapsed: false,
+          details: "",
+          note: "",
+          attributes: {},
+          link: "",
+        },
+        child1: {
+          id: "child1",
+          parentId: "root",
+          children: [],
+          nodeType: "text",
+          text: "API Test Child",
+          collapsed: false,
+          details: "",
+          note: "",
+          attributes: {},
+          link: "",
+        },
+      },
+    },
+  };
+
+  // POST the document.
+  const postResponse = await request.post(`/api/docs/${encodeURIComponent(testDocId)}`, {
+    data: docPayload,
+  });
+  expect(postResponse.status()).toBe(200);
+  const postBody = await postResponse.json();
+  expect(postBody.ok).toBe(true);
+
+  // GET the document back.
+  const getResponse = await request.get(`/api/docs/${encodeURIComponent(testDocId)}`);
+  expect(getResponse.status()).toBe(200);
+  const getBody = await getResponse.json();
+  expect(getBody.version).toBe(1);
+  expect(getBody.state.rootId).toBe("root");
+  expect(getBody.state.nodes.root.text).toBe("API Test Root");
+  expect(getBody.state.nodes.child1.text).toBe("API Test Child");
+  expect(getBody.state.nodes.root.children).toContain("child1");
+});


### PR DESCRIPTION
## Summary
- Add E2E Playwright test infrastructure isolated from visual tests (dedicated config, port 14173, temp SQLite DB)
- Implement 5 smoke tests: page load, root node display, Tab add child, Enter edit text, API POST/GET round-trip
- Add npm scripts `test:e2e` and `test:e2e:headed`

## Test plan
- [ ] `npm run test:e2e` passes all 5 tests
- [ ] `npm run test:e2e:headed` opens browser and tests pass visually
- [ ] Temp data directory is cleaned up after test run

Generated with Claude Code