### PR TITLE
fix(test): migrate node:test to vitest for all unit tests

### DIFF
--- a/beta/package-lock.json
+++ b/beta/package-lock.json
@@ -18,7 +18,78 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^18.19.130",
         "typescript": "^5.4.0",
-        "undici-types": "^5.26.5"
+        "undici-types": "^5.26.5",
+        "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@playwright/test": {
@@ -36,6 +107,295 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.0",
@@ -123,6 +483,17 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -132,6 +503,31 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.130",
@@ -149,6 +545,129 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/base64-js": {
@@ -229,6 +748,16 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -243,6 +772,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -298,6 +834,23 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -305,6 +858,34 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-uri-to-path": {
@@ -397,6 +978,289 @@
         "katex": "cli.js"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -424,6 +1288,25 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -442,6 +1325,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -449,6 +1343,33 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/playwright": {
@@ -481,6 +1402,35 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -549,6 +1499,40 @@
         "node": ">= 6"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -580,6 +1564,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -625,6 +1616,30 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -672,6 +1687,50 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -715,6 +1774,206 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/beta/package.json
+++ b/beta/package.json
@@ -9,8 +9,8 @@
     "build:browser": "tsc -p tsconfig.browser.json",
     "start": "node dist/node/start_viewer.js",
     "test": "npm run test:unit",
-    "test:unit": "npm run build:node && node --test tests/unit/*.test.js",
-    "test:unit:watch": "npm run build:node && node --test --watch tests/unit/*.test.js",
+    "test:unit": "npm run build:node && npx vitest run",
+    "test:unit:watch": "npm run build:node && npx vitest --watch",
     "test:ci": "npm run test:unit",
     "test:visual": "playwright test",
     "test:shortcuts": "playwright test tests/visual/shortcuts.spec.js",
@@ -23,7 +23,8 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^18.19.130",
     "typescript": "^5.4.0",
-    "undici-types": "^5.26.5"
+    "undici-types": "^5.26.5",
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.103.0",

--- a/beta/tests/unit/audit_log.test.js
+++ b/beta/tests/unit/audit_log.test.js
@@ -1,7 +1,6 @@
 // @ts-check
 "use strict";
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 
 const { recordAudit, getRecentAuditEntries, getAuditEntriesForNode, resetAuditLog, setBufferSize } = require("../../dist/node/audit_log.js");
 
@@ -13,10 +12,10 @@ test("recordAudit adds entry with timestamp", () => {
     targetNodeId: "n_123",
     details: { text: "hello" },
   });
-  assert.ok(entry.timestamp);
-  assert.equal(entry.userId, "e_test1");
-  assert.equal(entry.operationType, "add");
-  assert.equal(entry.targetNodeId, "n_123");
+  expect(entry.timestamp).toBeTruthy();
+  expect(entry.userId).toBe("e_test1");
+  expect(entry.operationType).toBe("add");
+  expect(entry.targetNodeId).toBe("n_123");
 });
 
 test("getRecentAuditEntries returns entries in order", () => {
@@ -26,9 +25,9 @@ test("getRecentAuditEntries returns entries in order", () => {
   recordAudit({ userId: "u1", operationType: "delete", targetNodeId: "n_3", details: {} });
 
   const entries = getRecentAuditEntries(10);
-  assert.equal(entries.length, 3);
-  assert.equal(entries[0].operationType, "add");
-  assert.equal(entries[2].operationType, "delete");
+  expect(entries.length).toBe(3);
+  expect(entries[0].operationType).toBe("add");
+  expect(entries[2].operationType).toBe("delete");
 });
 
 test("ring buffer enforces max size", () => {
@@ -38,9 +37,9 @@ test("ring buffer enforces max size", () => {
     recordAudit({ userId: "u1", operationType: "add", targetNodeId: `n_${i}`, details: {} });
   }
   const entries = getRecentAuditEntries(10);
-  assert.equal(entries.length, 3);
-  assert.equal(entries[0].targetNodeId, "n_2");
-  assert.equal(entries[2].targetNodeId, "n_4");
+  expect(entries.length).toBe(3);
+  expect(entries[0].targetNodeId).toBe("n_2");
+  expect(entries[2].targetNodeId).toBe("n_4");
   setBufferSize(500); // restore default
 });
 
@@ -51,8 +50,8 @@ test("getAuditEntriesForNode filters by nodeId", () => {
   recordAudit({ userId: "u1", operationType: "edit", targetNodeId: "n_a", details: {} });
 
   const entries = getAuditEntriesForNode("n_a");
-  assert.equal(entries.length, 2);
-  entries.forEach((e) => assert.equal(e.targetNodeId, "n_a"));
+  expect(entries.length).toBe(2);
+  entries.forEach((e) => expect(e.targetNodeId).toBe("n_a"));
 });
 
 test("limit parameter caps returned entries", () => {
@@ -61,6 +60,6 @@ test("limit parameter caps returned entries", () => {
     recordAudit({ userId: "u1", operationType: "add", targetNodeId: `n_${i}`, details: {} });
   }
   const entries = getRecentAuditEntries(3);
-  assert.equal(entries.length, 3);
-  assert.equal(entries[0].targetNodeId, "n_7");
+  expect(entries.length).toBe(3);
+  expect(entries[0].targetNodeId).toBe("n_7");
 });

--- a/beta/tests/unit/backup.test.js
+++ b/beta/tests/unit/backup.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -29,15 +28,15 @@ test("createBackup produces a file in backupDir", async () => {
 
   const result = await createBackup(dbPath, backupDir);
 
-  assert.ok(fs.existsSync(result), "backup file should exist");
-  assert.ok(result.startsWith(backupDir), "backup should be inside backupDir");
-  assert.match(path.basename(result), /^M3E_dataV1_\d{8}_\d{6}\.sqlite$/);
+  expect(fs.existsSync(result)).toBe(true);
+  expect(result.startsWith(backupDir)).toBe(true);
+  expect(path.basename(result)).toMatch(/^M3E_dataV1_\d{8}_\d{6}\.sqlite$/);
 
   // Verify backup is a valid SQLite file
   const backupDb = new Database(result, { readonly: true });
   const row = backupDb.prepare("SELECT id FROM documents WHERE id = ?").get("default");
   backupDb.close();
-  assert.ok(row, "backup DB should contain the document");
+  expect(row).toBeTruthy();
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -47,9 +46,9 @@ test("createBackup creates backupDir if it does not exist", async () => {
   const dbPath = createTestDb(tmpDir);
   const backupDir = path.join(tmpDir, "nested", "deep", "backups");
 
-  assert.ok(!fs.existsSync(backupDir));
+  expect(fs.existsSync(backupDir)).toBe(false);
   await createBackup(dbPath, backupDir);
-  assert.ok(fs.existsSync(backupDir));
+  expect(fs.existsSync(backupDir)).toBe(true);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -75,14 +74,14 @@ test("pruneOldBackups keeps maxGenerations and deletes oldest", () => {
   pruneOldBackups(backupDir, 3);
 
   const remaining = fs.readdirSync(backupDir).sort();
-  assert.equal(remaining.length, 3);
+  expect(remaining.length).toBe(3);
   // Oldest two should be gone
-  assert.ok(!remaining.includes("M3E_dataV1_20260401_100000.sqlite"));
-  assert.ok(!remaining.includes("M3E_dataV1_20260401_110000.sqlite"));
+  expect(remaining.includes("M3E_dataV1_20260401_100000.sqlite")).toBe(false);
+  expect(remaining.includes("M3E_dataV1_20260401_110000.sqlite")).toBe(false);
   // Newest three should remain
-  assert.ok(remaining.includes("M3E_dataV1_20260401_120000.sqlite"));
-  assert.ok(remaining.includes("M3E_dataV1_20260401_130000.sqlite"));
-  assert.ok(remaining.includes("M3E_dataV1_20260401_140000.sqlite"));
+  expect(remaining.includes("M3E_dataV1_20260401_120000.sqlite")).toBe(true);
+  expect(remaining.includes("M3E_dataV1_20260401_130000.sqlite")).toBe(true);
+  expect(remaining.includes("M3E_dataV1_20260401_140000.sqlite")).toBe(true);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -98,7 +97,7 @@ test("pruneOldBackups does nothing when under limit", () => {
   pruneOldBackups(backupDir, 10);
 
   const remaining = fs.readdirSync(backupDir);
-  assert.equal(remaining.length, 2);
+  expect(remaining.length).toBe(2);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -115,9 +114,9 @@ test("pruneOldBackups ignores non-matching files", () => {
   pruneOldBackups(backupDir, 1);
 
   const remaining = fs.readdirSync(backupDir).sort();
-  assert.equal(remaining.length, 2); // 1 backup + 1 random file
-  assert.ok(remaining.includes("random-file.txt"));
-  assert.ok(remaining.includes("M3E_dataV1_20260401_110000.sqlite"));
+  expect(remaining.length).toBe(2); // 1 backup + 1 random file
+  expect(remaining.includes("random-file.txt")).toBe(true);
+  expect(remaining.includes("M3E_dataV1_20260401_110000.sqlite")).toBe(true);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });

--- a/beta/tests/unit/cloud_ops_safety.test.js
+++ b/beta/tests/unit/cloud_ops_safety.test.js
@@ -10,8 +10,7 @@
 //   4. Supabase restore doc ID inconsistency
 // ---------------------------------------------------------------------------
 
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeAll, afterAll } from "vitest";
 const http = require("node:http");
 
 const { createAppServer } = require("../../dist/node/start_viewer.js");
@@ -53,7 +52,7 @@ async function getDoc(docId) {
 // Setup / Teardown
 // ---------------------------------------------------------------------------
 
-test.before(async () => {
+beforeAll(async () => {
   server = createAppServer();
   await new Promise((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -62,7 +61,7 @@ test.before(async () => {
   baseUrl = `http://127.0.0.1:${address.port}`;
 });
 
-test.after(async () => {
+afterAll(async () => {
   if (server) {
     await new Promise((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
@@ -76,59 +75,59 @@ test.after(async () => {
 
 test("POST /api/docs/:id with empty state ({}) returns 400", async () => {
   const { response, payload } = await postDoc("safety-empty-state", { state: {} });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error, "Should have an error message");
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 test("POST /api/docs/:id with empty nodes ({nodes: {}}) returns 400", async () => {
   const { response, payload } = await postDoc("safety-empty-nodes", {
     state: { rootId: "nonexistent", nodes: {} },
   });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error, "Should have an error message");
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 test("POST /api/docs/:id without state field returns 400", async () => {
   const { response, payload } = await postDoc("safety-no-state", { foo: "bar" });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error);
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 test("POST /api/docs/:id with state: null returns 400", async () => {
   const { response, payload } = await postDoc("safety-null-state", { state: null });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error);
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 test("POST /api/docs/:id with state: 'string' returns 400", async () => {
   const { response, payload } = await postDoc("safety-string-state", { state: "not-an-object" });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error);
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 test("POST /api/docs/:id with valid state returns 200 and correct documentId", async () => {
   const docId = "safety-valid-post";
   const state = createValidState("Safety Test Root");
   const { response, payload } = await postDoc(docId, { state });
-  assert.equal(response.status, 200);
-  assert.equal(payload.ok, true);
-  assert.equal(payload.documentId, docId, "Response documentId must match request docId");
+  expect(response.status).toBe(200);
+  expect(payload.ok).toBe(true);
+  expect(payload.documentId).toBe(docId);
 
   // Verify data is readable back with the same doc ID
   const { response: getRes, payload: getPayload } = await getDoc(docId);
-  assert.equal(getRes.status, 200);
-  assert.ok(getPayload.state);
-  assert.ok(Object.keys(getPayload.state.nodes).length >= 3, "Should have root + 2 children");
+  expect(getRes.status).toBe(200);
+  expect(getPayload.state).toBeTruthy();
+  expect(Object.keys(getPayload.state.nodes).length >= 3).toBe(true);
 });
 
 test("GET /api/docs/:id for non-existent doc returns 404 (no auto-creation)", async () => {
   const { response, payload } = await getDoc("safety-nonexistent-doc-xyz");
-  assert.equal(response.status, 404);
-  assert.ok(payload.error);
+  expect(response.status).toBe(404);
+  expect(payload.error).toBeTruthy();
 
   // Confirm a second GET still returns 404 (not auto-created on first access)
   const { response: r2 } = await getDoc("safety-nonexistent-doc-xyz");
-  assert.equal(r2.status, 404);
+  expect(r2.status).toBe(404);
 });
 
 test("POST /api/docs/:id with invalid JSON body returns 400", async () => {
@@ -137,8 +136,8 @@ test("POST /api/docs/:id with invalid JSON body returns 400", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: "{ this is not json }",
   });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error);
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 // =========================================================================
@@ -151,29 +150,27 @@ test("POST then GET with same doc ID returns matching data", async () => {
   await postDoc(docId, { state });
 
   const { response, payload } = await getDoc(docId);
-  assert.equal(response.status, 200);
-  assert.equal(payload.state.rootId, state.rootId, "rootId must be preserved");
-  assert.equal(
+  expect(response.status).toBe(200);
+  expect(payload.state.rootId).toBe(state.rootId);
+  expect(
     Object.keys(payload.state.nodes).length,
-    Object.keys(state.nodes).length,
-    "Node count must match after round-trip",
-  );
+  ).toBe(Object.keys(state.nodes).length);
 });
 
 test("doc ID is case-sensitive and preserved exactly", async () => {
   const docId = "Akaghef-Beta";
   const state = createValidState("Case Test");
   const { payload: postPayload } = await postDoc(docId, { state });
-  assert.equal(postPayload.documentId, docId);
+  expect(postPayload.documentId).toBe(docId);
 
   const { response } = await getDoc(docId);
-  assert.equal(response.status, 200);
+  expect(response.status).toBe(200);
 
   // A different casing should NOT find the doc
   const { response: wrongCase } = await getDoc("akaghef-beta");
   // This may be 404 or 200 depending on SQLite collation; we just verify
   // the correct casing works.
-  assert.equal(response.status, 200);
+  expect(response.status).toBe(200);
 });
 
 test("POST to doc ID 'akaghef-beta' is retrievable with exactly that ID", async () => {
@@ -183,9 +180,9 @@ test("POST to doc ID 'akaghef-beta' is retrievable with exactly that ID", async 
   await postDoc(docId, { state });
 
   const { response, payload } = await getDoc(docId);
-  assert.equal(response.status, 200);
-  assert.ok(payload.state.nodes, "Must have nodes");
-  assert.ok(Object.keys(payload.state.nodes).length > 0, "Nodes must not be empty");
+  expect(response.status).toBe(200);
+  expect(payload.state.nodes).toBeTruthy();
+  expect(Object.keys(payload.state.nodes).length > 0).toBe(true);
 });
 
 test("two different doc IDs store independent data", async () => {
@@ -199,7 +196,7 @@ test("two different doc IDs store independent data", async () => {
   const { payload: p2 } = await getDoc("safety-doc-two");
 
   // rootIds are different (each model generates a unique rootId)
-  assert.notEqual(p1.state.rootId, p2.state.rootId, "Different docs must have different rootIds");
+  expect(p1.state.rootId).not.toBe(p2.state.rootId);
 });
 
 // =========================================================================
@@ -213,26 +210,24 @@ test("existing data survives an invalid POST (empty state)", async () => {
 
   // Save valid data first
   const { response: saveRes } = await postDoc(docId, { state });
-  assert.equal(saveRes.status, 200);
+  expect(saveRes.status).toBe(200);
 
   // Attempt to overwrite with empty state -- should be rejected
   const { response: emptyRes } = await postDoc(docId, { state: {} });
-  assert.equal(emptyRes.status, 400);
+  expect(emptyRes.status).toBe(400);
 
   // Attempt with empty nodes -- should be rejected
   const { response: emptyNodesRes } = await postDoc(docId, {
     state: { rootId: "x", nodes: {} },
   });
-  assert.equal(emptyNodesRes.status, 400);
+  expect(emptyNodesRes.status).toBe(400);
 
   // Verify original data is intact
   const { response: getRes, payload: getPayload } = await getDoc(docId);
-  assert.equal(getRes.status, 200);
-  assert.equal(
+  expect(getRes.status).toBe(200);
+  expect(
     Object.keys(getPayload.state.nodes).length,
-    originalNodeCount,
-    "Node count must not change after rejected POSTs",
-  );
+  ).toBe(originalNodeCount);
 });
 
 test("existing data survives a POST with null state", async () => {
@@ -241,10 +236,10 @@ test("existing data survives a POST with null state", async () => {
 
   await postDoc(docId, { state });
   const { response: badRes } = await postDoc(docId, { state: null });
-  assert.equal(badRes.status, 400);
+  expect(badRes.status).toBe(400);
 
   const { payload } = await getDoc(docId);
-  assert.ok(Object.keys(payload.state.nodes).length > 0, "Nodes must survive null POST");
+  expect(Object.keys(payload.state.nodes).length > 0).toBe(true);
 });
 
 test("POST with nodes containing only invalid references is rejected", async () => {
@@ -262,7 +257,7 @@ test("POST with nodes containing only invalid references is rejected", async () 
     },
   });
   // validate() should catch the missing child reference
-  assert.equal(response.status, 400);
+  expect(response.status).toBe(400);
 });
 
 // =========================================================================
@@ -277,29 +272,25 @@ test("simulated map_update flow: GET, add node, POST preserves all nodes", async
 
   // Simulate: GET current state
   const { payload: current } = await getDoc(docId);
-  assert.equal(Object.keys(current.state.nodes).length, originalNodeCount);
+  expect(Object.keys(current.state.nodes).length).toBe(originalNodeCount);
 
   // Simulate: add a node via model
   const model = RapidMvpModel.fromJSON(current.state);
   model.addNode(model.state.rootId, "New Node from map_update");
   const updatedState = model.toJSON();
-  assert.equal(
+  expect(
     Object.keys(updatedState.nodes).length,
-    originalNodeCount + 1,
-    "Should have one more node",
-  );
+  ).toBe(originalNodeCount + 1);
 
   // Simulate: POST back
   const { response: postRes } = await postDoc(docId, { state: updatedState });
-  assert.equal(postRes.status, 200);
+  expect(postRes.status).toBe(200);
 
   // Verify
   const { payload: final } = await getDoc(docId);
-  assert.equal(
+  expect(
     Object.keys(final.state.nodes).length,
-    originalNodeCount + 1,
-    "All nodes including new one must be present after map_update flow",
-  );
+  ).toBe(originalNodeCount + 1);
 });
 
 test("map_update safety guard: POST that would erase all children is blocked", async () => {
@@ -309,7 +300,7 @@ test("map_update safety guard: POST that would erase all children is blocked", a
   model.addNode(model.state.rootId, "Child 2");
   model.addNode(model.state.rootId, "Child 3");
   const state = model.toJSON();
-  assert.ok(Object.keys(state.nodes).length >= 4);
+  expect(Object.keys(state.nodes).length >= 4).toBe(true);
 
   await postDoc(docId, { state });
 
@@ -318,12 +309,12 @@ test("map_update safety guard: POST that would erase all children is blocked", a
   // Server should still accept structurally valid state.
   const rootOnlyModel = new RapidMvpModel("Root with children");
   const rootOnlyState = rootOnlyModel.toJSON();
-  assert.equal(Object.keys(rootOnlyState.nodes).length, 1);
+  expect(Object.keys(rootOnlyState.nodes).length).toBe(1);
 
   const { response } = await postDoc(docId, { state: rootOnlyState });
   // The server accepts this since it's structurally valid (has root + nodes).
   // The map_update client script should check node count BEFORE posting.
-  assert.equal(response.status, 200);
+  expect(response.status).toBe(200);
 });
 
 test("POST with empty body string returns 400", async () => {
@@ -332,8 +323,8 @@ test("POST with empty body string returns 400", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: "",
   });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error);
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });
 
 test("POST with body '{}' (no state field) returns 400", async () => {
@@ -342,6 +333,6 @@ test("POST with body '{}' (no state field) returns 400", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: "{}",
   });
-  assert.equal(response.status, 400);
-  assert.ok(payload.error);
+  expect(response.status).toBe(400);
+  expect(payload.error).toBeTruthy();
 });

--- a/beta/tests/unit/cloud_sync_api_integration.test.js
+++ b/beta/tests/unit/cloud_sync_api_integration.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeAll, afterAll } from "vitest";
 const os = require("node:os");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -26,7 +25,7 @@ function createState(label) {
   return model.toJSON();
 }
 
-test.before(async () => {
+beforeAll(async () => {
   server = createAppServer();
   await new Promise((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -35,7 +34,7 @@ test.before(async () => {
   baseUrl = `http://127.0.0.1:${address.port}`;
 });
 
-test.after(async () => {
+afterAll(async () => {
   if (server) {
     await new Promise((resolve, reject) => {
       server.close((err) => {
@@ -53,41 +52,41 @@ test.after(async () => {
 test("sync status and push/pull round-trip works in file-mirror mode", async () => {
   const docId = "integration-roundtrip";
   const status1 = await requestJson(`${baseUrl}/api/sync/status/${docId}`);
-  assert.equal(status1.response.status, 200);
-  assert.equal(status1.payload.ok, true);
-  assert.equal(status1.payload.mode, "file-mirror");
-  assert.equal(status1.payload.documentId, docId);
-  assert.equal(status1.payload.enabled, true);
-  assert.equal(status1.payload.exists, false);
+  expect(status1.response.status).toBe(200);
+  expect(status1.payload.ok).toBe(true);
+  expect(status1.payload.mode).toBe("file-mirror");
+  expect(status1.payload.documentId).toBe(docId);
+  expect(status1.payload.enabled).toBe(true);
+  expect(status1.payload.exists).toBe(false);
 
   const push = await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({ state: createState("A"), savedAt: "2026-04-02T00:00:00.000Z" }),
   });
-  assert.equal(push.response.status, 200);
-  assert.equal(push.payload.ok, true);
-  assert.equal(push.payload.mode, "file-mirror");
-  assert.equal(push.payload.documentId, docId);
+  expect(push.response.status).toBe(200);
+  expect(push.payload.ok).toBe(true);
+  expect(push.payload.mode).toBe("file-mirror");
+  expect(push.payload.documentId).toBe(docId);
 
   const status2 = await requestJson(`${baseUrl}/api/sync/status/${docId}`);
-  assert.equal(status2.response.status, 200);
-  assert.equal(status2.payload.ok, true);
-  assert.equal(status2.payload.mode, "file-mirror");
-  assert.equal(status2.payload.documentId, docId);
-  assert.equal(status2.payload.exists, true);
-  assert.equal(status2.payload.cloudSavedAt, "2026-04-02T00:00:00.000Z");
+  expect(status2.response.status).toBe(200);
+  expect(status2.payload.ok).toBe(true);
+  expect(status2.payload.mode).toBe("file-mirror");
+  expect(status2.payload.documentId).toBe(docId);
+  expect(status2.payload.exists).toBe(true);
+  expect(status2.payload.cloudSavedAt).toBe("2026-04-02T00:00:00.000Z");
 
   const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({}),
   });
-  assert.equal(pull.response.status, 200);
-  assert.equal(pull.payload.ok, true);
-  assert.equal(pull.payload.mode, "file-mirror");
-  assert.equal(pull.payload.documentId, docId);
-  assert.equal(pull.payload.state.rootId.length > 0, true);
+  expect(pull.response.status).toBe(200);
+  expect(pull.payload.ok).toBe(true);
+  expect(pull.payload.mode).toBe("file-mirror");
+  expect(pull.payload.documentId).toBe(docId);
+  expect(pull.payload.state.rootId.length > 0).toBe(true);
 });
 
 test("sync push returns 409 on savedAt conflict and force push overrides", async () => {
@@ -98,10 +97,10 @@ test("sync push returns 409 on savedAt conflict and force push overrides", async
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({ state: createState("First"), savedAt: "2026-04-02T00:00:00.000Z" }),
   });
-  assert.equal(initialPush.response.status, 200);
-  assert.equal(initialPush.payload.ok, true);
-  assert.equal(initialPush.payload.mode, "file-mirror");
-  assert.equal(initialPush.payload.documentId, docId);
+  expect(initialPush.response.status).toBe(200);
+  expect(initialPush.payload.ok).toBe(true);
+  expect(initialPush.payload.mode).toBe("file-mirror");
+  expect(initialPush.payload.documentId).toBe(docId);
 
   const updatePush = await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
     method: "POST",
@@ -112,10 +111,10 @@ test("sync push returns 409 on savedAt conflict and force push overrides", async
       baseSavedAt: "2026-04-02T00:00:00.000Z",
     }),
   });
-  assert.equal(updatePush.response.status, 200);
-  assert.equal(updatePush.payload.ok, true);
-  assert.equal(updatePush.payload.mode, "file-mirror");
-  assert.equal(updatePush.payload.documentId, docId);
+  expect(updatePush.response.status).toBe(200);
+  expect(updatePush.payload.ok).toBe(true);
+  expect(updatePush.payload.mode).toBe("file-mirror");
+  expect(updatePush.payload.documentId).toBe(docId);
 
   const conflictingPush = await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
     method: "POST",
@@ -126,10 +125,10 @@ test("sync push returns 409 on savedAt conflict and force push overrides", async
       baseSavedAt: "2026-04-02T00:00:00.000Z",
     }),
   });
-  assert.equal(conflictingPush.response.status, 409);
-  assert.equal(conflictingPush.payload.code, "CLOUD_CONFLICT");
-  assert.equal(conflictingPush.payload.ok, false);
-  assert.equal(conflictingPush.payload.documentId, docId);
+  expect(conflictingPush.response.status).toBe(409);
+  expect(conflictingPush.payload.code).toBe("CLOUD_CONFLICT");
+  expect(conflictingPush.payload.ok).toBe(false);
+  expect(conflictingPush.payload.documentId).toBe(docId);
 
   const forcedPush = await requestJson(`${baseUrl}/api/sync/push/${docId}`, {
     method: "POST",
@@ -141,11 +140,11 @@ test("sync push returns 409 on savedAt conflict and force push overrides", async
       force: true,
     }),
   });
-  assert.equal(forcedPush.response.status, 200);
-  assert.equal(forcedPush.payload.ok, true);
-  assert.equal(forcedPush.payload.mode, "file-mirror");
-  assert.equal(forcedPush.payload.documentId, docId);
-  assert.equal(forcedPush.payload.forced, true);
+  expect(forcedPush.response.status).toBe(200);
+  expect(forcedPush.payload.ok).toBe(true);
+  expect(forcedPush.payload.mode).toBe("file-mirror");
+  expect(forcedPush.payload.documentId).toBe(docId);
+  expect(forcedPush.payload.forced).toBe(true);
 });
 
 test("sync pull returns 500 when cloud file JSON is broken", async () => {
@@ -159,11 +158,11 @@ test("sync pull returns 500 when cloud file JSON is broken", async () => {
     body: JSON.stringify({}),
   });
 
-  assert.equal(pulled.response.status, 500);
-  assert.equal(pulled.payload.code, "SYNC_PULL_FAILED");
-  assert.equal(pulled.payload.ok, false);
-  assert.equal(pulled.payload.documentId, docId);
-  assert.equal(typeof pulled.payload.error, "string");
+  expect(pulled.response.status).toBe(500);
+  expect(pulled.payload.code).toBe("SYNC_PULL_FAILED");
+  expect(pulled.payload.ok).toBe(false);
+  expect(pulled.payload.documentId).toBe(docId);
+  expect(typeof pulled.payload.error).toBe("string");
 });
 
 test("sync pull returns 400 for unsupported cloud document format", async () => {
@@ -177,11 +176,11 @@ test("sync pull returns 400 for unsupported cloud document format", async () => 
     body: JSON.stringify({}),
   });
 
-  assert.equal(pulled.response.status, 400);
-  assert.equal(pulled.payload.code, "SYNC_CLOUD_UNSUPPORTED_FORMAT");
-  assert.equal(pulled.payload.ok, false);
-  assert.equal(pulled.payload.documentId, docId);
-  assert.equal(pulled.payload.error, "Cloud document has unsupported format.");
+  expect(pulled.response.status).toBe(400);
+  expect(pulled.payload.code).toBe("SYNC_CLOUD_UNSUPPORTED_FORMAT");
+  expect(pulled.payload.ok).toBe(false);
+  expect(pulled.payload.documentId).toBe(docId);
+  expect(pulled.payload.error).toBe("Cloud document has unsupported format.");
 });
 
 test("sync push returns 400 for structurally invalid model", async () => {
@@ -192,11 +191,11 @@ test("sync push returns 400 for structurally invalid model", async () => {
     body: JSON.stringify({ state: { rootId: "missing-root", nodes: {} } }),
   });
 
-  assert.equal(pushed.response.status, 400);
-  assert.equal(pushed.payload.code, "SYNC_PUSH_INVALID_MODEL");
-  assert.equal(pushed.payload.ok, false);
-  assert.equal(pushed.payload.documentId, docId);
-  assert.equal(typeof pushed.payload.error, "string");
+  expect(pushed.response.status).toBe(400);
+  expect(pushed.payload.code).toBe("SYNC_PUSH_INVALID_MODEL");
+  expect(pushed.payload.ok).toBe(false);
+  expect(pushed.payload.documentId).toBe(docId);
+  expect(typeof pushed.payload.error).toBe("string");
 });
 
 test("sync endpoints return 405 on unsupported method", async () => {
@@ -207,22 +206,22 @@ test("sync endpoints return 405 on unsupported method", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({}),
   });
-  assert.equal(statusPost.response.status, 405);
-  assert.equal(statusPost.payload.code, "SYNC_METHOD_NOT_ALLOWED");
-  assert.equal(statusPost.payload.ok, false);
-  assert.equal(statusPost.payload.documentId, docId);
+  expect(statusPost.response.status).toBe(405);
+  expect(statusPost.payload.code).toBe("SYNC_METHOD_NOT_ALLOWED");
+  expect(statusPost.payload.ok).toBe(false);
+  expect(statusPost.payload.documentId).toBe(docId);
 
   const pushGet = await requestJson(`${baseUrl}/api/sync/push/${docId}`);
-  assert.equal(pushGet.response.status, 405);
-  assert.equal(pushGet.payload.code, "SYNC_METHOD_NOT_ALLOWED");
-  assert.equal(pushGet.payload.ok, false);
-  assert.equal(pushGet.payload.documentId, docId);
+  expect(pushGet.response.status).toBe(405);
+  expect(pushGet.payload.code).toBe("SYNC_METHOD_NOT_ALLOWED");
+  expect(pushGet.payload.ok).toBe(false);
+  expect(pushGet.payload.documentId).toBe(docId);
 
   const pullGet = await requestJson(`${baseUrl}/api/sync/pull/${docId}`);
-  assert.equal(pullGet.response.status, 405);
-  assert.equal(pullGet.payload.code, "SYNC_METHOD_NOT_ALLOWED");
-  assert.equal(pullGet.payload.ok, false);
-  assert.equal(pullGet.payload.documentId, docId);
+  expect(pullGet.response.status).toBe(405);
+  expect(pullGet.payload.code).toBe("SYNC_METHOD_NOT_ALLOWED");
+  expect(pullGet.payload.ok).toBe(false);
+  expect(pullGet.payload.documentId).toBe(docId);
 });
 
 test("sync push returns 400 (not 500) when state has no nodes", async () => {
@@ -233,10 +232,10 @@ test("sync push returns 400 (not 500) when state has no nodes", async () => {
     body: JSON.stringify({ state: {}, savedAt: "2026-01-01T00:00:00Z" }),
   });
 
-  assert.equal(pushed.response.status, 400);
-  assert.equal(pushed.payload.code, "SYNC_PUSH_INVALID_MODEL");
-  assert.equal(pushed.payload.ok, false);
-  assert.equal(pushed.payload.documentId, docId);
+  expect(pushed.response.status).toBe(400);
+  expect(pushed.payload.code).toBe("SYNC_PUSH_INVALID_MODEL");
+  expect(pushed.payload.ok).toBe(false);
+  expect(pushed.payload.documentId).toBe(docId);
 });
 
 test("sync push returns 400 when state is null", async () => {
@@ -247,8 +246,8 @@ test("sync push returns 400 when state is null", async () => {
     body: JSON.stringify({ state: null }),
   });
 
-  assert.equal(pushed.response.status, 400);
-  assert.equal(pushed.payload.ok, false);
+  expect(pushed.response.status).toBe(400);
+  expect(pushed.payload.ok).toBe(false);
   // state:null is falsy so body itself becomes candidate.state; it has no nodes field
-  assert.equal(pushed.payload.code, "SYNC_PUSH_INVALID_MODEL");
+  expect(pushed.payload.code).toBe("SYNC_PUSH_INVALID_MODEL");
 });

--- a/beta/tests/unit/cloud_sync_conflict.test.js
+++ b/beta/tests/unit/cloud_sync_conflict.test.js
@@ -1,30 +1,27 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 
 const { detectCloudConflict } = require("../../dist/node/cloud_sync.js");
 
 test("detectCloudConflict returns false when force push is enabled", () => {
-  assert.equal(detectCloudConflict("2026-04-02T00:00:10.000Z", "2026-04-02T00:00:00.000Z", true), false);
+  expect(detectCloudConflict("2026-04-02T00:00:10.000Z", "2026-04-02T00:00:00.000Z", true)).toBe(false);
 });
 
 test("detectCloudConflict returns false when cloud doc does not exist", () => {
-  assert.equal(detectCloudConflict(null, "2026-04-02T00:00:00.000Z", false), false);
+  expect(detectCloudConflict(null, "2026-04-02T00:00:00.000Z", false)).toBe(false);
 });
 
 test("detectCloudConflict returns false when baseSavedAt is not provided", () => {
-  assert.equal(detectCloudConflict("2026-04-02T00:00:10.000Z", null, false), false);
+  expect(detectCloudConflict("2026-04-02T00:00:10.000Z", null, false)).toBe(false);
 });
 
 test("detectCloudConflict returns false when timestamps match", () => {
-  assert.equal(
+  expect(
     detectCloudConflict("2026-04-02T00:00:10.000Z", "2026-04-02T00:00:10.000Z", false),
-    false,
-  );
+  ).toBe(false);
 });
 
 test("detectCloudConflict returns true when timestamps differ and force is false", () => {
-  assert.equal(
+  expect(
     detectCloudConflict("2026-04-02T00:00:20.000Z", "2026-04-02T00:00:10.000Z", false),
-    true,
-  );
+  ).toBe(true);
 });

--- a/beta/tests/unit/cloud_sync_transport.test.js
+++ b/beta/tests/unit/cloud_sync_transport.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const os = require("node:os");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -28,19 +27,19 @@ test("FileTransport: push and pull round-trip", async () => {
     const doc = createSavedDoc("A", "2026-04-09T00:00:00.000Z");
 
     const pushResult = await transport.push("doc1", doc, null, false);
-    assert.equal(pushResult.ok, true);
-    assert.equal(pushResult.savedAt, "2026-04-09T00:00:00.000Z");
-    assert.equal(pushResult.forced, false);
-    assert.equal(typeof pushResult.cloudDocVersion, "number");
-    assert.equal(pushResult.cloudDocVersion, 1);
+    expect(pushResult.ok).toBe(true);
+    expect(pushResult.savedAt).toBe("2026-04-09T00:00:00.000Z");
+    expect(pushResult.forced).toBe(false);
+    expect(typeof pushResult.cloudDocVersion).toBe("number");
+    expect(pushResult.cloudDocVersion).toBe(1);
 
     const pullResult = await transport.pull("doc1");
-    assert.equal(pullResult.ok, true);
-    assert.equal(pullResult.version, 1);
-    assert.equal(pullResult.savedAt, "2026-04-09T00:00:00.000Z");
-    assert.ok(pullResult.state.rootId);
-    assert.ok(Object.keys(pullResult.state.nodes).length > 0);
-    assert.equal(pullResult.docVersion, 1);
+    expect(pullResult.ok).toBe(true);
+    expect(pullResult.version).toBe(1);
+    expect(pullResult.savedAt).toBe("2026-04-09T00:00:00.000Z");
+    expect(pullResult.state.rootId).toBeTruthy();
+    expect(Object.keys(pullResult.state.nodes).length > 0).toBe(true);
+    expect(pullResult.docVersion).toBe(1);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -51,13 +50,13 @@ test("FileTransport: status returns exists=false for missing doc", async () => {
   try {
     const transport = new FileTransport(dir);
     const result = await transport.status("nonexistent");
-    assert.equal(result.ok, true);
-    assert.equal(result.enabled, true);
-    assert.equal(result.mode, "file-mirror");
-    assert.equal(result.documentId, "nonexistent");
-    assert.equal(result.exists, false);
-    assert.equal(result.cloudSavedAt, null);
-    assert.equal(result.lastSyncedAt, null);
+    expect(result.ok).toBe(true);
+    expect(result.enabled).toBe(true);
+    expect(result.mode).toBe("file-mirror");
+    expect(result.documentId).toBe("nonexistent");
+    expect(result.exists).toBe(false);
+    expect(result.cloudSavedAt).toBe(null);
+    expect(result.lastSyncedAt).toBe(null);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -71,11 +70,11 @@ test("FileTransport: status returns exists=true after push", async () => {
     await transport.push("doc2", doc, null, false);
 
     const result = await transport.status("doc2");
-    assert.equal(result.ok, true);
-    assert.equal(result.exists, true);
-    assert.equal(result.cloudSavedAt, "2026-04-09T01:00:00.000Z");
-    assert.ok(result.lastSyncedAt);
-    assert.equal(result.cloudDocVersion, 1);
+    expect(result.ok).toBe(true);
+    expect(result.exists).toBe(true);
+    expect(result.cloudSavedAt).toBe("2026-04-09T01:00:00.000Z");
+    expect(result.lastSyncedAt).toBeTruthy();
+    expect(result.cloudDocVersion).toBe(1);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -87,21 +86,21 @@ test("FileTransport: push detects conflict via docVersion", async () => {
     const transport = new FileTransport(dir);
     const doc1 = createSavedDoc("V1", "2026-04-09T00:00:00.000Z");
     const push1 = await transport.push("doc3", doc1, null, false);
-    assert.equal(push1.cloudDocVersion, 1);
+    expect(push1.cloudDocVersion).toBe(1);
 
     // Update the doc with correct base version
     const doc2 = createSavedDoc("V2", "2026-04-09T00:00:10.000Z");
     const push2 = await transport.push("doc3", doc2, push1.savedAt, false, push1.cloudDocVersion);
-    assert.equal(push2.ok, true);
-    assert.equal(push2.cloudDocVersion, 2);
+    expect(push2.ok).toBe(true);
+    expect(push2.cloudDocVersion).toBe(2);
 
     // Conflict: stale baseDocVersion
     const doc3 = createSavedDoc("V3", "2026-04-09T00:00:20.000Z");
     const result = await transport.push("doc3", doc3, push1.savedAt, false, push1.cloudDocVersion);
-    assert.equal(result.ok, false);
-    assert.equal(result.conflict, true);
-    assert.equal(result.cloudDocVersion, 2);
-    assert.ok(result.remoteState);
+    expect(result.ok).toBe(false);
+    expect(result.conflict).toBe(true);
+    expect(result.cloudDocVersion).toBe(2);
+    expect(result.remoteState).toBeTruthy();
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -120,9 +119,9 @@ test("FileTransport: push detects conflict via savedAt fallback", async () => {
     // Conflict: stale baseSavedAt (no docVersion provided)
     const doc3 = createSavedDoc("V3", "2026-04-09T00:00:20.000Z");
     const result = await transport.push("doc3b", doc3, "2026-04-09T00:00:00.000Z", false);
-    assert.equal(result.ok, false);
-    assert.equal(result.conflict, true);
-    assert.equal(result.cloudSavedAt, "2026-04-09T00:00:10.000Z");
+    expect(result.ok).toBe(false);
+    expect(result.conflict).toBe(true);
+    expect(result.cloudSavedAt).toBe("2026-04-09T00:00:10.000Z");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -141,13 +140,13 @@ test("FileTransport: force push overrides conflict", async () => {
     // Force push with stale baseSavedAt
     const doc3 = createSavedDoc("Forced", "2026-04-09T00:00:30.000Z");
     const result = await transport.push("doc4", doc3, "2026-04-09T00:00:00.000Z", true);
-    assert.equal(result.ok, true);
-    assert.equal(result.forced, true);
+    expect(result.ok).toBe(true);
+    expect(result.forced).toBe(true);
 
     // Verify forced doc is what we get back
     const pulled = await transport.pull("doc4");
-    assert.equal(pulled.ok, true);
-    assert.equal(pulled.savedAt, "2026-04-09T00:00:30.000Z");
+    expect(pulled.ok).toBe(true);
+    expect(pulled.savedAt).toBe("2026-04-09T00:00:30.000Z");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -158,8 +157,8 @@ test("FileTransport: pull returns error for missing doc", async () => {
   try {
     const transport = new FileTransport(dir);
     const result = await transport.pull("missing");
-    assert.equal(result.ok, false);
-    assert.ok(result.error.includes("not found"));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -173,8 +172,8 @@ test("FileTransport: pull returns error for unsupported format", async () => {
     fs.writeFileSync(filePath, JSON.stringify({ version: 99, state: {} }), "utf8");
 
     const result = await transport.pull("bad-format");
-    assert.equal(result.ok, false);
-    assert.ok(result.error.includes("unsupported"));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unsupported/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -184,10 +183,10 @@ test("FileTransport: creates cloud dir if it does not exist", async () => {
   const dir = path.join(os.tmpdir(), `m3e-ft-nested-${Date.now()}`);
   const nested = path.join(dir, "sub", "deep");
   try {
-    assert.equal(fs.existsSync(nested), false);
+    expect(fs.existsSync(nested)).toBe(false);
     const transport = new FileTransport(nested);
     await transport.status("probe");
-    assert.equal(fs.existsSync(nested), true);
+    expect(fs.existsSync(nested)).toBe(true);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -199,15 +198,15 @@ test("FileTransport: docVersion increments on each push", async () => {
     const transport = new FileTransport(dir);
     const doc1 = createSavedDoc("A", "2026-04-09T00:00:00.000Z");
     const push1 = await transport.push("ver-test", doc1, null, false);
-    assert.equal(push1.cloudDocVersion, 1);
+    expect(push1.cloudDocVersion).toBe(1);
 
     const doc2 = createSavedDoc("B", "2026-04-09T00:00:10.000Z");
     const push2 = await transport.push("ver-test", doc2, push1.savedAt, false, push1.cloudDocVersion);
-    assert.equal(push2.cloudDocVersion, 2);
+    expect(push2.cloudDocVersion).toBe(2);
 
     const doc3 = createSavedDoc("C", "2026-04-09T00:00:20.000Z");
     const push3 = await transport.push("ver-test", doc3, push2.savedAt, false, push2.cloudDocVersion);
-    assert.equal(push3.cloudDocVersion, 3);
+    expect(push3.cloudDocVersion).toBe(3);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -219,22 +218,22 @@ test("FileTransport: docVersion increments on each push", async () => {
 
 test("detectCloudConflict: docVersion takes priority over savedAt", () => {
   // docVersions match even though savedAt differ => no conflict
-  assert.equal(detectCloudConflict("2026-04-01", "2026-04-02", false, 5, 5), false);
+  expect(detectCloudConflict("2026-04-01", "2026-04-02", false, 5, 5)).toBe(false);
   // docVersions differ even though savedAt match => conflict
-  assert.equal(detectCloudConflict("2026-04-01", "2026-04-01", false, 6, 5), true);
+  expect(detectCloudConflict("2026-04-01", "2026-04-01", false, 6, 5)).toBe(true);
 });
 
 test("detectCloudConflict: falls back to savedAt when docVersion not provided", () => {
-  assert.equal(detectCloudConflict("a", "b", false), true);
-  assert.equal(detectCloudConflict("a", "a", false), false);
+  expect(detectCloudConflict("a", "b", false)).toBe(true);
+  expect(detectCloudConflict("a", "a", false)).toBe(false);
 });
 
 test("detectCloudConflict still works after refactor", () => {
-  assert.equal(detectCloudConflict("a", "b", false), true);
-  assert.equal(detectCloudConflict("a", "a", false), false);
-  assert.equal(detectCloudConflict("a", "b", true), false);
-  assert.equal(detectCloudConflict(null, "b", false), false);
-  assert.equal(detectCloudConflict("a", null, false), false);
+  expect(detectCloudConflict("a", "b", false)).toBe(true);
+  expect(detectCloudConflict("a", "a", false)).toBe(false);
+  expect(detectCloudConflict("a", "b", true)).toBe(false);
+  expect(detectCloudConflict(null, "b", false)).toBe(false);
+  expect(detectCloudConflict("a", null, false)).toBe(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -248,8 +247,8 @@ test("withRetry: succeeds on first attempt", async () => {
     () => true,
     { maxRetries: 3, initialDelayMs: 1, maxDelayMs: 10 },
   );
-  assert.equal(result, "ok");
-  assert.equal(calls, 1);
+  expect(result).toBe("ok");
+  expect(calls).toBe(1);
 });
 
 test("withRetry: retries on transient error and succeeds", async () => {
@@ -263,32 +262,30 @@ test("withRetry: retries on transient error and succeeds", async () => {
     () => true,
     { maxRetries: 3, initialDelayMs: 1, maxDelayMs: 10 },
   );
-  assert.equal(result, "recovered");
-  assert.equal(calls, 3);
+  expect(result).toBe("recovered");
+  expect(calls).toBe(3);
 });
 
 test("withRetry: does not retry non-retryable errors", async () => {
   let calls = 0;
-  await assert.rejects(
-    () => withRetry(
+  await expect(
+    withRetry(
       async () => { calls++; throw new Error("conflict"); },
       (err) => !err.message.includes("conflict"),
       { maxRetries: 3, initialDelayMs: 1, maxDelayMs: 10 },
     ),
-    /conflict/,
-  );
-  assert.equal(calls, 1);
+  ).rejects.toThrow(/conflict/);
+  expect(calls).toBe(1);
 });
 
 test("withRetry: throws after max retries", async () => {
   let calls = 0;
-  await assert.rejects(
-    () => withRetry(
+  await expect(
+    withRetry(
       async () => { calls++; throw new Error("fail"); },
       () => true,
       { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 10 },
     ),
-    /fail/,
-  );
-  assert.equal(calls, 3); // 1 initial + 2 retries
+  ).rejects.toThrow(/fail/);
+  expect(calls).toBe(3); // 1 initial + 2 retries
 });

--- a/beta/tests/unit/collab_api.test.js
+++ b/beta/tests/unit/collab_api.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const { describe, it, before, after } = require("node:test");
-const assert = require("node:assert/strict");
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 const http = require("http");
 
 const { createAppServer } = require("../../dist/node/start_viewer");
@@ -46,7 +45,7 @@ async function request(method, path, body, headers = {}) {
 const COLLAB_ENABLED = process.env.M3E_COLLAB === "1";
 
 describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
-  before(async () => {
+  beforeAll(async () => {
     server = createAppServer();
     await new Promise((resolve) => {
       server.listen(0, "127.0.0.1", () => {
@@ -57,7 +56,7 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
     });
   });
 
-  after(() => {
+  afterAll(() => {
     server?.close();
   });
 
@@ -67,11 +66,11 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
       role: "human",
       capabilities: ["read", "write"],
     });
-    assert.equal(res.status, 200);
-    assert.equal(res.json.ok, true);
-    assert.ok(res.json.entityId.startsWith("e_"));
-    assert.ok(res.json.token.startsWith("tok_"));
-    assert.equal(res.json.priority, 100);
+    expect(res.status).toBe(200);
+    expect(res.json.ok).toBe(true);
+    expect(res.json.entityId.startsWith("e_")).toBe(true);
+    expect(res.json.token.startsWith("tok_")).toBe(true);
+    expect(res.json.priority).toBe(100);
   });
 
   it("register rejects invalid role", async () => {
@@ -79,12 +78,12 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
       displayName: "bad",
       role: "superadmin",
     });
-    assert.equal(res.status, 400);
+    expect(res.status).toBe(400);
   });
 
   it("unauthenticated request returns 401", async () => {
     const res = await request("POST", "/api/collab/heartbeat", {});
-    assert.equal(res.status, 401);
+    expect(res.status).toBe(401);
   });
 
   it("authenticated heartbeat succeeds", async () => {
@@ -97,8 +96,8 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
     const res = await request("POST", "/api/collab/heartbeat", { lockIds: [] }, {
       Authorization: `Bearer ${token}`,
     });
-    assert.equal(res.status, 200);
-    assert.equal(res.json.ok, true);
+    expect(res.status).toBe(200);
+    expect(res.json.ok).toBe(true);
   });
 
   it("scope lock acquire and release", async () => {
@@ -111,15 +110,15 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
 
     // Acquire
     const lockRes = await request("POST", "/api/collab/scope/folder_123/lock", null, auth);
-    assert.equal(lockRes.status, 200);
-    assert.equal(lockRes.json.ok, true);
-    assert.ok(lockRes.json.lockId.startsWith("lock_"));
-    assert.ok(lockRes.json.expiresAt);
+    expect(lockRes.status).toBe(200);
+    expect(lockRes.json.ok).toBe(true);
+    expect(lockRes.json.lockId.startsWith("lock_")).toBe(true);
+    expect(lockRes.json.expiresAt).toBeTruthy();
 
     // Release
     const releaseRes = await request("DELETE", "/api/collab/scope/folder_123/lock", null, auth);
-    assert.equal(releaseRes.status, 200);
-    assert.equal(releaseRes.json.ok, true);
+    expect(releaseRes.status).toBe(200);
+    expect(releaseRes.json.ok).toBe(true);
   });
 
   it("higher priority preempts lock", async () => {
@@ -138,8 +137,8 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
     });
     const humanAuth = { Authorization: `Bearer ${humanReg.json.token}` };
     const preemptRes = await request("POST", "/api/collab/scope/scope_preempt/lock", null, humanAuth);
-    assert.equal(preemptRes.status, 200);
-    assert.equal(preemptRes.json.ok, true);
+    expect(preemptRes.status).toBe(200);
+    expect(preemptRes.json.ok).toBe(true);
   });
 
   it("lower priority cannot preempt lock", async () => {
@@ -151,14 +150,14 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
     const humanAuth = { Authorization: `Bearer ${humanReg.json.token}` };
     await request("POST", "/api/collab/scope/scope_no_preempt/lock", null, humanAuth);
 
-    // AI tries to lock → 409
+    // AI tries to lock -> 409
     const aiReg = await request("POST", "/api/collab/register", {
       displayName: "ai-blocked",
       role: "ai",
     });
     const aiAuth = { Authorization: `Bearer ${aiReg.json.token}` };
     const failRes = await request("POST", "/api/collab/scope/scope_no_preempt/lock", null, aiAuth);
-    assert.equal(failRes.status, 409);
+    expect(failRes.status).toBe(409);
   });
 
   it("entities list returns active entities", async () => {
@@ -169,9 +168,9 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
     const auth = { Authorization: `Bearer ${reg.json.token}` };
 
     const res = await request("GET", "/api/collab/entities/test-doc", null, auth);
-    assert.equal(res.status, 200);
-    assert.ok(Array.isArray(res.json.entities));
-    assert.ok(res.json.entities.length > 0);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.json.entities)).toBe(true);
+    expect(res.json.entities.length > 0).toBe(true);
   });
 
   it("unregister removes entity", async () => {
@@ -182,11 +181,11 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
     const auth = { Authorization: `Bearer ${reg.json.token}` };
 
     const res = await request("DELETE", "/api/collab/unregister", null, auth);
-    assert.equal(res.status, 200);
+    expect(res.status).toBe(200);
 
     // Subsequent request should fail
     const hb = await request("POST", "/api/collab/heartbeat", {}, auth);
-    assert.equal(hb.status, 401);
+    expect(hb.status).toBe(401);
   });
 
   it("SSE endpoint returns event-stream headers", async () => {
@@ -207,7 +206,7 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
           headers: { Authorization: `Bearer ${reg.json.token}` },
         },
         (res) => {
-          assert.equal(res.headers["content-type"], "text/event-stream");
+          expect(res.headers["content-type"]).toBe("text/event-stream");
           res.destroy(); // Close immediately, don't wait for stream
           resolve();
         },
@@ -219,7 +218,7 @@ describe("Collab API", { skip: !COLLAB_ENABLED }, () => {
 });
 
 describe("Collab API disabled", { skip: COLLAB_ENABLED }, () => {
-  before(async () => {
+  beforeAll(async () => {
     server = createAppServer();
     await new Promise((resolve) => {
       server.listen(0, "127.0.0.1", () => {
@@ -230,7 +229,7 @@ describe("Collab API disabled", { skip: COLLAB_ENABLED }, () => {
     });
   });
 
-  after(() => {
+  afterAll(() => {
     server?.close();
   });
 
@@ -239,6 +238,6 @@ describe("Collab API disabled", { skip: COLLAB_ENABLED }, () => {
       displayName: "test",
       role: "human",
     });
-    assert.equal(res.status, 404);
+    expect(res.status).toBe(404);
   });
 });

--- a/beta/tests/unit/collab_push.test.js
+++ b/beta/tests/unit/collab_push.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeAll, afterAll } from "vitest";
 const http = require("node:http");
 const fs = require("node:fs");
 const os = require("node:os");
@@ -7,7 +6,7 @@ const path = require("node:path");
 
 if (process.env.M3E_COLLAB !== "1") {
   test("collab_push: skipped (M3E_COLLAB not set)", () => {
-    assert.ok(true, "Set M3E_COLLAB=1 to run collab push tests");
+    expect(true).toBe(true);
   });
 } else {
 
@@ -80,7 +79,7 @@ function seedDoc(docId) {
   return { rootId, folderId, child1Id, child2Id, outsideId };
 }
 
-test.before(() => {
+beforeAll(() => {
   return new Promise((resolve) => {
     collab.resetCollab();
     server = createAppServer();
@@ -92,7 +91,7 @@ test.before(() => {
   });
 });
 
-test.after(() => {
+afterAll(() => {
   return new Promise((resolve) => {
     server.close(() => {
       try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
@@ -113,7 +112,7 @@ test("push a new node into a scope succeeds and version increments", async () =>
 
   // Acquire lock
   const lockRes = await request("POST", `/api/collab/scope/${ids.folderId}/lock`, null, auth);
-  assert.equal(lockRes.json.ok, true);
+  expect(lockRes.json.ok).toBe(true);
 
   const newNodeId = "new_child_3";
   const res = await request("POST", `/api/collab/push/${docId}`, {
@@ -126,11 +125,11 @@ test("push a new node into a scope succeeds and version increments", async () =>
     } } },
   }, auth);
 
-  assert.equal(res.status, 200);
-  assert.equal(res.json.ok, true);
-  assert.equal(res.json.version, 2);
-  assert.ok(res.json.applied.includes(newNodeId));
-  assert.equal(res.json.rejected.length, 0);
+  expect(res.status).toBe(200);
+  expect(res.json.ok).toBe(true);
+  expect(res.json.version).toBe(2);
+  expect(res.json.applied.includes(newNodeId)).toBe(true);
+  expect(res.json.rejected.length).toBe(0);
 });
 
 test("push to a scope without lock is rejected (403)", async () => {
@@ -148,8 +147,8 @@ test("push to a scope without lock is rejected (403)", async () => {
     changes: { nodes: { child_1: { id: "child_1", parentId: "folder_a", children: [], nodeType: "text", text: "Updated", collapsed: false, details: "", note: "", attributes: {}, link: "" } } },
   }, auth);
 
-  assert.equal(res.status, 403);
-  assert.equal(res.json.ok, false);
+  expect(res.status).toBe(403);
+  expect(res.json.ok).toBe(false);
 });
 
 test("push node outside scope is rejected", async () => {
@@ -168,9 +167,9 @@ test("push node outside scope is rejected", async () => {
     changes: { nodes: { [ids.outsideId]: { id: ids.outsideId, parentId: ids.rootId, children: [], nodeType: "text", text: "Hacked", collapsed: false, details: "", note: "", attributes: {}, link: "" } } },
   }, auth);
 
-  assert.equal(res.status, 200);
-  assert.ok(res.json.rejected.includes(ids.outsideId));
-  assert.equal(res.json.applied.length, 0);
+  expect(res.status).toBe(200);
+  expect(res.json.rejected.includes(ids.outsideId)).toBe(true);
+  expect(res.json.applied.length).toBe(0);
 });
 
 test("two entities push non-overlapping nodes - both succeed", async () => {
@@ -186,8 +185,8 @@ test("two entities push non-overlapping nodes - both succeed", async () => {
     scopeId: ids.folderId, lockId: lock1.json.lockId, baseVersion: 1,
     changes: { nodes: { merge_a: { id: "merge_a", parentId: ids.folderId, children: [], nodeType: "text", text: "A", collapsed: false, details: "", note: "", attributes: {}, link: "" } } },
   }, auth1);
-  assert.equal(res1.json.ok, true);
-  assert.equal(res1.json.version, 2);
+  expect(res1.json.ok).toBe(true);
+  expect(res1.json.version).toBe(2);
 
   // Release lock1
   await request("DELETE", `/api/collab/scope/${ids.folderId}/lock`, null, auth1);
@@ -201,13 +200,13 @@ test("two entities push non-overlapping nodes - both succeed", async () => {
     scopeId: ids.rootId, lockId: lock2.json.lockId, baseVersion: 2,
     changes: { nodes: { merge_b: { id: "merge_b", parentId: ids.rootId, children: [], nodeType: "text", text: "B", collapsed: false, details: "", note: "", attributes: {}, link: "" } } },
   }, auth2);
-  assert.equal(res2.json.ok, true);
-  assert.equal(res2.json.version, 3);
+  expect(res2.json.ok).toBe(true);
+  expect(res2.json.version).toBe(3);
 
   // Verify both nodes exist
   const model = RapidMvpModel.loadFromSqlite(sqlitePath, docId);
-  assert.ok(model.state.nodes["merge_a"]);
-  assert.ok(model.state.nodes["merge_b"]);
+  expect(model.state.nodes["merge_a"]).toBeTruthy();
+  expect(model.state.nodes["merge_b"]).toBeTruthy();
 });
 
 test("push with stale baseVersion still applies when priority allows", async () => {
@@ -235,8 +234,8 @@ test("push with stale baseVersion still applies when priority allows", async () 
     changes: { nodes: { [ids.child1Id]: { id: ids.child1Id, parentId: ids.folderId, children: [], nodeType: "text", text: "AI Edit", collapsed: false, details: "", note: "", attributes: {}, link: "" } } },
   }, auth2);
 
-  assert.equal(res2.status, 200);
-  assert.equal(res2.json.ok, true);
+  expect(res2.status).toBe(200);
+  expect(res2.json.ok).toBe(true);
 });
 
 }

--- a/beta/tests/unit/collab_unit.test.js
+++ b/beta/tests/unit/collab_unit.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeEach } from "vitest";
 
 const {
   registerEntity,
@@ -32,19 +31,19 @@ function makeRequest(token) {
 // Entity management
 // ---------------------------------------------------------------------------
 
-test.beforeEach(() => {
+beforeEach(() => {
   resetCollab();
 });
 
 test("registerEntity returns entity with expected fields", () => {
   const e = registerEntity("Alice", "human", ["read", "write"]);
-  assert.ok(e.entityId.startsWith("e_"));
-  assert.ok(e.token.startsWith("tok_"));
-  assert.equal(e.displayName, "Alice");
-  assert.equal(e.role, "human");
-  assert.equal(e.priority, 100);
-  assert.deepEqual(e.capabilities, ["read", "write"]);
-  assert.ok(e.lastHeartbeat > 0);
+  expect(e.entityId.startsWith("e_")).toBe(true);
+  expect(e.token.startsWith("tok_")).toBe(true);
+  expect(e.displayName).toBe("Alice");
+  expect(e.role).toBe("human");
+  expect(e.priority).toBe(100);
+  expect(e.capabilities).toEqual(["read", "write"]);
+  expect(e.lastHeartbeat > 0).toBe(true);
 });
 
 test("registerEntity assigns correct priority for each role", () => {
@@ -54,30 +53,30 @@ test("registerEntity assigns correct priority for each role", () => {
   const ai = registerEntity("A", "ai", ["read", "write"]);
   const aiRo = registerEntity("AR", "ai-readonly", ["read"]);
 
-  assert.equal(owner.priority, 1000);
-  assert.equal(human.priority, 100);
-  assert.equal(aiSup.priority, 50);
-  assert.equal(ai.priority, 10);
-  assert.equal(aiRo.priority, 1);
+  expect(owner.priority).toBe(1000);
+  expect(human.priority).toBe(100);
+  expect(aiSup.priority).toBe(50);
+  expect(ai.priority).toBe(10);
+  expect(aiRo.priority).toBe(1);
 });
 
 test("unregisterEntity removes entity and returns true", () => {
   const e = registerEntity("Bob", "ai", ["read"]);
-  assert.equal(unregisterEntity(e.entityId), true);
-  assert.equal(getActiveEntities().length, 0);
+  expect(unregisterEntity(e.entityId)).toBe(true);
+  expect(getActiveEntities().length).toBe(0);
 });
 
 test("unregisterEntity returns false for unknown entityId", () => {
-  assert.equal(unregisterEntity("nonexistent"), false);
+  expect(unregisterEntity("nonexistent")).toBe(false);
 });
 
 test("unregisterEntity releases locks held by entity", () => {
   const e = registerEntity("Locker", "human", ["read", "write"]);
   acquireScopeLock("scope_1", e);
-  assert.equal(getScopeLocks().length, 1);
+  expect(getScopeLocks().length).toBe(1);
 
   unregisterEntity(e.entityId);
-  assert.equal(getScopeLocks().length, 0);
+  expect(getScopeLocks().length).toBe(0);
 });
 
 // ---------------------------------------------------------------------------
@@ -87,23 +86,23 @@ test("unregisterEntity releases locks held by entity", () => {
 test("authenticateRequest returns entity for valid token", () => {
   const e = registerEntity("Auth", "human", ["read", "write"]);
   const result = authenticateRequest(makeRequest(e.token));
-  assert.ok(result);
-  assert.equal(result.entityId, e.entityId);
+  expect(result).toBeTruthy();
+  expect(result.entityId).toBe(e.entityId);
 });
 
 test("authenticateRequest returns null for missing Authorization header", () => {
   const result = authenticateRequest({ headers: {} });
-  assert.equal(result, null);
+  expect(result).toBe(null);
 });
 
 test("authenticateRequest returns null for non-Bearer auth", () => {
   const result = authenticateRequest({ headers: { authorization: "Basic abc" } });
-  assert.equal(result, null);
+  expect(result).toBe(null);
 });
 
 test("authenticateRequest returns null for unknown token", () => {
   const result = authenticateRequest(makeRequest("tok_unknown_value"));
-  assert.equal(result, null);
+  expect(result).toBe(null);
 });
 
 test("authenticateRequest returns null for timed-out entity", () => {
@@ -111,7 +110,7 @@ test("authenticateRequest returns null for timed-out entity", () => {
   // Simulate timeout by backdating lastHeartbeat
   e.lastHeartbeat = Date.now() - 60_000;
   const result = authenticateRequest(makeRequest(e.token));
-  assert.equal(result, null);
+  expect(result).toBe(null);
 });
 
 // ---------------------------------------------------------------------------
@@ -123,18 +122,18 @@ test("heartbeat updates lastHeartbeat timestamp", () => {
   const before = e.lastHeartbeat;
   // Small delay to ensure time advances
   const updated = heartbeat(e.entityId, []);
-  assert.equal(updated, true);
-  assert.ok(e.lastHeartbeat >= before);
+  expect(updated).toBe(true);
+  expect(e.lastHeartbeat >= before).toBe(true);
 });
 
 test("heartbeat returns false for unknown entity", () => {
-  assert.equal(heartbeat("unknown_id", []), false);
+  expect(heartbeat("unknown_id", [])).toBe(false);
 });
 
 test("heartbeat extends lock expiry", () => {
   const e = registerEntity("LockHB", "human", ["read", "write"]);
   const lockResult = acquireScopeLock("scope_hb", e);
-  assert.equal(lockResult.ok, true);
+  expect(lockResult.ok).toBe(true);
   const originalExpiry = lockResult.lock.expiresAt;
 
   // Simulate time passing
@@ -142,7 +141,7 @@ test("heartbeat extends lock expiry", () => {
   heartbeat(e.entityId, [lockResult.lock.lockId]);
 
   // Lock should be extended
-  assert.ok(lockResult.lock.expiresAt > Date.now() + 5000);
+  expect(lockResult.lock.expiresAt > Date.now() + 5000).toBe(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -156,11 +155,11 @@ test("getActiveEntities returns only non-timed-out entities", () => {
   e3.lastHeartbeat = Date.now() - 60_000;
 
   const active = getActiveEntities();
-  assert.equal(active.length, 2);
+  expect(active.length).toBe(2);
   const ids = active.map((a) => a.entityId);
-  assert.ok(ids.includes(e1.entityId));
-  assert.ok(ids.includes(e2.entityId));
-  assert.ok(!ids.includes(e3.entityId));
+  expect(ids.includes(e1.entityId)).toBe(true);
+  expect(ids.includes(e2.entityId)).toBe(true);
+  expect(ids.includes(e3.entityId)).toBe(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -170,22 +169,22 @@ test("getActiveEntities returns only non-timed-out entities", () => {
 test("acquireScopeLock succeeds for unlocked scope", () => {
   const e = registerEntity("Locker", "human", ["read", "write"]);
   const result = acquireScopeLock("scope_a", e);
-  assert.equal(result.ok, true);
-  assert.ok(result.lock.lockId.startsWith("lock_"));
-  assert.equal(result.lock.scopeId, "scope_a");
-  assert.equal(result.lock.entityId, e.entityId);
-  assert.ok(result.lock.expiresAt > Date.now());
+  expect(result.ok).toBe(true);
+  expect(result.lock.lockId.startsWith("lock_")).toBe(true);
+  expect(result.lock.scopeId).toBe("scope_a");
+  expect(result.lock.entityId).toBe(e.entityId);
+  expect(result.lock.expiresAt > Date.now()).toBe(true);
 });
 
 test("acquireScopeLock refreshes own lock", () => {
   const e = registerEntity("SelfRefresh", "human", ["read", "write"]);
   const first = acquireScopeLock("scope_self", e);
-  assert.equal(first.ok, true);
+  expect(first.ok).toBe(true);
 
   const second = acquireScopeLock("scope_self", e);
-  assert.equal(second.ok, true);
-  assert.equal(second.lock.lockId, first.lock.lockId);
-  assert.ok(second.lock.expiresAt >= first.lock.expiresAt);
+  expect(second.ok).toBe(true);
+  expect(second.lock.lockId).toBe(first.lock.lockId);
+  expect(second.lock.expiresAt >= first.lock.expiresAt).toBe(true);
 });
 
 test("acquireScopeLock fails for lower priority", () => {
@@ -194,8 +193,8 @@ test("acquireScopeLock fails for lower priority", () => {
 
   acquireScopeLock("scope_pri", human);
   const result = acquireScopeLock("scope_pri", ai);
-  assert.equal(result.ok, false);
-  assert.equal(result.status, 409);
+  expect(result.ok).toBe(false);
+  expect(result.status).toBe(409);
 });
 
 test("acquireScopeLock preempts for higher priority", () => {
@@ -204,18 +203,18 @@ test("acquireScopeLock preempts for higher priority", () => {
 
   acquireScopeLock("scope_preempt", ai);
   const result = acquireScopeLock("scope_preempt", human);
-  assert.equal(result.ok, true);
-  assert.equal(result.lock.entityId, human.entityId);
+  expect(result.ok).toBe(true);
+  expect(result.lock.entityId).toBe(human.entityId);
 });
 
 test("releaseScopeLock removes lock", () => {
   const e = registerEntity("Releaser", "human", ["read", "write"]);
   acquireScopeLock("scope_rel", e);
-  assert.equal(getScopeLocks().length, 1);
+  expect(getScopeLocks().length).toBe(1);
 
   const released = releaseScopeLock("scope_rel", e);
-  assert.equal(released, true);
-  assert.equal(getScopeLocks().length, 0);
+  expect(released).toBe(true);
+  expect(getScopeLocks().length).toBe(0);
 });
 
 test("releaseScopeLock returns false if entity does not hold the lock", () => {
@@ -223,19 +222,19 @@ test("releaseScopeLock returns false if entity does not hold the lock", () => {
   const e2 = registerEntity("Other", "human", ["read", "write"]);
   acquireScopeLock("scope_other", e1);
 
-  assert.equal(releaseScopeLock("scope_other", e2), false);
+  expect(releaseScopeLock("scope_other", e2)).toBe(false);
 });
 
 test("expired locks are cleaned up on getScopeLocks", () => {
   const e = registerEntity("Expiry", "human", ["read", "write"]);
   const result = acquireScopeLock("scope_exp", e);
-  assert.equal(result.ok, true);
+  expect(result.ok).toBe(true);
 
   // Expire the lock manually
   result.lock.expiresAt = Date.now() - 1000;
 
   const locks = getScopeLocks();
-  assert.equal(locks.length, 0);
+  expect(locks.length).toBe(0);
 });
 
 // ---------------------------------------------------------------------------
@@ -249,9 +248,9 @@ test("findScopeRoot returns folder ancestor", () => {
     child1: { id: "child1", parentId: "folder1", children: [], nodeType: "text" },
   };
 
-  assert.equal(findScopeRoot(nodes, "child1", "root"), "folder1");
-  assert.equal(findScopeRoot(nodes, "folder1", "root"), "folder1");
-  assert.equal(findScopeRoot(nodes, "root", "root"), "root");
+  expect(findScopeRoot(nodes, "child1", "root")).toBe("folder1");
+  expect(findScopeRoot(nodes, "folder1", "root")).toBe("folder1");
+  expect(findScopeRoot(nodes, "root", "root")).toBe("root");
 });
 
 test("findScopeRoot returns rootId when no folder ancestor", () => {
@@ -260,7 +259,7 @@ test("findScopeRoot returns rootId when no folder ancestor", () => {
     child1: { id: "child1", parentId: "root", children: [], nodeType: "text" },
   };
 
-  assert.equal(findScopeRoot(nodes, "child1", "root"), "root");
+  expect(findScopeRoot(nodes, "child1", "root")).toBe("root");
 });
 
 test("isInScope returns true for node within scope", () => {
@@ -270,8 +269,8 @@ test("isInScope returns true for node within scope", () => {
     child1: { id: "child1", parentId: "folder1", children: [], nodeType: "text" },
   };
 
-  assert.equal(isInScope(nodes, "child1", "folder1", "root"), true);
-  assert.equal(isInScope(nodes, "folder1", "folder1", "root"), true);
+  expect(isInScope(nodes, "child1", "folder1", "root")).toBe(true);
+  expect(isInScope(nodes, "folder1", "folder1", "root")).toBe(true);
 });
 
 test("isInScope returns false for node outside scope", () => {
@@ -282,7 +281,7 @@ test("isInScope returns false for node outside scope", () => {
     outside: { id: "outside", parentId: "root", children: [], nodeType: "text" },
   };
 
-  assert.equal(isInScope(nodes, "outside", "folder1", "root"), false);
+  expect(isInScope(nodes, "outside", "folder1", "root")).toBe(false);
 });
 
 test("isInScope returns true for any node when scope is root", () => {
@@ -291,7 +290,7 @@ test("isInScope returns true for any node when scope is root", () => {
     child1: { id: "child1", parentId: "root", children: [], nodeType: "text" },
   };
 
-  assert.equal(isInScope(nodes, "child1", "root", "root"), true);
+  expect(isInScope(nodes, "child1", "root", "root")).toBe(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -299,16 +298,16 @@ test("isInScope returns true for any node when scope is root", () => {
 // ---------------------------------------------------------------------------
 
 test("version starts at 0 after reset", () => {
-  assert.equal(getDocVersion(), 0);
+  expect(getDocVersion()).toBe(0);
 });
 
 test("incrementDocVersion increments and returns new value", () => {
-  assert.equal(incrementDocVersion(), 1);
-  assert.equal(incrementDocVersion(), 2);
-  assert.equal(getDocVersion(), 2);
+  expect(incrementDocVersion()).toBe(1);
+  expect(incrementDocVersion()).toBe(2);
+  expect(getDocVersion()).toBe(2);
 });
 
 test("setDocVersion sets arbitrary value", () => {
   setDocVersion(42);
-  assert.equal(getDocVersion(), 42);
+  expect(getDocVersion()).toBe(42);
 });

--- a/beta/tests/unit/conflict_backup.test.js
+++ b/beta/tests/unit/conflict_backup.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeEach, afterEach } from "vitest";
 const os = require("node:os");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -21,11 +20,11 @@ function createState(label) {
   return model.toJSON();
 }
 
-test.beforeEach(() => {
+beforeEach(() => {
   tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-backup-test-"));
 });
 
-test.afterEach(() => {
+afterEach(() => {
   fs.rmSync(tempDataDir, { recursive: true, force: true });
 });
 
@@ -33,11 +32,11 @@ test("createConflictBackup saves a backup and returns entry metadata", () => {
   const state = createState("TestNode");
   const entry = createConflictBackup(tempDataDir, "doc-1", state, "cloud-sync-pull");
 
-  assert.ok(entry.backupId);
-  assert.equal(entry.documentId, "doc-1");
-  assert.equal(entry.reason, "cloud-sync-pull");
-  assert.ok(entry.createdAt);
-  assert.ok(entry.savedAt);
+  expect(entry.backupId).toBeTruthy();
+  expect(entry.documentId).toBe("doc-1");
+  expect(entry.reason).toBe("cloud-sync-pull");
+  expect(entry.createdAt).toBeTruthy();
+  expect(entry.savedAt).toBeTruthy();
 });
 
 test("listConflictBackups returns saved backups sorted newest first", () => {
@@ -48,15 +47,15 @@ test("listConflictBackups returns saved backups sorted newest first", () => {
   const entry2 = createConflictBackup(tempDataDir, "doc-1", state2, "reason-2");
 
   const list = listConflictBackups(tempDataDir, "doc-1");
-  assert.equal(list.length, 2);
+  expect(list.length).toBe(2);
   // Newest first
-  assert.equal(list[0].backupId, entry2.backupId);
-  assert.equal(list[1].backupId, entry1.backupId);
+  expect(list[0].backupId).toBe(entry2.backupId);
+  expect(list[1].backupId).toBe(entry1.backupId);
 });
 
 test("listConflictBackups returns empty array when no backups exist", () => {
   const list = listConflictBackups(tempDataDir, "nonexistent");
-  assert.deepEqual(list, []);
+  expect(list).toEqual([]);
 });
 
 test("listConflictBackups filters by documentId", () => {
@@ -64,12 +63,12 @@ test("listConflictBackups filters by documentId", () => {
   createConflictBackup(tempDataDir, "doc-b", createState("B"), "r2");
 
   const listA = listConflictBackups(tempDataDir, "doc-a");
-  assert.equal(listA.length, 1);
-  assert.equal(listA[0].documentId, "doc-a");
+  expect(listA.length).toBe(1);
+  expect(listA[0].documentId).toBe("doc-a");
 
   const listB = listConflictBackups(tempDataDir, "doc-b");
-  assert.equal(listB.length, 1);
-  assert.equal(listB[0].documentId, "doc-b");
+  expect(listB.length).toBe(1);
+  expect(listB[0].documentId).toBe("doc-b");
 });
 
 test("getConflictBackup returns full backup with state", () => {
@@ -77,36 +76,36 @@ test("getConflictBackup returns full backup with state", () => {
   const entry = createConflictBackup(tempDataDir, "doc-1", state, "test-reason");
 
   const full = getConflictBackup(tempDataDir, "doc-1", entry.backupId);
-  assert.ok(full);
-  assert.equal(full.version, 1);
-  assert.equal(full.backupId, entry.backupId);
-  assert.equal(full.documentId, "doc-1");
-  assert.ok(full.state);
-  assert.ok(full.state.rootId);
-  assert.ok(full.state.nodes);
+  expect(full).toBeTruthy();
+  expect(full.version).toBe(1);
+  expect(full.backupId).toBe(entry.backupId);
+  expect(full.documentId).toBe("doc-1");
+  expect(full.state).toBeTruthy();
+  expect(full.state.rootId).toBeTruthy();
+  expect(full.state.nodes).toBeTruthy();
 });
 
 test("getConflictBackup returns null for nonexistent backup", () => {
   const full = getConflictBackup(tempDataDir, "doc-1", "nonexistent-id");
-  assert.equal(full, null);
+  expect(full).toBe(null);
 });
 
 test("deleteConflictBackup removes the backup file", () => {
   const entry = createConflictBackup(tempDataDir, "doc-1", createState("Del"), "r");
 
   const deleted = deleteConflictBackup(tempDataDir, "doc-1", entry.backupId);
-  assert.equal(deleted, true);
+  expect(deleted).toBe(true);
 
   const list = listConflictBackups(tempDataDir, "doc-1");
-  assert.equal(list.length, 0);
+  expect(list.length).toBe(0);
 
   const full = getConflictBackup(tempDataDir, "doc-1", entry.backupId);
-  assert.equal(full, null);
+  expect(full).toBe(null);
 });
 
 test("deleteConflictBackup returns false for nonexistent backup", () => {
   const deleted = deleteConflictBackup(tempDataDir, "doc-1", "nonexistent");
-  assert.equal(deleted, false);
+  expect(deleted).toBe(false);
 });
 
 test("createConflictBackup prunes backups beyond limit of 10", () => {
@@ -115,5 +114,5 @@ test("createConflictBackup prunes backups beyond limit of 10", () => {
   }
 
   const list = listConflictBackups(tempDataDir, "doc-prune");
-  assert.equal(list.length, 10);
+  expect(list.length).toBe(10);
 });

--- a/beta/tests/unit/conflict_backup_api.test.js
+++ b/beta/tests/unit/conflict_backup_api.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeAll, afterAll } from "vitest";
 const os = require("node:os");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -28,7 +27,7 @@ function createState(label) {
   return model.toJSON();
 }
 
-test.before(async () => {
+beforeAll(async () => {
   server = createAppServer();
   await new Promise((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -37,7 +36,7 @@ test.before(async () => {
   baseUrl = `http://127.0.0.1:${address.port}`;
 });
 
-test.after(async () => {
+afterAll(async () => {
   if (server) {
     await new Promise((resolve, reject) => {
       server.close((err) => {
@@ -52,10 +51,10 @@ test.after(async () => {
 
 test("backup list returns empty array when no backups exist", async () => {
   const res = await requestJson(`${baseUrl}/api/sync/backups/no-backups`);
-  assert.equal(res.response.status, 200);
-  assert.equal(res.payload.ok, true);
-  assert.equal(res.payload.documentId, "no-backups");
-  assert.deepEqual(res.payload.backups, []);
+  expect(res.response.status).toBe(200);
+  expect(res.payload.ok).toBe(true);
+  expect(res.payload.documentId).toBe("no-backups");
+  expect(res.payload.backups).toEqual([]);
 });
 
 test("pull with localState creates a conflict backup", async () => {
@@ -68,7 +67,7 @@ test("pull with localState creates a conflict backup", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({ state: createState("CloudVersion"), savedAt: "2026-04-02T00:00:00.000Z" }),
   });
-  assert.equal(push.response.status, 200);
+  expect(push.response.status).toBe(200);
 
   // Pull with localState to trigger backup
   const pull = await requestJson(`${baseUrl}/api/sync/pull/${docId}`, {
@@ -76,17 +75,17 @@ test("pull with localState creates a conflict backup", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({ localState }),
   });
-  assert.equal(pull.response.status, 200);
-  assert.equal(pull.payload.ok, true);
-  assert.ok(pull.payload.backup);
-  assert.ok(pull.payload.backup.backupId);
-  assert.equal(pull.payload.backup.reason, "cloud-sync-pull");
+  expect(pull.response.status).toBe(200);
+  expect(pull.payload.ok).toBe(true);
+  expect(pull.payload.backup).toBeTruthy();
+  expect(pull.payload.backup.backupId).toBeTruthy();
+  expect(pull.payload.backup.reason).toBe("cloud-sync-pull");
 
   // Verify backup appears in list
   const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
-  assert.equal(list.response.status, 200);
-  assert.equal(list.payload.backups.length, 1);
-  assert.equal(list.payload.backups[0].backupId, pull.payload.backup.backupId);
+  expect(list.response.status).toBe(200);
+  expect(list.payload.backups.length).toBe(1);
+  expect(list.payload.backups[0].backupId).toBe(pull.payload.backup.backupId);
 });
 
 test("pull without localState does not create a backup", async () => {
@@ -105,12 +104,12 @@ test("pull without localState does not create a backup", async () => {
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: JSON.stringify({}),
   });
-  assert.equal(pull.response.status, 200);
-  assert.equal(pull.payload.backup, undefined);
+  expect(pull.response.status).toBe(200);
+  expect(pull.payload.backup).toBeUndefined();
 
   // No backup in list
   const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
-  assert.equal(list.payload.backups.length, 0);
+  expect(list.payload.backups.length).toBe(0);
 });
 
 test("push conflict creates a backup of the pushed state", async () => {
@@ -144,15 +143,15 @@ test("push conflict creates a backup of the pushed state", async () => {
       baseSavedAt: "2026-04-02T00:00:00.000Z",
     }),
   });
-  assert.equal(conflict.response.status, 409);
-  assert.equal(conflict.payload.code, "CLOUD_CONFLICT");
-  assert.ok(conflict.payload.backup);
-  assert.ok(conflict.payload.backup.backupId);
-  assert.equal(conflict.payload.backup.reason, "cloud-conflict-push");
+  expect(conflict.response.status).toBe(409);
+  expect(conflict.payload.code).toBe("CLOUD_CONFLICT");
+  expect(conflict.payload.backup).toBeTruthy();
+  expect(conflict.payload.backup.backupId).toBeTruthy();
+  expect(conflict.payload.backup.reason).toBe("cloud-conflict-push");
 
   // Backup should be in list
   const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
-  assert.equal(list.payload.backups.length, 1);
+  expect(list.payload.backups.length).toBe(1);
 });
 
 test("get backup returns full state", async () => {
@@ -176,18 +175,18 @@ test("get backup returns full state", async () => {
 
   // Get the backup
   const get = await requestJson(`${baseUrl}/api/sync/backups/${docId}/${backupId}`);
-  assert.equal(get.response.status, 200);
-  assert.equal(get.payload.ok, true);
-  assert.ok(get.payload.backup);
-  assert.equal(get.payload.backup.backupId, backupId);
-  assert.ok(get.payload.backup.state);
-  assert.ok(get.payload.backup.state.rootId);
+  expect(get.response.status).toBe(200);
+  expect(get.payload.ok).toBe(true);
+  expect(get.payload.backup).toBeTruthy();
+  expect(get.payload.backup.backupId).toBe(backupId);
+  expect(get.payload.backup.state).toBeTruthy();
+  expect(get.payload.backup.state.rootId).toBeTruthy();
 });
 
 test("get nonexistent backup returns 404", async () => {
   const get = await requestJson(`${baseUrl}/api/sync/backups/doc/nonexistent-id`);
-  assert.equal(get.response.status, 404);
-  assert.equal(get.payload.ok, false);
+  expect(get.response.status).toBe(404);
+  expect(get.payload.ok).toBe(false);
 });
 
 test("restore backup saves state to SQLite", async () => {
@@ -214,12 +213,12 @@ test("restore backup saves state to SQLite", async () => {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8" },
   });
-  assert.equal(restore.response.status, 200);
-  assert.equal(restore.payload.ok, true);
-  assert.equal(restore.payload.restored, true);
-  assert.equal(restore.payload.backupId, backupId);
-  assert.equal(restore.payload.documentId, docId);
-  assert.ok(restore.payload.savedAt);
+  expect(restore.response.status).toBe(200);
+  expect(restore.payload.ok).toBe(true);
+  expect(restore.payload.restored).toBe(true);
+  expect(restore.payload.backupId).toBe(backupId);
+  expect(restore.payload.documentId).toBe(docId);
+  expect(restore.payload.savedAt).toBeTruthy();
 });
 
 test("delete backup via DELETE method on get endpoint", async () => {
@@ -243,11 +242,11 @@ test("delete backup via DELETE method on get endpoint", async () => {
   const del = await requestJson(`${baseUrl}/api/sync/backups/${docId}/${backupId}`, {
     method: "DELETE",
   });
-  assert.equal(del.response.status, 200);
-  assert.equal(del.payload.ok, true);
-  assert.equal(del.payload.deleted, true);
+  expect(del.response.status).toBe(200);
+  expect(del.payload.ok).toBe(true);
+  expect(del.payload.deleted).toBe(true);
 
   // Verify gone
   const list = await requestJson(`${baseUrl}/api/sync/backups/${docId}`);
-  assert.equal(list.payload.backups.length, 0);
+  expect(list.payload.backups.length).toBe(0);
 });

--- a/beta/tests/unit/data_model_integrity.test.js
+++ b/beta/tests/unit/data_model_integrity.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -26,24 +25,17 @@ function assertParentChildConsistency(model) {
   for (const [id, node] of Object.entries(nodes)) {
     // Every child listed in children array must exist and point back
     for (const childId of node.children) {
-      assert.ok(nodes[childId], `Child ${childId} of ${id} does not exist`);
-      assert.equal(
-        nodes[childId].parentId,
-        id,
-        `Child ${childId} parentId should be ${id} but is ${nodes[childId].parentId}`,
-      );
+      expect(nodes[childId]).toBeTruthy();
+      expect(nodes[childId].parentId).toBe(id);
     }
 
     // Every node except root should appear in its parent's children
     if (node.parentId !== null) {
       const parent = nodes[node.parentId];
-      assert.ok(parent, `Parent ${node.parentId} of ${id} does not exist`);
-      assert.ok(
-        parent.children.includes(id),
-        `Node ${id} not found in parent ${node.parentId}'s children`,
-      );
+      expect(parent).toBeTruthy();
+      expect(parent.children.includes(id)).toBe(true);
     } else {
-      assert.equal(id, rootId, "Only root should have null parentId");
+      expect(id).toBe(rootId);
     }
   }
 }
@@ -60,9 +52,9 @@ test("addNode maintains parent-child consistency", () => {
   const a1 = model.addNode(a, "A1");
 
   assertParentChildConsistency(model);
-  assert.equal(Object.keys(model.state.nodes).length, 4);
-  assert.deepEqual(model.state.nodes[rootId].children, [a, b]);
-  assert.deepEqual(model.state.nodes[a].children, [a1]);
+  expect(Object.keys(model.state.nodes).length).toBe(4);
+  expect(model.state.nodes[rootId].children).toEqual([a, b]);
+  expect(model.state.nodes[a].children).toEqual([a1]);
 });
 
 test("addNode at specific index inserts correctly", () => {
@@ -72,7 +64,7 @@ test("addNode at specific index inserts correctly", () => {
   const b = model.addNode(rootId, "B");
   const c = model.addNode(rootId, "C", 1); // between A and B
 
-  assert.deepEqual(model.state.nodes[rootId].children, [a, c, b]);
+  expect(model.state.nodes[rootId].children).toEqual([a, c, b]);
   assertParentChildConsistency(model);
 });
 
@@ -86,11 +78,11 @@ test("deleteNode with deep subtree maintains consistency", () => {
 
   model.deleteNode(a);
 
-  assert.equal(model.state.nodes[a], undefined);
-  assert.equal(model.state.nodes[b], undefined);
-  assert.equal(model.state.nodes[c], undefined);
-  assert.equal(model.state.nodes[d], undefined);
-  assert.deepEqual(model.state.nodes[rootId].children, []);
+  expect(model.state.nodes[a]).toBeUndefined();
+  expect(model.state.nodes[b]).toBeUndefined();
+  expect(model.state.nodes[c]).toBeUndefined();
+  expect(model.state.nodes[d]).toBeUndefined();
+  expect(model.state.nodes[rootId].children).toEqual([]);
   assertParentChildConsistency(model);
 });
 
@@ -103,9 +95,9 @@ test("deleteNode preserves siblings", () => {
 
   model.deleteNode(b);
 
-  assert.deepEqual(model.state.nodes[rootId].children, [a, c]);
-  assert.ok(model.state.nodes[a]);
-  assert.ok(model.state.nodes[c]);
+  expect(model.state.nodes[rootId].children).toEqual([a, c]);
+  expect(model.state.nodes[a]).toBeTruthy();
+  expect(model.state.nodes[c]).toBeTruthy();
   assertParentChildConsistency(model);
 });
 
@@ -119,8 +111,8 @@ test("reparentNode updates children arrays correctly", () => {
   model.reparentNode(a1, b);
 
   // Children arrays are updated correctly
-  assert.deepEqual(model.state.nodes[a].children, []);
-  assert.ok(model.state.nodes[b].children.includes(a1));
+  expect(model.state.nodes[a].children).toEqual([]);
+  expect(model.state.nodes[b].children.includes(a1)).toBe(true);
 });
 
 // Fixed: _isDescendant used to call _requireNode which replaced the node object
@@ -135,8 +127,7 @@ test("reparentNode correctly updates parentId (stale reference bug fixed)", () =
 
   model.reparentNode(a1, b);
 
-  assert.equal(model.state.nodes[a1].parentId, b,
-    "parentId should be updated to new parent after reparent");
+  expect(model.state.nodes[a1].parentId).toBe(b);
 });
 
 test("reparentNode with subtree moves children array correctly", () => {
@@ -150,13 +141,11 @@ test("reparentNode with subtree moves children array correctly", () => {
   model.reparentNode(a, b);
 
   // Children arrays are correct
-  assert.deepEqual(model.state.nodes[rootId].children, [b]);
-  assert.ok(model.state.nodes[b].children.includes(a));
+  expect(model.state.nodes[rootId].children).toEqual([b]);
+  expect(model.state.nodes[b].children.includes(a)).toBe(true);
   // Subtree internal structure unchanged
-  assert.equal(model.state.nodes[a1].parentId, a);
-  assert.equal(model.state.nodes[a1a].parentId, a1);
-  // Note: a.parentId is NOT updated to b due to known stale reference bug
-  // (see "BUG: reparentNode does not update parentId" test)
+  expect(model.state.nodes[a1].parentId).toBe(a);
+  expect(model.state.nodes[a1a].parentId).toBe(a1);
 });
 
 test("reparentNode rejects moving root", () => {
@@ -164,7 +153,7 @@ test("reparentNode rejects moving root", () => {
   const rootId = model.state.rootId;
   const a = model.addNode(rootId, "A");
 
-  assert.throws(() => model.reparentNode(rootId, a));
+  expect(() => model.reparentNode(rootId, a)).toThrow();
 });
 
 // ---------------------------------------------------------------------------
@@ -183,19 +172,19 @@ test("sequence: add, edit, delete keeps consistency", () => {
 
   // Edit
   model.editNode(c, "C-edited");
-  assert.equal(model.state.nodes[c].text, "C-edited");
+  expect(model.state.nodes[c].text).toBe("C-edited");
 
   // Delete D
   model.deleteNode(d);
-  assert.equal(model.state.nodes[d], undefined);
+  expect(model.state.nodes[d]).toBeUndefined();
 
   // Delete C
   model.deleteNode(c);
-  assert.equal(model.state.nodes[c], undefined);
-  assert.deepEqual(model.state.nodes[a].children, []);
+  expect(model.state.nodes[c]).toBeUndefined();
+  expect(model.state.nodes[a].children).toEqual([]);
 
   assertParentChildConsistency(model);
-  assert.deepEqual(validateModel(model), []);
+  expect(validateModel(model)).toEqual([]);
 });
 
 test("sequence: add, delete, undo, redo maintains consistency", () => {
@@ -206,15 +195,15 @@ test("sequence: add, delete, undo, redo maintains consistency", () => {
   const b = model.addNode(rootId, "B");
   model.deleteNode(a);
 
-  assert.equal(model.state.nodes[a], undefined);
+  expect(model.state.nodes[a]).toBeUndefined();
   assertParentChildConsistency(model);
 
   model.undo();
-  assert.ok(model.state.nodes[a]);
+  expect(model.state.nodes[a]).toBeTruthy();
   assertParentChildConsistency(model);
 
   model.redo();
-  assert.equal(model.state.nodes[a], undefined);
+  expect(model.state.nodes[a]).toBeUndefined();
   assertParentChildConsistency(model);
 });
 
@@ -228,7 +217,7 @@ test("validate passes for valid tree", () => {
   model.addNode(rootId, "A");
   model.addNode(rootId, "B");
   const errors = validateModel(model);
-  assert.deepEqual(errors, []);
+  expect(errors).toEqual([]);
 });
 
 test("validate detects orphan node (parentId points to nonexistent node)", () => {
@@ -240,7 +229,7 @@ test("validate detects orphan node (parentId points to nonexistent node)", () =>
   model.state.nodes[a].parentId = "nonexistent";
 
   const errors = validateModel(model);
-  assert.ok(errors.length > 0, "Should detect orphan node");
+  expect(errors.length > 0).toBe(true);
 });
 
 test("validate detects child not listed in parent", () => {
@@ -253,7 +242,7 @@ test("validate detects child not listed in parent", () => {
   model.state.nodes[rootId].children = [a];
 
   const errors = validateModel(model);
-  assert.ok(errors.length > 0, "Should detect child not listed in parent");
+  expect(errors.length > 0).toBe(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -276,20 +265,20 @@ test("SQLite save and load preserves full tree structure", () => {
     model.saveToSqlite(sqlitePath, docId);
     const loaded = RapidMvpModel.loadFromSqlite(sqlitePath, docId);
 
-    assert.equal(loaded.state.rootId, rootId);
-    assert.equal(Object.keys(loaded.state.nodes).length, 4);
-    assert.deepEqual(loaded.state.nodes[rootId].children, [a, b]);
-    assert.deepEqual(loaded.state.nodes[a].children, [a1]);
-    assert.equal(loaded.state.nodes[a1].parentId, a);
+    expect(loaded.state.rootId).toBe(rootId);
+    expect(Object.keys(loaded.state.nodes).length).toBe(4);
+    expect(loaded.state.nodes[rootId].children).toEqual([a, b]);
+    expect(loaded.state.nodes[a].children).toEqual([a1]);
+    expect(loaded.state.nodes[a1].parentId).toBe(a);
 
     // Links preserved
     const links = Object.values(loaded.state.links || {});
-    assert.equal(links.length, 1);
-    assert.equal(links[0].sourceNodeId, a);
-    assert.equal(links[0].targetNodeId, b);
+    expect(links.length).toBe(1);
+    expect(links[0].sourceNodeId).toBe(a);
+    expect(links[0].targetNodeId).toBe(b);
 
     assertParentChildConsistency(loaded);
-    assert.deepEqual(validateModel(loaded), []);
+    expect(validateModel(loaded)).toEqual([]);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -305,9 +294,9 @@ test("JSON save and load preserves full tree structure", () => {
   const json = model.toJSON();
   const restored = RapidMvpModel.fromJSON(json);
 
-  assert.equal(restored.state.rootId, rootId);
-  assert.equal(Object.keys(restored.state.nodes).length, 3);
-  assert.equal(restored.state.nodes[b].text, "B-edited");
+  expect(restored.state.rootId).toBe(rootId);
+  expect(Object.keys(restored.state.nodes).length).toBe(3);
+  expect(restored.state.nodes[b].text).toBe("B-edited");
   assertParentChildConsistency(restored);
 });
 
@@ -321,14 +310,14 @@ test("alias points to valid target after multi-operation", () => {
   const target = model.addNode(rootId, "Target");
   const aliasId = model.addAlias(rootId, target);
 
-  assert.equal(model.state.nodes[aliasId].nodeType, "alias");
-  assert.equal(model.state.nodes[aliasId].targetNodeId, target);
-  assert.ok(!model.state.nodes[aliasId].isBroken);
+  expect(model.state.nodes[aliasId].nodeType).toBe("alias");
+  expect(model.state.nodes[aliasId].targetNodeId).toBe(target);
+  expect(model.state.nodes[aliasId].isBroken).toBeFalsy();
 
   // Delete target -- alias should be marked broken
   model.deleteNode(target);
-  assert.equal(model.state.nodes[aliasId].isBroken, true);
-  assert.match(model.state.nodes[aliasId].text, /deleted/);
+  expect(model.state.nodes[aliasId].isBroken).toBe(true);
+  expect(model.state.nodes[aliasId].text).toMatch(/deleted/);
   assertParentChildConsistency(model);
 });
 
@@ -348,9 +337,9 @@ test("links are cleaned up when either endpoint is deleted", () => {
 
   // Delete B -- both links should be removed
   model.deleteNode(b);
-  assert.equal(model.state.links[link1], undefined);
-  assert.equal(model.state.links[link2], undefined);
-  assert.deepEqual(validateModel(model), []);
+  expect(model.state.links[link1]).toBeUndefined();
+  expect(model.state.links[link2]).toBeUndefined();
+  expect(validateModel(model)).toEqual([]);
 });
 
 test("links survive when nodes are edited but not deleted", () => {
@@ -365,9 +354,9 @@ test("links survive when nodes are edited but not deleted", () => {
   model.editNode(b, "B-edited");
 
   // Link should still exist
-  assert.ok(model.state.links[linkId]);
-  assert.equal(model.state.links[linkId].sourceNodeId, a);
-  assert.equal(model.state.links[linkId].targetNodeId, b);
+  expect(model.state.links[linkId]).toBeTruthy();
+  expect(model.state.links[linkId].sourceNodeId).toBe(a);
+  expect(model.state.links[linkId].targetNodeId).toBe(b);
   assertParentChildConsistency(model);
 });
 
@@ -379,10 +368,10 @@ test("addNode to leaf node makes it a branch", () => {
   const model = createModel("Root");
   const rootId = model.state.rootId;
   const leaf = model.addNode(rootId, "Leaf");
-  assert.deepEqual(model.state.nodes[leaf].children, []);
+  expect(model.state.nodes[leaf].children).toEqual([]);
 
   const child = model.addNode(leaf, "ChildOfLeaf");
-  assert.deepEqual(model.state.nodes[leaf].children, [child]);
+  expect(model.state.nodes[leaf].children).toEqual([child]);
   assertParentChildConsistency(model);
 });
 
@@ -400,14 +389,14 @@ test("multiple undo/redo cycles preserve integrity", () => {
 
   // Undo edit
   model.undo();
-  assert.equal(model.state.nodes[a].text, "A");
+  expect(model.state.nodes[a].text).toBe("A");
   assertParentChildConsistency(model);
 
   // Redo both
   model.redo();
   model.redo();
-  assert.equal(model.state.nodes[a].text, "A2");
-  assert.ok(model.state.nodes[b] || model.state.nodes[Object.keys(model.state.nodes).find(k => model.state.nodes[k].text === "B")]);
+  expect(model.state.nodes[a].text).toBe("A2");
+  expect(model.state.nodes[b] || model.state.nodes[Object.keys(model.state.nodes).find(k => model.state.nodes[k].text === "B")]).toBeTruthy();
   assertParentChildConsistency(model);
 });
 
@@ -422,6 +411,6 @@ test("deeply nested tree (10 levels) validates correctly", () => {
   }
 
   assertParentChildConsistency(model);
-  assert.deepEqual(validateModel(model), []);
-  assert.equal(Object.keys(model.state.nodes).length, 11); // root + 10
+  expect(validateModel(model)).toEqual([]);
+  expect(Object.keys(model.state.nodes).length).toBe(11); // root + 10
 });

--- a/beta/tests/unit/linear_transform_api_integration.test.js
+++ b/beta/tests/unit/linear_transform_api_integration.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeAll, afterAll } from "vitest";
 const http = require("node:http");
 
 const { createAppServer } = require("../../dist/node/start_viewer.js");
@@ -15,7 +14,7 @@ async function requestJson(url, init) {
   return { response, payload };
 }
 
-test.before(async () => {
+beforeAll(async () => {
   providerServer = http.createServer(async (req, res) => {
     if (req.url !== "/chat/completions" || req.method !== "POST") {
       res.statusCode = 404;
@@ -58,7 +57,7 @@ test.before(async () => {
   appBaseUrl = `http://127.0.0.1:${appAddress.port}`;
 });
 
-test.after(async () => {
+afterAll(async () => {
   delete process.env.M3E_AI_ENABLED;
   delete process.env.M3E_AI_PROVIDER;
   delete process.env.M3E_AI_GATEWAY;
@@ -88,10 +87,10 @@ test("linear transform status returns disabled when subagent is explicitly opted
   delete process.env.M3E_AI_MODEL;
 
   const result = await requestJson(`${appBaseUrl}/api/linear-transform/status`);
-  assert.equal(result.response.status, 200);
-  assert.equal(result.payload.ok, true);
-  assert.equal(result.payload.enabled, false);
-  assert.equal(result.payload.configured, false);
+  expect(result.response.status).toBe(200);
+  expect(result.payload.ok).toBe(true);
+  expect(result.payload.enabled).toBe(false);
+  expect(result.payload.configured).toBe(false);
 });
 
 test("linear transform convert proxies request to configured subagent", async () => {
@@ -103,13 +102,13 @@ test("linear transform convert proxies request to configured subagent", async ()
   process.env.M3E_AI_MODEL = "deepseek-chat";
 
   const status = await requestJson(`${appBaseUrl}/api/ai/status`);
-  assert.equal(status.response.status, 200);
-  assert.equal(status.payload.ok, true);
-  assert.equal(status.payload.enabled, true);
-  assert.equal(status.payload.configured, true);
-  assert.equal(status.payload.provider, "deepseek");
-  assert.equal(status.payload.features["linear-transform"].available, true);
-  assert.equal(status.payload.features["topic-suggest"].available, true);
+  expect(status.response.status).toBe(200);
+  expect(status.payload.ok).toBe(true);
+  expect(status.payload.enabled).toBe(true);
+  expect(status.payload.configured).toBe(true);
+  expect(status.payload.provider).toBe("deepseek");
+  expect(status.payload.features["linear-transform"].available).toBe(true);
+  expect(status.payload.features["topic-suggest"].available).toBe(true);
 
   const converted = await requestJson(`${appBaseUrl}/api/ai/subagent/linear-transform`, {
     method: "POST",
@@ -125,14 +124,14 @@ test("linear transform convert proxies request to configured subagent", async ()
       },
     }),
   });
-  assert.equal(converted.response.status, 200);
-  assert.equal(converted.payload.ok, true);
-  assert.equal(converted.payload.subagent, "linear-transform");
-  assert.equal(converted.payload.provider, "deepseek");
-  assert.equal(converted.payload.model, "deepseek-chat");
-  assert.equal(converted.payload.requiresApproval, false);
-  assert.equal(converted.payload.proposal.kind, "text-transform");
-  assert.equal(converted.payload.proposal.result.outputText, "stubbed-transform:ttl");
+  expect(converted.response.status).toBe(200);
+  expect(converted.payload.ok).toBe(true);
+  expect(converted.payload.subagent).toBe("linear-transform");
+  expect(converted.payload.provider).toBe("deepseek");
+  expect(converted.payload.model).toBe("deepseek-chat");
+  expect(converted.payload.requiresApproval).toBe(false);
+  expect(converted.payload.proposal.kind).toBe("text-transform");
+  expect(converted.payload.proposal.result.outputText).toBe("stubbed-transform:ttl");
 
   const compatibility = await requestJson(`${appBaseUrl}/api/linear-transform/convert`, {
     method: "POST",
@@ -144,8 +143,8 @@ test("linear transform convert proxies request to configured subagent", async ()
       scopeLabel: "Root",
     }),
   });
-  assert.equal(compatibility.response.status, 200);
-  assert.equal(compatibility.payload.outputText, "stubbed-transform:ttl");
+  expect(compatibility.response.status).toBe(200);
+  expect(compatibility.payload.outputText).toBe("stubbed-transform:ttl");
 });
 
 test("linear transform convert returns 503 when provider config is incomplete", async () => {
@@ -168,10 +167,10 @@ test("linear transform convert returns 503 when provider config is incomplete", 
       },
     }),
   });
-  assert.equal(converted.response.status, 503);
-  assert.equal(converted.payload.ok, false);
-  assert.equal(converted.payload.code, "AI_NOT_CONFIGURED");
-  assert.match(converted.payload.error, /not fully configured/);
+  expect(converted.response.status).toBe(503);
+  expect(converted.payload.ok).toBe(false);
+  expect(converted.payload.code).toBe("AI_NOT_CONFIGURED");
+  expect(converted.payload.error).toMatch(/not fully configured/);
 });
 
 test("ai status and subagent resolve model alias from registry", async () => {
@@ -195,12 +194,12 @@ test("ai status and subagent resolve model alias from registry", async () => {
   });
 
   const status = await requestJson(`${appBaseUrl}/api/ai/status`);
-  assert.equal(status.response.status, 200);
-  assert.equal(status.payload.ok, true);
-  assert.equal(status.payload.gateway, "litellm");
-  assert.equal(status.payload.activeModelAlias, "chat.fast");
-  assert.equal(status.payload.model, "deepseek-chat");
-  assert.deepEqual(status.payload.availableModelAliases, ["chat.fast"]);
+  expect(status.response.status).toBe(200);
+  expect(status.payload.ok).toBe(true);
+  expect(status.payload.gateway).toBe("litellm");
+  expect(status.payload.activeModelAlias).toBe("chat.fast");
+  expect(status.payload.model).toBe("deepseek-chat");
+  expect(status.payload.availableModelAliases).toEqual(["chat.fast"]);
 
   const converted = await requestJson(`${appBaseUrl}/api/ai/subagent/linear-transform`, {
     method: "POST",
@@ -217,10 +216,10 @@ test("ai status and subagent resolve model alias from registry", async () => {
     }),
   });
 
-  assert.equal(converted.response.status, 200);
-  assert.equal(converted.payload.ok, true);
-  assert.equal(converted.payload.model, "deepseek-chat");
-  assert.equal(converted.payload.resolvedModelAlias, "chat.fast");
+  expect(converted.response.status).toBe(200);
+  expect(converted.payload.ok).toBe(true);
+  expect(converted.payload.model).toBe("deepseek-chat");
+  expect(converted.payload.resolvedModelAlias).toBe("chat.fast");
 });
 
 test("ai subagent returns 404 for unsupported subagent", async () => {
@@ -240,8 +239,8 @@ test("ai subagent returns 404 for unsupported subagent", async () => {
       input: {},
     }),
   });
-  assert.equal(response.response.status, 404);
-  assert.equal(response.payload.code, "AI_UNSUPPORTED_SUBAGENT");
+  expect(response.response.status).toBe(404);
+  expect(response.payload.code).toBe("AI_UNSUPPORTED_SUBAGENT");
 });
 
 test("topic suggest subagent returns related topics", async () => {
@@ -266,11 +265,11 @@ test("topic suggest subagent returns related topics", async () => {
     }),
   });
 
-  assert.equal(response.response.status, 200);
-  assert.equal(response.payload.ok, true);
-  assert.equal(response.payload.subagent, "topic-suggest");
-  assert.equal(response.payload.model, "gemma3:4b");
-  assert.deepEqual(response.payload.proposal.result.topics, [
+  expect(response.response.status).toBe(200);
+  expect(response.payload.ok).toBe(true);
+  expect(response.payload.subagent).toBe("topic-suggest");
+  expect(response.payload.model).toBe("gemma3:4b");
+  expect(response.payload.proposal.result.topics).toEqual([
     "Root cause",
     "Alternative design",
     "Validation steps",
@@ -324,8 +323,8 @@ test("topic suggest subagent parses fenced json response", async () => {
     }),
   });
 
-  assert.equal(response.response.status, 200);
-  assert.deepEqual(response.payload.proposal.result.topics, [
+  expect(response.response.status).toBe(200);
+  expect(response.payload.proposal.result.topics).toEqual([
     "栄養成分分析",
     "食品添加物",
     "食品安全規制",

--- a/beta/tests/unit/local_binding.test.js
+++ b/beta/tests/unit/local_binding.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -63,22 +62,22 @@ Some body text.
 
   const { frontmatter, body } = parseFrontmatter(md);
 
-  assert.equal(frontmatter.m3e.nodeId, "n_1234_abc");
-  assert.equal(frontmatter.m3e.nodeType, "folder");
-  assert.equal(frontmatter.m3e.collapsed, false);
-  assert.deepEqual(frontmatter.m3e["children-order"], ["n_child1", "n_child2"]);
-  assert.deepEqual(frontmatter.tags, ["hypothesis", "biology"]);
-  assert.deepEqual(frontmatter.aliases, ["Hypothesis A"]);
-  assert.ok(body.includes("# Hypothesis A"));
-  assert.ok(body.includes("Some body text."));
+  expect(frontmatter.m3e.nodeId).toBe("n_1234_abc");
+  expect(frontmatter.m3e.nodeType).toBe("folder");
+  expect(frontmatter.m3e.collapsed).toBe(false);
+  expect(frontmatter.m3e["children-order"]).toEqual(["n_child1", "n_child2"]);
+  expect(frontmatter.tags).toEqual(["hypothesis", "biology"]);
+  expect(frontmatter.aliases).toEqual(["Hypothesis A"]);
+  expect(body.includes("# Hypothesis A")).toBe(true);
+  expect(body.includes("Some body text.")).toBe(true);
 });
 
 test("parseFrontmatter: returns empty frontmatter when no delimiters", () => {
   const md = "# Just a heading\n\nSome text.";
   const { frontmatter, body } = parseFrontmatter(md);
 
-  assert.deepEqual(frontmatter, {});
-  assert.ok(body.includes("# Just a heading"));
+  expect(frontmatter).toEqual({});
+  expect(body.includes("# Just a heading")).toBe(true);
 });
 
 test("parseFrontmatter: handles empty frontmatter block", () => {
@@ -89,8 +88,8 @@ test("parseFrontmatter: handles empty frontmatter block", () => {
 `;
   const { frontmatter, body } = parseFrontmatter(md);
 
-  assert.deepEqual(frontmatter, {});
-  assert.ok(body.includes("# Title"));
+  expect(frontmatter).toEqual({});
+  expect(body.includes("# Title")).toBe(true);
 });
 
 test("parseSimpleYaml: parses scalar values", () => {
@@ -101,10 +100,10 @@ disabled: false`;
 
   const result = parseSimpleYaml(yaml);
 
-  assert.equal(result.name, "test");
-  assert.equal(result.count, 42);
-  assert.equal(result.active, true);
-  assert.equal(result.disabled, false);
+  expect(result.name).toBe("test");
+  expect(result.count).toBe(42);
+  expect(result.active).toBe(true);
+  expect(result.disabled).toBe(false);
 });
 
 test("parseSimpleYaml: parses quoted strings", () => {
@@ -112,8 +111,8 @@ test("parseSimpleYaml: parses quoted strings", () => {
 double: "goodbye world"`;
 
   const result = parseSimpleYaml(yaml);
-  assert.equal(result.single, "hello world");
-  assert.equal(result.double, "goodbye world");
+  expect(result.single).toBe("hello world");
+  expect(result.double).toBe("goodbye world");
 });
 
 test("parseSimpleYaml: parses nested objects (m3e block)", () => {
@@ -123,9 +122,9 @@ test("parseSimpleYaml: parses nested objects (m3e block)", () => {
   collapsed: true`;
 
   const result = parseSimpleYaml(yaml);
-  assert.equal(result.m3e.nodeId, "n_123");
-  assert.equal(result.m3e.nodeType, "folder");
-  assert.equal(result.m3e.collapsed, true);
+  expect(result.m3e.nodeId).toBe("n_123");
+  expect(result.m3e.nodeType).toBe("folder");
+  expect(result.m3e.collapsed).toBe(true);
 });
 
 test("parseSimpleYaml: parses arrays", () => {
@@ -135,7 +134,7 @@ test("parseSimpleYaml: parses arrays", () => {
   - gamma`;
 
   const result = parseSimpleYaml(yaml);
-  assert.deepEqual(result.tags, ["alpha", "beta", "gamma"]);
+  expect(result.tags).toEqual(["alpha", "beta", "gamma"]);
 });
 
 test("extractWikilinks: extracts simple wikilinks", () => {
@@ -143,29 +142,29 @@ test("extractWikilinks: extracts simple wikilinks", () => {
 And [[another|Custom Label]] here.`;
 
   const refs = extractWikilinks(body);
-  assert.equal(refs.length, 2);
+  expect(refs.length).toBe(2);
 
-  assert.equal(refs[0].target, "target-note");
-  assert.equal(refs[0].label, undefined);
-  assert.equal(refs[0].embedded, false);
+  expect(refs[0].target).toBe("target-note");
+  expect(refs[0].label).toBeUndefined();
+  expect(refs[0].embedded).toBe(false);
 
-  assert.equal(refs[1].target, "another");
-  assert.equal(refs[1].label, "Custom Label");
-  assert.equal(refs[1].embedded, false);
+  expect(refs[1].target).toBe("another");
+  expect(refs[1].label).toBe("Custom Label");
+  expect(refs[1].embedded).toBe(false);
 });
 
 test("extractWikilinks: detects embedded wikilinks", () => {
   const body = "Check ![[embedded-note]] for details.";
   const refs = extractWikilinks(body);
 
-  assert.equal(refs.length, 1);
-  assert.equal(refs[0].target, "embedded-note");
-  assert.equal(refs[0].embedded, true);
+  expect(refs.length).toBe(1);
+  expect(refs[0].target).toBe("embedded-note");
+  expect(refs[0].embedded).toBe(true);
 });
 
 test("extractWikilinks: returns empty for no links", () => {
   const refs = extractWikilinks("Just plain text, no links.");
-  assert.equal(refs.length, 0);
+  expect(refs.length).toBe(0);
 });
 
 test("parseMdContent: full .md parsing", () => {
@@ -193,36 +192,36 @@ Body paragraph two with [[some-ref]].
 
   const result = parseMdContent(md, { id: "fallback_id", text: "fallback" });
 
-  assert.equal(result.node.id, "n_test_1");
-  assert.equal(result.node.text, "My Node Title");
-  assert.equal(result.node.nodeType, "text");
-  assert.equal(result.node.collapsed, false);
-  assert.equal(result.node.note, "internal memo");
-  assert.equal(result.node.link, "https://example.com");
-  assert.equal(result.node.attributes.tags, "research");
-  assert.equal(result.node.attributes.aliases, "Alias Name");
+  expect(result.node.id).toBe("n_test_1");
+  expect(result.node.text).toBe("My Node Title");
+  expect(result.node.nodeType).toBe("text");
+  expect(result.node.collapsed).toBe(false);
+  expect(result.node.note).toBe("internal memo");
+  expect(result.node.link).toBe("https://example.com");
+  expect(result.node.attributes.tags).toBe("research");
+  expect(result.node.attributes.aliases).toBe("Alias Name");
 
   // Wikilinks
-  assert.equal(result.wikilinks.length, 2);
-  assert.equal(result.wikilinks[0].target, "some-ref");
-  assert.equal(result.wikilinks[1].target, "another-ref");
-  assert.equal(result.wikilinks[1].label, "Label");
+  expect(result.wikilinks.length).toBe(2);
+  expect(result.wikilinks[0].target).toBe("some-ref");
+  expect(result.wikilinks[1].target).toBe("another-ref");
+  expect(result.wikilinks[1].label).toBe("Label");
 });
 
 test("parseMdContent: uses defaults when no frontmatter", () => {
   const md = "Just plain text, no frontmatter or heading.";
   const result = parseMdContent(md, { id: "default_id", text: "default text" });
 
-  assert.equal(result.node.id, "default_id");
-  assert.equal(result.node.text, "default text");
-  assert.equal(result.node.nodeType, "text");
+  expect(result.node.id).toBe("default_id");
+  expect(result.node.text).toBe("default text");
+  expect(result.node.nodeType).toBe("text");
 });
 
 test("parseMdContent: uses heading as text over default", () => {
   const md = "# Heading Override\n\nSome body.";
   const result = parseMdContent(md, { id: "id1", text: "fallback" });
 
-  assert.equal(result.node.text, "Heading Override");
+  expect(result.node.text).toBe("Heading Override");
 });
 
 test("parseFolderMd: parses _folder.md with children-order", () => {
@@ -241,9 +240,9 @@ Folder A description text
 
   const result = parseFolderMd(md, { id: "fallback", text: "Folder A" });
 
-  assert.equal(result.node.id, "n_folder_a");
-  assert.equal(result.node.nodeType, "folder");
-  assert.deepEqual(result.childrenOrder, ["note-1", "note-2", "note-3"]);
+  expect(result.node.id).toBe("n_folder_a");
+  expect(result.node.nodeType).toBe("folder");
+  expect(result.childrenOrder).toEqual(["note-1", "note-2", "note-3"]);
 });
 
 test("parseFolderMd: returns empty children-order when not specified", () => {
@@ -256,8 +255,8 @@ Simple folder
 `;
 
   const result = parseFolderMd(md, { id: "fb", text: "Folder B" });
-  assert.deepEqual(result.childrenOrder, []);
-  assert.equal(result.node.nodeType, "folder");
+  expect(result.childrenOrder).toEqual([]);
+  expect(result.node.nodeType).toBe("folder");
 });
 
 // =========================================================================
@@ -278,17 +277,17 @@ test("serializeToMd: generates frontmatter with m3e metadata", () => {
 
   const md = serializeToMd(node, { childrenOrder: ["c1", "c2"] });
 
-  assert.ok(md.includes("---"));
-  assert.ok(md.includes("nodeId: n_write_1"));
-  assert.ok(md.includes("nodeType: folder"));
-  assert.ok(md.includes("collapsed: true"));
-  assert.ok(md.includes("note: a note"));
-  assert.ok(md.includes("link:"));
-  assert.ok(md.includes("# Test Node"));
-  assert.ok(md.includes("- c1"));
-  assert.ok(md.includes("- c2"));
-  assert.ok(md.includes("- alpha"));
-  assert.ok(md.includes("- beta"));
+  expect(md.includes("---")).toBe(true);
+  expect(md.includes("nodeId: n_write_1")).toBe(true);
+  expect(md.includes("nodeType: folder")).toBe(true);
+  expect(md.includes("collapsed: true")).toBe(true);
+  expect(md.includes("note: a note")).toBe(true);
+  expect(md.includes("link:")).toBe(true);
+  expect(md.includes("# Test Node")).toBe(true);
+  expect(md.includes("- c1")).toBe(true);
+  expect(md.includes("- c2")).toBe(true);
+  expect(md.includes("- alpha")).toBe(true);
+  expect(md.includes("- beta")).toBe(true);
 });
 
 test("serializeToMd: omits empty frontmatter", () => {
@@ -304,9 +303,7 @@ test("serializeToMd: omits empty frontmatter", () => {
 
   const md = serializeToMd(node);
 
-  // Should have no frontmatter since nodeType is default "text" (omitted),
-  // and all optional fields are empty. Only nodeId remains.
-  assert.ok(md.includes("# Simple"));
+  expect(md.includes("# Simple")).toBe(true);
 });
 
 test("serializeToMd: includes body details", () => {
@@ -322,9 +319,9 @@ test("serializeToMd: includes body details", () => {
 
   const md = serializeToMd(node);
 
-  assert.ok(md.includes("# With Body"));
-  assert.ok(md.includes("Paragraph one."));
-  assert.ok(md.includes("Paragraph two."));
+  expect(md.includes("# With Body")).toBe(true);
+  expect(md.includes("Paragraph one.")).toBe(true);
+  expect(md.includes("Paragraph two.")).toBe(true);
 });
 
 test("serializeToMd: includes wikilinks section", () => {
@@ -346,10 +343,10 @@ test("serializeToMd: includes wikilinks section", () => {
 
   const md = serializeToMd(node, { wikilinks });
 
-  assert.ok(md.includes("## Related"));
-  assert.ok(md.includes("- [[target-a]]"));
-  assert.ok(md.includes("- [[target-b|Label B]]"));
-  assert.ok(md.includes("- ![[embed-c]]"));
+  expect(md.includes("## Related")).toBe(true);
+  expect(md.includes("- [[target-a]]")).toBe(true);
+  expect(md.includes("- [[target-b|Label B]]")).toBe(true);
+  expect(md.includes("- ![[embed-c]]")).toBe(true);
 });
 
 test("serializeFolderMd: generates _folder.md content", () => {
@@ -365,11 +362,11 @@ test("serializeFolderMd: generates _folder.md content", () => {
 
   const md = serializeFolderMd(node, ["child-1", "child-2"]);
 
-  assert.ok(md.includes("nodeType: folder"));
-  assert.ok(md.includes("- child-1"));
-  assert.ok(md.includes("- child-2"));
-  assert.ok(md.includes("# My Folder"));
-  assert.ok(md.includes("Folder description"));
+  expect(md.includes("nodeType: folder")).toBe(true);
+  expect(md.includes("- child-1")).toBe(true);
+  expect(md.includes("- child-2")).toBe(true);
+  expect(md.includes("# My Folder")).toBe(true);
+  expect(md.includes("Folder description")).toBe(true);
 });
 
 // =========================================================================
@@ -391,13 +388,13 @@ test("round-trip: write then read produces same node data", () => {
   const md = serializeToMd(original);
   const parsed = parseMdContent(md, { id: "unused", text: "unused" });
 
-  assert.equal(parsed.node.id, original.id);
-  assert.equal(parsed.node.text, original.text);
-  assert.equal(parsed.node.collapsed, original.collapsed);
-  assert.equal(parsed.node.note, original.note);
-  assert.equal(parsed.node.link, original.link);
-  assert.equal(parsed.node.attributes.tags, original.attributes.tags);
-  assert.equal(parsed.node.attributes.aliases, original.attributes.aliases);
+  expect(parsed.node.id).toBe(original.id);
+  expect(parsed.node.text).toBe(original.text);
+  expect(parsed.node.collapsed).toBe(original.collapsed);
+  expect(parsed.node.note).toBe(original.note);
+  expect(parsed.node.link).toBe(original.link);
+  expect(parsed.node.attributes.tags).toBe(original.attributes.tags);
+  expect(parsed.node.attributes.aliases).toBe(original.attributes.aliases);
 });
 
 test("round-trip: folder write then read preserves children-order", () => {
@@ -415,9 +412,9 @@ test("round-trip: folder write then read preserves children-order", () => {
   const md = serializeFolderMd(node, order);
   const parsed = parseFolderMd(md, { id: "unused", text: "unused" });
 
-  assert.equal(parsed.node.id, "n_folder_rt");
-  assert.equal(parsed.node.nodeType, "folder");
-  assert.deepEqual(parsed.childrenOrder, order);
+  expect(parsed.node.id).toBe("n_folder_rt");
+  expect(parsed.node.nodeType).toBe("folder");
+  expect(parsed.childrenOrder).toEqual(order);
 });
 
 test("round-trip: wikilinks survive write then read", () => {
@@ -440,23 +437,19 @@ test("round-trip: wikilinks survive write then read", () => {
   const md = serializeToMd(node, { wikilinks });
   const parsed = parseMdContent(md, { id: "unused", text: "unused" });
 
-  assert.equal(parsed.wikilinks.length, 3);
-  assert.equal(parsed.wikilinks[0].target, "note-a");
-  assert.equal(parsed.wikilinks[0].embedded, false);
-  assert.equal(parsed.wikilinks[1].target, "note-b");
-  assert.equal(parsed.wikilinks[1].label, "Custom");
-  assert.equal(parsed.wikilinks[2].target, "note-c");
-  assert.equal(parsed.wikilinks[2].embedded, true);
+  expect(parsed.wikilinks.length).toBe(3);
+  expect(parsed.wikilinks[0].target).toBe("note-a");
+  expect(parsed.wikilinks[0].embedded).toBe(false);
+  expect(parsed.wikilinks[1].target).toBe("note-b");
+  expect(parsed.wikilinks[1].label).toBe("Custom");
+  expect(parsed.wikilinks[2].target).toBe("note-c");
+  expect(parsed.wikilinks[2].embedded).toBe(true);
 });
 
 // =========================================================================
 // Phase 1: Folder structure -> Tree structure
 // =========================================================================
 
-/**
- * Build a tree of TreeNodes from a folder of .md files.
- * Minimal implementation for testing — mirrors what BindingManager.mount() will do.
- */
 function buildTreeFromFolder(rootDir) {
   const nodes = {};
   const rootResult = readFolderNode(rootDir, null, nodes);
@@ -498,14 +491,12 @@ function readFolderNode(dirPath, parentId, nodes) {
 
   nodes[folderNode.id] = folderNode;
 
-  // Read children: files and subfolders
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
   const mdFiles = entries
     .filter((e) => e.isFile() && e.name.endsWith(".md") && e.name !== "_folder.md")
     .map((e) => e.name);
   const subDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
-  // Sort children: respect children-order from _folder.md, fallback to alphabetical
   const allChildNames = [
     ...mdFiles.map((f) => f.replace(/\.md$/, "")),
     ...subDirs,
@@ -513,7 +504,6 @@ function readFolderNode(dirPath, parentId, nodes) {
 
   let orderedNames;
   if (childrenOrder.length > 0) {
-    // Put ordered items first, then remaining alphabetically
     const remaining = allChildNames.filter((n) => !childrenOrder.includes(n));
     remaining.sort();
     orderedNames = [...childrenOrder.filter((n) => allChildNames.includes(n)), ...remaining];
@@ -526,7 +516,6 @@ function readFolderNode(dirPath, parentId, nodes) {
     const subDirPath = path.join(dirPath, name);
 
     if (fs.existsSync(mdPath) && fs.statSync(mdPath).isFile()) {
-      // .md file -> text node
       const content = fs.readFileSync(mdPath, "utf-8");
       const parsed = parseMdContent(content, { id: `file_${name}`, text: name });
       const childNode = {
@@ -537,7 +526,6 @@ function readFolderNode(dirPath, parentId, nodes) {
       nodes[childNode.id] = childNode;
       folderNode.children.push(childNode.id);
     } else if (fs.existsSync(subDirPath) && fs.statSync(subDirPath).isDirectory()) {
-      // Subdirectory -> recurse
       const subNode = readFolderNode(subDirPath, folderNode.id, nodes);
       folderNode.children.push(subNode.id);
     }
@@ -555,15 +543,14 @@ test("folder->tree: flat folder with .md files", () => {
     const tree = buildTreeFromFolder(dir);
 
     const root = tree.nodes[tree.rootId];
-    assert.equal(root.nodeType, "folder");
-    assert.equal(root.children.length, 2);
+    expect(root.nodeType).toBe("folder");
+    expect(root.children.length).toBe(2);
 
-    // Alphabetical order since no _folder.md
     const child0 = tree.nodes[root.children[0]];
     const child1 = tree.nodes[root.children[1]];
-    assert.equal(child0.id, "n_alpha");
-    assert.equal(child1.id, "n_beta");
-    assert.equal(child0.parentId, root.id);
+    expect(child0.id).toBe("n_alpha");
+    expect(child1.id).toBe("n_beta");
+    expect(child0.parentId).toBe(root.id);
   } finally {
     cleanup(dir);
   }
@@ -589,11 +576,10 @@ Root folder
     const tree = buildTreeFromFolder(dir);
     const root = tree.nodes[tree.rootId];
 
-    assert.equal(root.id, "n_root");
-    assert.equal(root.children.length, 2);
-    // Order should be beta, alpha (as specified in children-order)
-    assert.equal(tree.nodes[root.children[0]].id, "n_beta");
-    assert.equal(tree.nodes[root.children[1]].id, "n_alpha");
+    expect(root.id).toBe("n_root");
+    expect(root.children.length).toBe(2);
+    expect(tree.nodes[root.children[0]].id).toBe("n_beta");
+    expect(tree.nodes[root.children[1]].id).toBe("n_alpha");
   } finally {
     cleanup(dir);
   }
@@ -609,10 +595,10 @@ test("folder->tree: fallback to alphabetical when no _folder.md", () => {
     const tree = buildTreeFromFolder(dir);
     const root = tree.nodes[tree.rootId];
 
-    assert.equal(root.children.length, 3);
-    assert.equal(tree.nodes[root.children[0]].id, "n_a");
-    assert.equal(tree.nodes[root.children[1]].id, "n_m");
-    assert.equal(tree.nodes[root.children[2]].id, "n_z");
+    expect(root.children.length).toBe(3);
+    expect(tree.nodes[root.children[0]].id).toBe("n_a");
+    expect(tree.nodes[root.children[1]].id).toBe("n_m");
+    expect(tree.nodes[root.children[2]].id).toBe("n_z");
   } finally {
     cleanup(dir);
   }
@@ -623,7 +609,6 @@ test("folder->tree: nested folders become nested tree nodes", () => {
   try {
     writeMd(dir, "top.md", "---\nm3e:\n  nodeId: n_top\n---\n\n# Top");
 
-    // Create subfolder
     const subDir = path.join(dir, "subfolder");
     fs.mkdirSync(subDir);
     writeMd(subDir, "_folder.md", "---\nm3e:\n  nodeId: n_sub\n  nodeType: folder\n---\n\n# Sub");
@@ -632,20 +617,17 @@ test("folder->tree: nested folders become nested tree nodes", () => {
     const tree = buildTreeFromFolder(dir);
     const root = tree.nodes[tree.rootId];
 
-    // Root should have 2 children: subfolder and top.md (alphabetical: subfolder, top)
-    assert.equal(root.children.length, 2);
+    expect(root.children.length).toBe(2);
 
-    // Find the subfolder node
     const subNode = tree.nodes["n_sub"];
-    assert.ok(subNode, "subfolder node should exist");
-    assert.equal(subNode.nodeType, "folder");
-    assert.equal(subNode.parentId, root.id);
-    assert.equal(subNode.children.length, 1);
+    expect(subNode).toBeTruthy();
+    expect(subNode.nodeType).toBe("folder");
+    expect(subNode.parentId).toBe(root.id);
+    expect(subNode.children.length).toBe(1);
 
-    // Deep node
     const deepNode = tree.nodes["n_deep"];
-    assert.ok(deepNode, "deep node should exist");
-    assert.equal(deepNode.parentId, "n_sub");
+    expect(deepNode).toBeTruthy();
+    expect(deepNode.parentId).toBe("n_sub");
   } finally {
     cleanup(dir);
   }
@@ -660,22 +642,17 @@ test("cache: mtime comparison detects stale cache", () => {
   try {
     const fp = writeMd(dir, "test.md", "---\nm3e:\n  nodeId: n_cache\n---\n\n# Cache Test");
 
-    // Simulate cache entry with mtime
     const stat1 = fs.statSync(fp);
     const cachedMtime = stat1.mtimeMs;
 
-    // Modify file (force different mtime)
-    // Use a small delay workaround via changing content
     fs.writeFileSync(fp, "---\nm3e:\n  nodeId: n_cache\n---\n\n# Cache Test Updated", "utf-8");
     const stat2 = fs.statSync(fp);
 
-    // On some OS/FS the mtime granularity is coarse, so we also check content
     const currentMtime = stat2.mtimeMs;
 
-    // The mtime should be >= (could be same on fast FS, so also check size)
     const isStale =
       currentMtime > cachedMtime || stat2.size !== stat1.size;
-    assert.ok(isStale, "cache should detect file was modified");
+    expect(isStale).toBe(true);
   } finally {
     cleanup(dir);
   }
@@ -698,26 +675,22 @@ Body text for cache test.
 `;
     writeMd(dir, "cache_test.md", md);
 
-    // First read
     const read1 = parseMdContent(
       fs.readFileSync(path.join(dir, "cache_test.md"), "utf-8"),
       { id: "fallback", text: "fallback" }
     );
 
-    // Simulate cache: serialize the node
     const cached = JSON.parse(JSON.stringify(read1.node));
 
-    // Second read from file
     const read2 = parseMdContent(
       fs.readFileSync(path.join(dir, "cache_test.md"), "utf-8"),
       { id: "fallback", text: "fallback" }
     );
 
-    // Cached data should match re-read
-    assert.equal(cached.id, read2.node.id);
-    assert.equal(cached.text, read2.node.text);
-    assert.equal(cached.nodeType, read2.node.nodeType);
-    assert.deepEqual(cached.attributes, read2.node.attributes);
+    expect(cached.id).toBe(read2.node.id);
+    expect(cached.text).toBe(read2.node.text);
+    expect(cached.nodeType).toBe(read2.node.nodeType);
+    expect(cached.attributes).toEqual(read2.node.attributes);
   } finally {
     cleanup(dir);
   }
@@ -740,24 +713,21 @@ m3e:
 Original body.
 `);
 
-    // Read, modify, write back
     const content = fs.readFileSync(fp, "utf-8");
     const parsed = parseMdContent(content, { id: "n_edit", text: "Original Title" });
 
-    // Simulate edit
     parsed.node.text = "Updated Title";
     parsed.node.details = "Updated body content.";
 
     const newMd = serializeToMd(parsed.node);
     fs.writeFileSync(fp, newMd, "utf-8");
 
-    // Verify
     const reread = parseMdContent(
       fs.readFileSync(fp, "utf-8"),
       { id: "fallback", text: "fallback" }
     );
-    assert.equal(reread.node.text, "Updated Title");
-    assert.ok(reread.node.details.includes("Updated body content."));
+    expect(reread.node.text).toBe("Updated Title");
+    expect(reread.node.details.includes("Updated body content.")).toBe(true);
   } finally {
     cleanup(dir);
   }
@@ -781,15 +751,14 @@ test("write: add node -> new .md file created", () => {
     const fp = path.join(dir, "brand-new-node.md");
     fs.writeFileSync(fp, md, "utf-8");
 
-    // Verify file exists and content is correct
-    assert.ok(fs.existsSync(fp));
+    expect(fs.existsSync(fp)).toBe(true);
     const parsed = parseMdContent(
       fs.readFileSync(fp, "utf-8"),
       { id: "fallback", text: "fallback" }
     );
-    assert.equal(parsed.node.id, "n_new_node");
-    assert.equal(parsed.node.text, "Brand New Node");
-    assert.ok(parsed.node.details.includes("Fresh content."));
+    expect(parsed.node.id).toBe("n_new_node");
+    expect(parsed.node.text).toBe("Brand New Node");
+    expect(parsed.node.details.includes("Fresh content.")).toBe(true);
   } finally {
     cleanup(dir);
   }
@@ -800,12 +769,11 @@ test("write: delete node -> .md file removed", () => {
   try {
     const fp = writeMd(dir, "to-delete.md", "---\nm3e:\n  nodeId: n_del\n---\n\n# Delete Me");
 
-    assert.ok(fs.existsSync(fp));
+    expect(fs.existsSync(fp)).toBe(true);
 
-    // Simulate delete
     fs.unlinkSync(fp);
 
-    assert.ok(!fs.existsSync(fp));
+    expect(fs.existsSync(fp)).toBe(false);
   } finally {
     cleanup(dir);
   }
@@ -822,22 +790,20 @@ test("write: move node between folders -> file moves", () => {
     const srcPath = path.join(folderA, "moveme.md");
     fs.writeFileSync(srcPath, "---\nm3e:\n  nodeId: n_move\n---\n\n# Move Me", "utf-8");
 
-    assert.ok(fs.existsSync(srcPath));
+    expect(fs.existsSync(srcPath)).toBe(true);
 
-    // Simulate move
     const destPath = path.join(folderB, "moveme.md");
     fs.renameSync(srcPath, destPath);
 
-    assert.ok(!fs.existsSync(srcPath));
-    assert.ok(fs.existsSync(destPath));
+    expect(fs.existsSync(srcPath)).toBe(false);
+    expect(fs.existsSync(destPath)).toBe(true);
 
-    // Content preserved
     const parsed = parseMdContent(
       fs.readFileSync(destPath, "utf-8"),
       { id: "fallback", text: "fallback" }
     );
-    assert.equal(parsed.node.id, "n_move");
-    assert.equal(parsed.node.text, "Move Me");
+    expect(parsed.node.id).toBe("n_move");
+    expect(parsed.node.text).toBe("Move Me");
   } finally {
     cleanup(dir);
   }
@@ -851,12 +817,11 @@ test("write: node deletion to trash (rename to _trash folder)", () => {
 
     const fp = writeMd(dir, "soft-delete.md", "---\nm3e:\n  nodeId: n_soft\n---\n\n# Soft Delete");
 
-    // Simulate soft delete (move to trash)
     const trashPath = path.join(trashDir, "soft-delete.md");
     fs.renameSync(fp, trashPath);
 
-    assert.ok(!fs.existsSync(fp));
-    assert.ok(fs.existsSync(trashPath));
+    expect(fs.existsSync(fp)).toBe(false);
+    expect(fs.existsSync(trashPath)).toBe(true);
   } finally {
     cleanup(dir);
   }

--- a/beta/tests/unit/persistence_db_behavior.test.js
+++ b/beta/tests/unit/persistence_db_behavior.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -21,13 +20,13 @@ test("saveToFile creates missing directories and writes versioned document", () 
 
   model.saveToFile(filePath);
 
-  assert.equal(fs.existsSync(filePath), true);
+  expect(fs.existsSync(filePath)).toBe(true);
   const raw = fs.readFileSync(filePath, "utf8");
   const parsed = JSON.parse(raw);
 
-  assert.equal(parsed.version, 1);
-  assert.equal(typeof parsed.savedAt, "string");
-  assert.deepEqual(parsed.state, model.toJSON());
+  expect(parsed.version).toBe(1);
+  expect(typeof parsed.savedAt).toBe("string");
+  expect(parsed.state).toEqual(model.toJSON());
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -40,9 +39,9 @@ test("loadFromFile rejects unsupported version", () => {
     "utf8",
   );
 
-  assert.throws(() => RapidMvpModel.loadFromFile(filePath), {
-    message: "Unsupported or invalid save format.",
-  });
+  expect(() => RapidMvpModel.loadFromFile(filePath)).toThrow(
+    "Unsupported or invalid save format.",
+  );
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -51,9 +50,9 @@ test("loadFromFile rejects when state is missing", () => {
   const { base, filePath } = makeTempPath("missing-state.json");
   fs.writeFileSync(filePath, JSON.stringify({ version: 1 }), "utf8");
 
-  assert.throws(() => RapidMvpModel.loadFromFile(filePath), {
-    message: "Unsupported or invalid save format.",
-  });
+  expect(() => RapidMvpModel.loadFromFile(filePath)).toThrow(
+    "Unsupported or invalid save format.",
+  );
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -84,7 +83,7 @@ test("loadFromFile rejects structurally invalid graph", () => {
     "utf8",
   );
 
-  assert.throws(() => RapidMvpModel.loadFromFile(filePath), /Invalid model after load:/);
+  expect(() => RapidMvpModel.loadFromFile(filePath)).toThrow(/Invalid model after load:/);
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -93,7 +92,7 @@ test("loadFromFile rejects malformed JSON", () => {
   const { base, filePath } = makeTempPath("malformed.json");
   fs.writeFileSync(filePath, "{ this is not valid json", "utf8");
 
-  assert.throws(() => RapidMvpModel.loadFromFile(filePath), SyntaxError);
+  expect(() => RapidMvpModel.loadFromFile(filePath)).toThrow();
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -115,7 +114,7 @@ test("saveToSqlite and loadFromSqlite round-trip", () => {
   model.saveToSqlite(filePath, "doc-a");
 
   const loaded = RapidMvpModel.loadFromSqlite(filePath, "doc-a");
-  assert.deepEqual(loaded.toJSON(), model.toJSON());
+  expect(loaded.toJSON()).toEqual(model.toJSON());
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -152,7 +151,7 @@ test("loadFromFile rejects graph link with missing endpoint", () => {
     "utf8",
   );
 
-  assert.throws(() => RapidMvpModel.loadFromFile(filePath), /missing target node/);
+  expect(() => RapidMvpModel.loadFromFile(filePath)).toThrow(/missing target node/);
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -198,8 +197,8 @@ test("loadFromFile accepts broken alias with snapshot label", () => {
   );
 
   const loaded = RapidMvpModel.loadFromFile(filePath);
-  assert.equal(loaded.state.nodes["alias-1"].isBroken, true);
-  assert.equal(loaded.state.nodes["alias-1"].targetSnapshotLabel, "Lost Node");
+  expect(loaded.state.nodes["alias-1"].isBroken).toBe(true);
+  expect(loaded.state.nodes["alias-1"].targetSnapshotLabel).toBe("Lost Node");
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -220,9 +219,9 @@ test("loadFromSqlite rejects unsupported version", () => {
   ).run("doc-bad", 2, new Date().toISOString(), JSON.stringify({}));
   db.close();
 
-  assert.throws(() => RapidMvpModel.loadFromSqlite(filePath, "doc-bad"), {
-    message: "Unsupported or invalid save format.",
-  });
+  expect(() => RapidMvpModel.loadFromSqlite(filePath, "doc-bad")).toThrow(
+    "Unsupported or invalid save format.",
+  );
 
   fs.rmSync(base, { recursive: true, force: true });
 });
@@ -261,7 +260,7 @@ test("loadFromSqlite rejects invalid graph state", () => {
   ).run("doc-invalid", 1, new Date().toISOString(), JSON.stringify(invalidState));
   db.close();
 
-  assert.throws(() => RapidMvpModel.loadFromSqlite(filePath, "doc-invalid"), /Invalid model after load:/);
+  expect(() => RapidMvpModel.loadFromSqlite(filePath, "doc-invalid")).toThrow(/Invalid model after load:/);
 
   fs.rmSync(base, { recursive: true, force: true });
 });

--- a/beta/tests/unit/presence.test.js
+++ b/beta/tests/unit/presence.test.js
@@ -1,7 +1,6 @@
 // @ts-check
 "use strict";
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 
 const { touchPresence, removePresence, getPresenceList, resetPresence } = require("../../dist/node/presence.js");
 
@@ -9,11 +8,11 @@ test("touchPresence creates entry and getPresenceList returns it", () => {
   resetPresence();
   touchPresence("doc1", "e_1", "Alice", "human");
   const list = getPresenceList("doc1");
-  assert.equal(list.length, 1);
-  assert.equal(list[0].entityId, "e_1");
-  assert.equal(list[0].displayName, "Alice");
-  assert.equal(list[0].role, "human");
-  assert.equal(list[0].status, "active");
+  expect(list.length).toBe(1);
+  expect(list[0].entityId).toBe("e_1");
+  expect(list[0].displayName).toBe("Alice");
+  expect(list[0].role).toBe("human");
+  expect(list[0].status).toBe("active");
 });
 
 test("touchPresence updates existing entry", () => {
@@ -21,30 +20,30 @@ test("touchPresence updates existing entry", () => {
   touchPresence("doc1", "e_1", "Alice", "human");
   touchPresence("doc1", "e_1", "Alice Updated", "owner");
   const list = getPresenceList("doc1");
-  assert.equal(list.length, 1);
-  assert.equal(list[0].displayName, "Alice Updated");
-  assert.equal(list[0].role, "owner");
+  expect(list.length).toBe(1);
+  expect(list[0].displayName).toBe("Alice Updated");
+  expect(list[0].role).toBe("owner");
 });
 
 test("removePresence removes entry", () => {
   resetPresence();
   touchPresence("doc1", "e_1", "Alice", "human");
   touchPresence("doc1", "e_2", "Bob", "ai");
-  assert.ok(removePresence("doc1", "e_1"));
+  expect(removePresence("doc1", "e_1")).toBe(true);
   const list = getPresenceList("doc1");
-  assert.equal(list.length, 1);
-  assert.equal(list[0].entityId, "e_2");
+  expect(list.length).toBe(1);
+  expect(list[0].entityId).toBe("e_2");
 });
 
 test("removePresence returns false for unknown entity", () => {
   resetPresence();
-  assert.equal(removePresence("doc1", "e_unknown"), false);
+  expect(removePresence("doc1", "e_unknown")).toBe(false);
 });
 
 test("getPresenceList returns empty for unknown doc", () => {
   resetPresence();
   const list = getPresenceList("nonexistent");
-  assert.equal(list.length, 0);
+  expect(list.length).toBe(0);
 });
 
 test("multiple docs are tracked independently", () => {
@@ -52,8 +51,8 @@ test("multiple docs are tracked independently", () => {
   touchPresence("doc1", "e_1", "Alice", "human");
   touchPresence("doc2", "e_2", "Bob", "ai");
 
-  assert.equal(getPresenceList("doc1").length, 1);
-  assert.equal(getPresenceList("doc2").length, 1);
-  assert.equal(getPresenceList("doc1")[0].entityId, "e_1");
-  assert.equal(getPresenceList("doc2")[0].entityId, "e_2");
+  expect(getPresenceList("doc1").length).toBe(1);
+  expect(getPresenceList("doc2").length).toBe(1);
+  expect(getPresenceList("doc1")[0].entityId).toBe("e_1");
+  expect(getPresenceList("doc2")[0].entityId).toBe("e_2");
 });

--- a/beta/tests/unit/rapid_mvp.test.js
+++ b/beta/tests/unit/rapid_mvp.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -12,17 +11,17 @@ test("addNode updates parent children", () => {
 
   const childId = model.addNode(rootId, "Child A");
 
-  assert.deepEqual(model.state.nodes[rootId].children, [childId]);
-  assert.equal(model.state.nodes[childId].parentId, rootId);
-  assert.equal(model.state.nodes[childId].text, "Child A");
+  expect(model.state.nodes[rootId].children).toEqual([childId]);
+  expect(model.state.nodes[childId].parentId).toBe(rootId);
+  expect(model.state.nodes[childId].text).toBe("Child A");
 });
 
 test("addSibling on root throws", () => {
   const model = new RapidMvpModel("Root");
 
-  assert.throws(() => model.addSibling(model.state.rootId, "S"), {
-    message: "Root node cannot have siblings.",
-  });
+  expect(() => model.addSibling(model.state.rootId, "S")).toThrow(
+    "Root node cannot have siblings.",
+  );
 });
 
 test("deleteNode removes subtree", () => {
@@ -33,9 +32,9 @@ test("deleteNode removes subtree", () => {
 
   model.deleteNode(a);
 
-  assert.equal(model.state.nodes[a], undefined);
-  assert.equal(model.state.nodes[b], undefined);
-  assert.deepEqual(model.state.nodes[rootId].children, []);
+  expect(model.state.nodes[a]).toBeUndefined();
+  expect(model.state.nodes[b]).toBeUndefined();
+  expect(model.state.nodes[rootId].children).toEqual([]);
 });
 
 test("deleteNode keeps alias as broken reference", () => {
@@ -46,11 +45,11 @@ test("deleteNode keeps alias as broken reference", () => {
 
   model.deleteNode(targetId);
 
-  assert.equal(model.state.nodes[targetId], undefined);
-  assert.equal(model.state.nodes[aliasId].nodeType, "alias");
-  assert.equal(model.state.nodes[aliasId].isBroken, true);
-  assert.equal(model.state.nodes[aliasId].targetSnapshotLabel, "Target");
-  assert.equal(model.state.nodes[aliasId].text, "Target (deleted)");
+  expect(model.state.nodes[targetId]).toBeUndefined();
+  expect(model.state.nodes[aliasId].nodeType).toBe("alias");
+  expect(model.state.nodes[aliasId].isBroken).toBe(true);
+  expect(model.state.nodes[aliasId].targetSnapshotLabel).toBe("Target");
+  expect(model.state.nodes[aliasId].text).toBe("Target (deleted)");
 });
 
 test("addAlias stores access and label", () => {
@@ -62,10 +61,10 @@ test("addAlias stores access and label", () => {
     access: "write",
   });
 
-  assert.equal(model.state.nodes[aliasId].targetNodeId, targetId);
-  assert.equal(model.state.nodes[aliasId].aliasLabel, "Shortcut");
-  assert.equal(model.state.nodes[aliasId].access, "write");
-  assert.equal(model.state.nodes[aliasId].text, "Shortcut");
+  expect(model.state.nodes[aliasId].targetNodeId).toBe(targetId);
+  expect(model.state.nodes[aliasId].aliasLabel).toBe("Shortcut");
+  expect(model.state.nodes[aliasId].access).toBe("write");
+  expect(model.state.nodes[aliasId].text).toBe("Shortcut");
 });
 
 test("addLink stores graph link in state", () => {
@@ -81,10 +80,10 @@ test("addLink stores graph link in state", () => {
     style: "dashed",
   });
 
-  assert.equal(model.state.links[linkId].sourceNodeId, a);
-  assert.equal(model.state.links[linkId].targetNodeId, b);
-  assert.equal(model.state.links[linkId].direction, "forward");
-  assert.equal(model.state.links[linkId].style, "dashed");
+  expect(model.state.links[linkId].sourceNodeId).toBe(a);
+  expect(model.state.links[linkId].targetNodeId).toBe(b);
+  expect(model.state.links[linkId].direction).toBe("forward");
+  expect(model.state.links[linkId].style).toBe("dashed");
 });
 
 test("deleteNode removes graph links touching deleted nodes", () => {
@@ -96,7 +95,7 @@ test("deleteNode removes graph links touching deleted nodes", () => {
 
   model.deleteNode(a);
 
-  assert.equal(model.state.links[linkId], undefined);
+  expect(model.state.links[linkId]).toBeUndefined();
 });
 
 test("validate rejects alias targeting alias", () => {
@@ -111,7 +110,7 @@ test("validate rejects alias targeting alias", () => {
   model.state.nodes[badAliasId].access = "read";
   model.state.nodes[badAliasId].children = [];
 
-  assert.match(model.validate().join(" | "), /cannot target alias node/);
+  expect(model.validate().join(" | ")).toMatch(/cannot target alias node/);
 });
 
 test("validate rejects graph link with alias endpoint", () => {
@@ -130,7 +129,7 @@ test("validate rejects graph link with alias endpoint", () => {
     },
   };
 
-  assert.match(model.validate().join(" | "), /cannot use alias source node/);
+  expect(model.validate().join(" | ")).toMatch(/cannot use alias source node/);
 });
 
 test("reparentNode rejects cycle", () => {
@@ -139,9 +138,9 @@ test("reparentNode rejects cycle", () => {
   const a = model.addNode(rootId, "A");
   const b = model.addNode(a, "B");
 
-  assert.throws(() => model.reparentNode(a, b), {
-    message: "Cycle detected: cannot move node under its descendant.",
-  });
+  expect(() => model.reparentNode(a, b)).toThrow(
+    "Cycle detected: cannot move node under its descendant.",
+  );
 });
 
 test("undo and redo restore previous state", () => {
@@ -150,13 +149,13 @@ test("undo and redo restore previous state", () => {
   const a = model.addNode(rootId, "A");
 
   model.editNode(a, "A2");
-  assert.equal(model.state.nodes[a].text, "A2");
+  expect(model.state.nodes[a].text).toBe("A2");
 
-  assert.equal(model.undo(), true);
-  assert.equal(model.state.nodes[a].text, "A");
+  expect(model.undo()).toBe(true);
+  expect(model.state.nodes[a].text).toBe("A");
 
-  assert.equal(model.redo(), true);
-  assert.equal(model.state.nodes[a].text, "A2");
+  expect(model.redo()).toBe(true);
+  expect(model.state.nodes[a].text).toBe("A2");
 });
 
 test("saveToFile and loadFromFile round-trip", () => {
@@ -171,7 +170,7 @@ test("saveToFile and loadFromFile round-trip", () => {
   model.saveToFile(savePath);
   const loaded = RapidMvpModel.loadFromFile(savePath);
 
-  assert.deepEqual(loaded.toJSON(), model.toJSON());
+  expect(loaded.toJSON()).toEqual(model.toJSON());
 });
 
 test("queryNodes returns only subtree under scope", () => {
@@ -183,21 +182,21 @@ test("queryNodes returns only subtree under scope", () => {
 
   const scoped = model.queryNodes(a).map((node) => node.id);
 
-  assert.deepEqual(scoped, [a, a1]);
-  assert.equal(scoped.includes(b), false);
+  expect(scoped).toEqual([a, a1]);
+  expect(scoped.includes(b)).toBe(false);
 });
 
 test("queryNodes with unknown scope throws", () => {
   const model = new RapidMvpModel("Root");
 
-  assert.throws(() => model.queryNodes("missing"), {
-    message: "Node not found: missing",
-  });
+  expect(() => model.queryNodes("missing")).toThrow(
+    "Node not found: missing",
+  );
 });
 
 test("fromJSON handles missing nodes gracefully", () => {
   const model = RapidMvpModel.fromJSON({ rootId: "r", nodes: undefined, links: {} });
-  assert.deepEqual(model.state.nodes, {});
+  expect(model.state.nodes).toEqual({});
 });
 
 test("fromJSON handles missing links gracefully", () => {
@@ -205,7 +204,7 @@ test("fromJSON handles missing links gracefully", () => {
   const json = base.toJSON();
   delete json.links;
   const restored = RapidMvpModel.fromJSON(json);
-  assert.deepEqual(restored.state.links, {});
+  expect(restored.state.links).toEqual({});
 });
 
 test("reparent updates scope-root query results without any node-level scope cascade", () => {
@@ -215,11 +214,11 @@ test("reparent updates scope-root query results without any node-level scope cas
   const b = model.addNode(rootId, "B");
   const a1 = model.addNode(a, "A1");
 
-  assert.deepEqual(model.queryNodeIds(a), [a, a1]);
-  assert.deepEqual(model.queryNodeIds(b), [b]);
+  expect(model.queryNodeIds(a)).toEqual([a, a1]);
+  expect(model.queryNodeIds(b)).toEqual([b]);
 
   model.reparentNode(a1, b);
 
-  assert.deepEqual(model.queryNodeIds(a), [a]);
-  assert.deepEqual(model.queryNodeIds(b), [b, a1]);
+  expect(model.queryNodeIds(a)).toEqual([a]);
+  expect(model.queryNodeIds(b)).toEqual([b, a1]);
 });

--- a/beta/tests/unit/scope_structure.test.js
+++ b/beta/tests/unit/scope_structure.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect, beforeEach } from "vitest";
 
 const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
 const {
@@ -18,18 +17,6 @@ function createModel(rootText) {
   return new RapidMvpModel(rootText || "Root");
 }
 
-/**
- * Build a tree with folder-based scopes:
- *
- *   Root
- *   +-- ScopeA (folder)
- *   |   +-- A1
- *   |   +-- A2
- *   |       +-- A2a
- *   +-- ScopeB (folder)
- *   |   +-- B1
- *   +-- Orphan (text, not in any sub-scope)
- */
 function buildScopedTree() {
   const m = createModel("Root");
   const root = m.state.rootId;
@@ -53,44 +40,40 @@ function buildScopedTree() {
 // Phase 1: Existing scope functionality tests
 // ===========================================================================
 
-// --- Scope entry / exit (queryNodes as scope filter) ---
-
 test("enterScope: queryNodes(scopeRoot) returns only children of that scope", () => {
   const { m, scopeA, a1, a2, a2a, scopeB, b1 } = buildScopedTree();
 
   const scopeANodes = m.queryNodeIds(scopeA);
-  assert.ok(scopeANodes.includes(scopeA));
-  assert.ok(scopeANodes.includes(a1));
-  assert.ok(scopeANodes.includes(a2));
-  assert.ok(scopeANodes.includes(a2a));
-  assert.ok(!scopeANodes.includes(scopeB));
-  assert.ok(!scopeANodes.includes(b1));
+  expect(scopeANodes.includes(scopeA)).toBe(true);
+  expect(scopeANodes.includes(a1)).toBe(true);
+  expect(scopeANodes.includes(a2)).toBe(true);
+  expect(scopeANodes.includes(a2a)).toBe(true);
+  expect(scopeANodes.includes(scopeB)).toBe(false);
+  expect(scopeANodes.includes(b1)).toBe(false);
 });
 
 test("exitScope: queryNodes(root) returns all nodes", () => {
   const { m, root, scopeA, a1, scopeB, b1, orphan } = buildScopedTree();
 
   const allNodes = m.queryNodeIds(root);
-  assert.ok(allNodes.includes(root));
-  assert.ok(allNodes.includes(scopeA));
-  assert.ok(allNodes.includes(a1));
-  assert.ok(allNodes.includes(scopeB));
-  assert.ok(allNodes.includes(b1));
-  assert.ok(allNodes.includes(orphan));
+  expect(allNodes.includes(root)).toBe(true);
+  expect(allNodes.includes(scopeA)).toBe(true);
+  expect(allNodes.includes(a1)).toBe(true);
+  expect(allNodes.includes(scopeB)).toBe(true);
+  expect(allNodes.includes(b1)).toBe(true);
+  expect(allNodes.includes(orphan)).toBe(true);
 });
 
 test("scope enter then exit returns to full tree", () => {
   const { m, root, scopeA, a1, b1 } = buildScopedTree();
 
-  // Simulate enter scope A
   const inScope = m.queryNodeIds(scopeA);
-  assert.ok(inScope.includes(a1));
-  assert.ok(!inScope.includes(b1));
+  expect(inScope.includes(a1)).toBe(true);
+  expect(inScope.includes(b1)).toBe(false);
 
-  // Simulate exit scope (back to root)
   const full = m.queryNodeIds(root);
-  assert.ok(full.includes(a1));
-  assert.ok(full.includes(b1));
+  expect(full.includes(a1)).toBe(true);
+  expect(full.includes(b1)).toBe(true);
 });
 
 // --- Alias creation and broken detection ---
@@ -102,9 +85,9 @@ test("alias creation stores correct targetNodeId", () => {
   const aliasId = m.addAlias(root, target);
 
   const alias = m.state.nodes[aliasId];
-  assert.equal(alias.nodeType, "alias");
-  assert.equal(alias.targetNodeId, target);
-  assert.equal(alias.isBroken, false);
+  expect(alias.nodeType).toBe("alias");
+  expect(alias.targetNodeId).toBe(target);
+  expect(alias.isBroken).toBe(false);
 });
 
 test("alias broken detection triggers on target deletion", () => {
@@ -116,9 +99,9 @@ test("alias broken detection triggers on target deletion", () => {
   m.deleteNode(target);
 
   const alias = m.state.nodes[aliasId];
-  assert.equal(alias.isBroken, true);
-  assert.equal(alias.targetSnapshotLabel, "Important Node");
-  assert.match(alias.text, /deleted/);
+  expect(alias.isBroken).toBe(true);
+  expect(alias.targetSnapshotLabel).toBe("Important Node");
+  expect(alias.text).toMatch(/deleted/);
 });
 
 test("alias cannot target another alias", () => {
@@ -127,9 +110,9 @@ test("alias cannot target another alias", () => {
   const target = m.addNode(root, "Target");
   const aliasId = m.addAlias(root, target);
 
-  assert.throws(() => m.addAlias(root, aliasId), {
-    message: /cannot target another alias/i,
-  });
+  expect(() => m.addAlias(root, aliasId)).toThrow(
+    /cannot target another alias/i,
+  );
 });
 
 test("alias default access is read", () => {
@@ -138,7 +121,7 @@ test("alias default access is read", () => {
   const target = m.addNode(root, "Target");
   const aliasId = m.addAlias(root, target);
 
-  assert.equal(m.state.nodes[aliasId].access, "read");
+  expect(m.state.nodes[aliasId].access).toBe("read");
 });
 
 test("alias with write access is stored correctly", () => {
@@ -147,7 +130,7 @@ test("alias with write access is stored correctly", () => {
   const target = m.addNode(root, "Target");
   const aliasId = m.addAlias(root, target, { access: "write" });
 
-  assert.equal(m.state.nodes[aliasId].access, "write");
+  expect(m.state.nodes[aliasId].access).toBe("write");
 });
 
 // --- Nested scopes ---
@@ -162,15 +145,13 @@ test("nested scopes: folder inside folder creates nested scope", () => {
   m.state.nodes[inner].nodeType = "folder";
   const leaf = m.addNode(inner, "Leaf");
 
-  // Query inner scope
   const innerNodes = m.queryNodeIds(inner);
-  assert.deepEqual(innerNodes, [inner, leaf]);
+  expect(innerNodes).toEqual([inner, leaf]);
 
-  // Query outer scope includes inner
   const outerNodes = m.queryNodeIds(outer);
-  assert.ok(outerNodes.includes(outer));
-  assert.ok(outerNodes.includes(inner));
-  assert.ok(outerNodes.includes(leaf));
+  expect(outerNodes.includes(outer)).toBe(true);
+  expect(outerNodes.includes(inner)).toBe(true);
+  expect(outerNodes.includes(leaf)).toBe(true);
 });
 
 test("nested scopes: deeply nested (3 levels)", () => {
@@ -186,11 +167,11 @@ test("nested scopes: deeply nested (3 levels)", () => {
   const deep = m.addNode(l3, "DeepNode");
 
   const l3Nodes = m.queryNodeIds(l3);
-  assert.deepEqual(l3Nodes, [l3, deep]);
+  expect(l3Nodes).toEqual([l3, deep]);
 
   const l1Nodes = m.queryNodeIds(l1);
-  assert.ok(l1Nodes.includes(deep));
-  assert.equal(l1Nodes.length, 4); // l1, l2, l3, deep
+  expect(l1Nodes.includes(deep)).toBe(true);
+  expect(l1Nodes.length).toBe(4);
 });
 
 // --- Breadcrumb path calculation ---
@@ -199,30 +180,29 @@ test("breadcrumb: path from node to root", () => {
   const { m, root, scopeA, a2, a2a } = buildScopedTree();
   const nodes = m.state.nodes;
 
-  // Compute breadcrumb path by walking parentId
-  const path = [];
+  const breadcrumbPath = [];
   let current = nodes[a2a];
   while (current) {
-    path.unshift(current.id);
+    breadcrumbPath.unshift(current.id);
     if (current.parentId === null) break;
     current = nodes[current.parentId];
   }
 
-  assert.deepEqual(path, [root, scopeA, a2, a2a]);
+  expect(breadcrumbPath).toEqual([root, scopeA, a2, a2a]);
 });
 
 test("breadcrumb: root node has single-element path", () => {
   const m = createModel("Root");
   const root = m.state.rootId;
 
-  const path = [root];
-  assert.equal(path.length, 1);
-  assert.equal(path[0], root);
+  const breadcrumbPath = [root];
+  expect(breadcrumbPath.length).toBe(1);
+  expect(breadcrumbPath[0]).toBe(root);
 });
 
 // --- findScopeRoot ---
 
-test.beforeEach(() => {
+beforeEach(() => {
   resetCollab();
 });
 
@@ -230,21 +210,21 @@ test("findScopeRoot returns folder ancestor", () => {
   const { m, root, scopeA, a1 } = buildScopedTree();
 
   const result = findScopeRoot(m.state.nodes, a1, root);
-  assert.equal(result, scopeA);
+  expect(result).toBe(scopeA);
 });
 
 test("findScopeRoot returns rootId for top-level text node", () => {
   const { m, root, orphan } = buildScopedTree();
 
   const result = findScopeRoot(m.state.nodes, orphan, root);
-  assert.equal(result, root);
+  expect(result).toBe(root);
 });
 
 test("findScopeRoot on folder itself returns that folder", () => {
   const { m, root, scopeA } = buildScopedTree();
 
   const result = findScopeRoot(m.state.nodes, scopeA, root);
-  assert.equal(result, scopeA);
+  expect(result).toBe(scopeA);
 });
 
 test("findScopeRoot with nested folders returns nearest folder", () => {
@@ -258,7 +238,7 @@ test("findScopeRoot with nested folders returns nearest folder", () => {
   const leaf = m.addNode(inner, "Leaf");
 
   const result = findScopeRoot(m.state.nodes, leaf, root);
-  assert.equal(result, inner);
+  expect(result).toBe(inner);
 });
 
 test("findScopeRoot on root returns rootId", () => {
@@ -266,7 +246,7 @@ test("findScopeRoot on root returns rootId", () => {
   const root = m.state.rootId;
 
   const result = findScopeRoot(m.state.nodes, root, root);
-  assert.equal(result, root);
+  expect(result).toBe(root);
 });
 
 // --- isInScope ---
@@ -274,57 +254,53 @@ test("findScopeRoot on root returns rootId", () => {
 test("isInScope returns true for node inside scope", () => {
   const { m, root, scopeA, a1 } = buildScopedTree();
 
-  assert.equal(isInScope(m.state.nodes, a1, scopeA, root), true);
+  expect(isInScope(m.state.nodes, a1, scopeA, root)).toBe(true);
 });
 
 test("isInScope returns false for node outside scope", () => {
   const { m, root, scopeA, b1 } = buildScopedTree();
 
-  assert.equal(isInScope(m.state.nodes, b1, scopeA, root), false);
+  expect(isInScope(m.state.nodes, b1, scopeA, root)).toBe(false);
 });
 
 test("isInScope with rootId always returns true", () => {
   const { m, root, a1, b1, orphan } = buildScopedTree();
 
-  assert.equal(isInScope(m.state.nodes, a1, root, root), true);
-  assert.equal(isInScope(m.state.nodes, b1, root, root), true);
-  assert.equal(isInScope(m.state.nodes, orphan, root, root), true);
+  expect(isInScope(m.state.nodes, a1, root, root)).toBe(true);
+  expect(isInScope(m.state.nodes, b1, root, root)).toBe(true);
+  expect(isInScope(m.state.nodes, orphan, root, root)).toBe(true);
 });
 
 test("isInScope for deeply nested node in outer scope", () => {
   const { m, root, scopeA, a2a } = buildScopedTree();
 
-  assert.equal(isInScope(m.state.nodes, a2a, scopeA, root), true);
+  expect(isInScope(m.state.nodes, a2a, scopeA, root)).toBe(true);
 });
 
 test("isInScope for node at scope boundary (node is the scope itself)", () => {
   const { m, root, scopeA } = buildScopedTree();
 
-  assert.equal(isInScope(m.state.nodes, scopeA, scopeA, root), true);
+  expect(isInScope(m.state.nodes, scopeA, scopeA, root)).toBe(true);
 });
 
 // ===========================================================================
 // Phase 2: scope/alias spec implementation tests
 // ===========================================================================
 
-// --- Cross-scope reparent ---
-
 test("reparent node from one scope to another", () => {
   const { m, root, scopeA, a1, scopeB } = buildScopedTree();
 
   m.reparentNode(a1, scopeB);
 
-  // a1 is now under scopeB
-  assert.equal(m.state.nodes[a1].parentId, scopeB);
-  assert.ok(m.state.nodes[scopeB].children.includes(a1));
-  assert.ok(!m.state.nodes[scopeA].children.includes(a1));
+  expect(m.state.nodes[a1].parentId).toBe(scopeB);
+  expect(m.state.nodes[scopeB].children.includes(a1)).toBe(true);
+  expect(m.state.nodes[scopeA].children.includes(a1)).toBe(false);
 
-  // queryNodes reflects the change
   const scopeANodes = m.queryNodeIds(scopeA);
-  assert.ok(!scopeANodes.includes(a1));
+  expect(scopeANodes.includes(a1)).toBe(false);
 
   const scopeBNodes = m.queryNodeIds(scopeB);
-  assert.ok(scopeBNodes.includes(a1));
+  expect(scopeBNodes.includes(a1)).toBe(true);
 });
 
 test("reparent subtree from one scope to another moves entire subtree", () => {
@@ -332,14 +308,13 @@ test("reparent subtree from one scope to another moves entire subtree", () => {
 
   m.reparentNode(a2, scopeB);
 
-  // a2 and its child a2a both under scopeB now
   const scopeBNodes = m.queryNodeIds(scopeB);
-  assert.ok(scopeBNodes.includes(a2));
-  assert.ok(scopeBNodes.includes(a2a));
+  expect(scopeBNodes.includes(a2)).toBe(true);
+  expect(scopeBNodes.includes(a2a)).toBe(true);
 
   const scopeANodes = m.queryNodeIds(scopeA);
-  assert.ok(!scopeANodes.includes(a2));
-  assert.ok(!scopeANodes.includes(a2a));
+  expect(scopeANodes.includes(a2)).toBe(false);
+  expect(scopeANodes.includes(a2a)).toBe(false);
 });
 
 test("reparent to root level (out of scope)", () => {
@@ -347,9 +322,9 @@ test("reparent to root level (out of scope)", () => {
 
   m.reparentNode(a1, root);
 
-  assert.equal(m.state.nodes[a1].parentId, root);
-  assert.ok(m.state.nodes[root].children.includes(a1));
-  assert.ok(!m.state.nodes[scopeA].children.includes(a1));
+  expect(m.state.nodes[a1].parentId).toBe(root);
+  expect(m.state.nodes[root].children.includes(a1)).toBe(true);
+  expect(m.state.nodes[scopeA].children.includes(a1)).toBe(false);
 });
 
 test("reparent preserves model validity", () => {
@@ -358,7 +333,7 @@ test("reparent preserves model validity", () => {
   m.reparentNode(a1, scopeB);
 
   const errors = m.validate();
-  assert.equal(errors.length, 0, `Validation errors: ${errors.join(", ")}`);
+  expect(errors.length).toBe(0);
 });
 
 // --- Cross-scope alias references ---
@@ -366,17 +341,15 @@ test("reparent preserves model validity", () => {
 test("alias can reference node in different scope", () => {
   const { m, scopeA, a1, scopeB } = buildScopedTree();
 
-  // Create alias in scopeB pointing to a1 (in scopeA)
   const aliasId = m.addAlias(scopeB, a1, { aliasLabel: "Ref to A1" });
 
   const alias = m.state.nodes[aliasId];
-  assert.equal(alias.targetNodeId, a1);
-  assert.equal(alias.nodeType, "alias");
-  assert.equal(alias.parentId, scopeB);
+  expect(alias.targetNodeId).toBe(a1);
+  expect(alias.nodeType).toBe("alias");
+  expect(alias.parentId).toBe(scopeB);
 
-  // Model should still be valid
   const errors = m.validate();
-  assert.equal(errors.length, 0, `Validation errors: ${errors.join(", ")}`);
+  expect(errors.length).toBe(0);
 });
 
 test("cross-scope alias becomes broken when target is deleted", () => {
@@ -386,8 +359,8 @@ test("cross-scope alias becomes broken when target is deleted", () => {
   m.deleteNode(a1);
 
   const alias = m.state.nodes[aliasId];
-  assert.equal(alias.isBroken, true);
-  assert.equal(alias.targetSnapshotLabel, "A1");
+  expect(alias.isBroken).toBe(true);
+  expect(alias.targetSnapshotLabel).toBe("A1");
 });
 
 test("cross-scope alias with scope deletion breaks alias", () => {
@@ -395,11 +368,10 @@ test("cross-scope alias with scope deletion breaks alias", () => {
 
   const aliasId = m.addAlias(scopeB, a1);
 
-  // Delete entire scopeA (which contains a1)
   m.deleteNode(scopeA);
 
   const alias = m.state.nodes[aliasId];
-  assert.equal(alias.isBroken, true);
+  expect(alias.isBroken).toBe(true);
 });
 
 test("multiple aliases from different scopes to same target", () => {
@@ -408,13 +380,12 @@ test("multiple aliases from different scopes to same target", () => {
   const alias1 = m.addAlias(scopeB, a1, { aliasLabel: "Alias1" });
   const alias2 = m.addAlias(root, a1, { aliasLabel: "Alias2" });
 
-  assert.equal(m.state.nodes[alias1].targetNodeId, a1);
-  assert.equal(m.state.nodes[alias2].targetNodeId, a1);
+  expect(m.state.nodes[alias1].targetNodeId).toBe(a1);
+  expect(m.state.nodes[alias2].targetNodeId).toBe(a1);
 
-  // Delete target, both aliases break
   m.deleteNode(a1);
-  assert.equal(m.state.nodes[alias1].isBroken, true);
-  assert.equal(m.state.nodes[alias2].isBroken, true);
+  expect(m.state.nodes[alias1].isBroken).toBe(true);
+  expect(m.state.nodes[alias2].isBroken).toBe(true);
 });
 
 // --- findScopeRoot edge cases ---
@@ -424,7 +395,7 @@ test("findScopeRoot with non-existent nodeId returns rootId", () => {
   const root = m.state.rootId;
 
   const result = findScopeRoot(m.state.nodes, "nonexistent", root);
-  assert.equal(result, root);
+  expect(result).toBe(root);
 });
 
 test("findScopeRoot with text node chain (no folders) returns root", () => {
@@ -435,7 +406,7 @@ test("findScopeRoot with text node chain (no folders) returns root", () => {
   const c = m.addNode(b, "C");
 
   const result = findScopeRoot(m.state.nodes, c, root);
-  assert.equal(result, root);
+  expect(result).toBe(root);
 });
 
 test("findScopeRoot with text between folders returns innermost folder", () => {
@@ -449,10 +420,8 @@ test("findScopeRoot with text between folders returns innermost folder", () => {
   m.state.nodes[folder2].nodeType = "folder";
   const leaf = m.addNode(folder2, "Leaf");
 
-  // Leaf's scope root should be folder2
-  assert.equal(findScopeRoot(m.state.nodes, leaf, root), folder2);
-  // Text1's scope root should be folder1
-  assert.equal(findScopeRoot(m.state.nodes, text1, root), folder1);
+  expect(findScopeRoot(m.state.nodes, leaf, root)).toBe(folder2);
+  expect(findScopeRoot(m.state.nodes, text1, root)).toBe(folder1);
 });
 
 // ===========================================================================
@@ -466,18 +435,16 @@ test("band attribute: can assign flash/rapid/deep to nodes", () => {
   const b = m.addNode(root, "Rapid graph");
   const c = m.addNode(root, "Deep research");
 
-  // Use attributes to store band
   m.state.nodes[a].attributes.band = "flash";
   m.state.nodes[b].attributes.band = "rapid";
   m.state.nodes[c].attributes.band = "deep";
 
-  assert.equal(m.state.nodes[a].attributes.band, "flash");
-  assert.equal(m.state.nodes[b].attributes.band, "rapid");
-  assert.equal(m.state.nodes[c].attributes.band, "deep");
+  expect(m.state.nodes[a].attributes.band).toBe("flash");
+  expect(m.state.nodes[b].attributes.band).toBe("rapid");
+  expect(m.state.nodes[c].attributes.band).toBe("deep");
 
-  // Model should still be valid
   const errors = m.validate();
-  assert.equal(errors.length, 0);
+  expect(errors.length).toBe(0);
 });
 
 test("band filter: queryNodes then filter by band attribute", () => {
@@ -498,9 +465,9 @@ test("band filter: queryNodes then filter by band attribute", () => {
   const rapidNodes = allNodes.filter((n) => n.attributes.band === "rapid");
   const deepNodes = allNodes.filter((n) => n.attributes.band === "deep");
 
-  assert.equal(flashNodes.length, 2);
-  assert.equal(rapidNodes.length, 1);
-  assert.equal(deepNodes.length, 1);
+  expect(flashNodes.length).toBe(2);
+  expect(rapidNodes.length).toBe(1);
+  expect(deepNodes.length).toBe(1);
 });
 
 test("band promotion: flash -> rapid -> deep", () => {
@@ -508,20 +475,17 @@ test("band promotion: flash -> rapid -> deep", () => {
   const root = m.state.rootId;
   const node = m.addNode(root, "Evolving node");
 
-  // Start as flash
   m.state.nodes[node].attributes.band = "flash";
-  assert.equal(m.state.nodes[node].attributes.band, "flash");
+  expect(m.state.nodes[node].attributes.band).toBe("flash");
 
-  // Promote to rapid
   m.state.nodes[node].attributes.band = "rapid";
-  assert.equal(m.state.nodes[node].attributes.band, "rapid");
+  expect(m.state.nodes[node].attributes.band).toBe("rapid");
 
-  // Promote to deep
   m.state.nodes[node].attributes.band = "deep";
-  assert.equal(m.state.nodes[node].attributes.band, "deep");
+  expect(m.state.nodes[node].attributes.band).toBe("deep");
 
   const errors = m.validate();
-  assert.equal(errors.length, 0);
+  expect(errors.length).toBe(0);
 });
 
 test("band filter within scope", () => {
@@ -534,10 +498,10 @@ test("band filter within scope", () => {
   const flashInScope = scopeNodes.filter((n) => n.attributes.band === "flash");
   const rapidInScope = scopeNodes.filter((n) => n.attributes.band === "rapid");
 
-  assert.equal(flashInScope.length, 1);
-  assert.equal(flashInScope[0].id, a1);
-  assert.equal(rapidInScope.length, 1);
-  assert.equal(rapidInScope[0].id, a2);
+  expect(flashInScope.length).toBe(1);
+  expect(flashInScope[0].id).toBe(a1);
+  expect(rapidInScope.length).toBe(1);
+  expect(rapidInScope[0].id).toBe(a2);
 });
 
 test("band: nodes without band attribute are unclassified", () => {
@@ -551,10 +515,9 @@ test("band: nodes without band attribute are unclassified", () => {
   const allNodes = m.queryNodes(root);
   const unclassified = allNodes.filter((n) => !n.attributes.band);
 
-  // Root + b are unclassified
-  assert.ok(unclassified.some((n) => n.id === b));
-  assert.ok(unclassified.some((n) => n.id === root));
-  assert.ok(!unclassified.some((n) => n.id === a));
+  expect(unclassified.some((n) => n.id === b)).toBe(true);
+  expect(unclassified.some((n) => n.id === root)).toBe(true);
+  expect(unclassified.some((n) => n.id === a)).toBe(false);
 });
 
 test("band survives JSON round-trip", () => {
@@ -566,7 +529,7 @@ test("band survives JSON round-trip", () => {
   const json = m.toJSON();
   const restored = RapidMvpModel.fromJSON(json);
 
-  assert.equal(restored.state.nodes[a].attributes.band, "flash");
+  expect(restored.state.nodes[a].attributes.band).toBe("flash");
 });
 
 // ===========================================================================
@@ -579,16 +542,15 @@ test("bookmark: store scope bookmark in linearNotesByScope", () => {
   const scope1 = m.addNode(root, "Scope1");
   m.state.nodes[scope1].nodeType = "folder";
 
-  // Use linearNotesByScope as a bookmark store (existing field)
   if (!m.state.linearNotesByScope) m.state.linearNotesByScope = {};
   m.state.linearNotesByScope["__bookmarks__"] = JSON.stringify([
     { scopeId: scope1, label: "My Bookmark" },
   ]);
 
   const bookmarks = JSON.parse(m.state.linearNotesByScope["__bookmarks__"]);
-  assert.equal(bookmarks.length, 1);
-  assert.equal(bookmarks[0].scopeId, scope1);
-  assert.equal(bookmarks[0].label, "My Bookmark");
+  expect(bookmarks.length).toBe(1);
+  expect(bookmarks[0].scopeId).toBe(scope1);
+  expect(bookmarks[0].label).toBe("My Bookmark");
 });
 
 test("bookmark: multiple bookmarks stored and retrieved", () => {
@@ -602,9 +564,9 @@ test("bookmark: multiple bookmarks stored and retrieved", () => {
   m.state.linearNotesByScope["__bookmarks__"] = JSON.stringify(bookmarks);
 
   const loaded = JSON.parse(m.state.linearNotesByScope["__bookmarks__"]);
-  assert.equal(loaded.length, 2);
-  assert.equal(loaded[0].scopeId, scopeA);
-  assert.equal(loaded[1].scopeId, scopeB);
+  expect(loaded.length).toBe(2);
+  expect(loaded[0].scopeId).toBe(scopeA);
+  expect(loaded[1].scopeId).toBe(scopeB);
 });
 
 test("bookmark: jump to bookmarked scope returns correct nodes", () => {
@@ -617,15 +579,14 @@ test("bookmark: jump to bookmarked scope returns correct nodes", () => {
   ];
   m.state.linearNotesByScope["__bookmarks__"] = JSON.stringify(bookmarks);
 
-  // "Jump" to bookmark = queryNodes with that scopeId
   const jumpA = m.queryNodeIds(bookmarks[0].scopeId);
-  assert.ok(jumpA.includes(a1));
-  assert.ok(jumpA.includes(a2));
-  assert.ok(!jumpA.includes(b1));
+  expect(jumpA.includes(a1)).toBe(true);
+  expect(jumpA.includes(a2)).toBe(true);
+  expect(jumpA.includes(b1)).toBe(false);
 
   const jumpB = m.queryNodeIds(bookmarks[1].scopeId);
-  assert.ok(jumpB.includes(b1));
-  assert.ok(!jumpB.includes(a1));
+  expect(jumpB.includes(b1)).toBe(true);
+  expect(jumpB.includes(a1)).toBe(false);
 });
 
 test("bookmark: survives JSON round-trip", () => {
@@ -639,8 +600,8 @@ test("bookmark: survives JSON round-trip", () => {
   const restored = RapidMvpModel.fromJSON(json);
 
   const loaded = JSON.parse(restored.state.linearNotesByScope["__bookmarks__"]);
-  assert.equal(loaded.length, 1);
-  assert.equal(loaded[0].scopeId, scopeA);
+  expect(loaded.length).toBe(1);
+  expect(loaded[0].scopeId).toBe(scopeA);
 });
 
 test("bookmark: deleted scope bookmark returns empty queryNodes", () => {
@@ -652,10 +613,9 @@ test("bookmark: deleted scope bookmark returns empty queryNodes", () => {
 
   m.deleteNode(scopeA);
 
-  // Trying to jump to deleted scope should throw (node not found)
-  assert.throws(() => m.queryNodeIds(scopeA), {
-    message: /not found/i,
-  });
+  expect(() => m.queryNodeIds(scopeA)).toThrow(
+    /not found/i,
+  );
 });
 
 // ===========================================================================
@@ -669,7 +629,7 @@ test("combined: scoped alias with band attribute validates", () => {
   const aliasId = m.addAlias(scopeB, a1, { aliasLabel: "Rapid Ref", access: "read" });
 
   const errors = m.validate();
-  assert.equal(errors.length, 0, `Validation errors: ${errors.join(", ")}`);
+  expect(errors.length).toBe(0);
 });
 
 test("combined: reparent + alias + band all maintain validity", () => {
@@ -678,16 +638,13 @@ test("combined: reparent + alias + band all maintain validity", () => {
   m.state.nodes[a1].attributes.band = "flash";
   m.state.nodes[a2].attributes.band = "deep";
 
-  // Create cross-scope alias
   const aliasId = m.addAlias(scopeB, a1);
 
-  // Reparent a2 to scopeB
   m.reparentNode(a2, scopeB);
 
   const errors = m.validate();
-  assert.equal(errors.length, 0, `Validation errors: ${errors.join(", ")}`);
+  expect(errors.length).toBe(0);
 
-  // Verify band attributes survived
-  assert.equal(m.state.nodes[a1].attributes.band, "flash");
-  assert.equal(m.state.nodes[a2].attributes.band, "deep");
+  expect(m.state.nodes[a1].attributes.band).toBe("flash");
+  expect(m.state.nodes[a2].attributes.band).toBe("deep");
 });

--- a/beta/tests/unit/supabase_transport.test.js
+++ b/beta/tests/unit/supabase_transport.test.js
@@ -1,5 +1,4 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
@@ -26,13 +25,13 @@ test("FileTransport push + pull round-trip", async () => {
   };
 
   const pushResult = await transport.push("test-doc", doc, null, false);
-  assert.equal(pushResult.ok, true);
-  assert.equal(pushResult.documentId, "test-doc");
+  expect(pushResult.ok).toBe(true);
+  expect(pushResult.documentId).toBe("test-doc");
 
   const pullResult = await transport.pull("test-doc");
-  assert.equal(pullResult.ok, true);
-  assert.equal(pullResult.documentId, "test-doc");
-  assert.equal(pullResult.state.rootId, "r1");
+  expect(pullResult.ok).toBe(true);
+  expect(pullResult.documentId).toBe("test-doc");
+  expect(pullResult.state.rootId).toBe("r1");
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -42,9 +41,9 @@ test("FileTransport status returns exists false for missing doc", async () => {
   const transport = new FileTransport(tmpDir);
 
   const status = await transport.status("nonexistent");
-  assert.equal(status.ok, true);
-  assert.equal(status.exists, false);
-  assert.equal(status.cloudSavedAt, null);
+  expect(status.ok).toBe(true);
+  expect(status.exists).toBe(false);
+  expect(status.cloudSavedAt).toBe(null);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -67,8 +66,8 @@ test("FileTransport push detects conflict", async () => {
   };
   // baseSavedAt does not match cloud savedAt => conflict
   const pushResult = await transport.push("test-doc", doc2, "2026-04-08T00:00:00.000Z", false);
-  assert.equal(pushResult.ok, false);
-  assert.equal(pushResult.conflict, true);
+  expect(pushResult.ok).toBe(false);
+  expect(pushResult.conflict).toBe(true);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -90,8 +89,8 @@ test("FileTransport push with force bypasses conflict", async () => {
     state: { rootId: "r2", nodes: {} },
   };
   const pushResult = await transport.push("test-doc", doc2, "2026-04-08T00:00:00.000Z", true);
-  assert.equal(pushResult.ok, true);
-  assert.equal(pushResult.forced, true);
+  expect(pushResult.ok).toBe(true);
+  expect(pushResult.forced).toBe(true);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -101,36 +100,29 @@ test("FileTransport pull returns error for nonexistent doc", async () => {
   const transport = new FileTransport(tmpDir);
 
   const result = await transport.pull("missing");
-  assert.equal(result.ok, false);
-  assert.match(result.error, /not found/i);
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/not found/i);
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
-// SupabaseTransport — constructor + getClient guard
+// SupabaseTransport -- constructor + getClient guard
 // ---------------------------------------------------------------------------
 
 test("SupabaseTransport constructor stores url and anonKey", () => {
   const t = new SupabaseTransport("https://example.supabase.co", "anon-key-123");
-  assert.equal(t.mode, "supabase");
+  expect(t.mode).toBe("supabase");
 });
 
 test("SupabaseTransport methods fail gracefully when supabase-js is not resolvable", async () => {
-  // This test verifies that calling push/pull/status without the actual
-  // supabase-js library throws a clear error rather than crashing silently.
-  // In CI, @supabase/supabase-js may not be installed.
   const t = new SupabaseTransport("https://fake.supabase.co", "fake-key");
   try {
     await t.status("test-doc");
-    // If supabase-js IS installed, status will try to connect and may fail
-    // with a network error — that is also acceptable.
   } catch (err) {
-    // Expected: either MODULE_NOT_FOUND or a network/connection error
-    assert.ok(
+    expect(
       err.message || err.code,
-      "Error should have a message or code",
-    );
+    ).toBeTruthy();
   }
 });
 
@@ -142,8 +134,8 @@ test("loadCloudSyncConfig returns disabled when M3E_CLOUD_SYNC is not set", () =
   const original = process.env.M3E_CLOUD_SYNC;
   delete process.env.M3E_CLOUD_SYNC;
   const config = loadCloudSyncConfig();
-  assert.equal(config.enabled, false);
-  assert.equal(config.transport, null);
+  expect(config.enabled).toBe(false);
+  expect(config.transport).toBe(null);
   if (original !== undefined) process.env.M3E_CLOUD_SYNC = original;
 });
 
@@ -154,9 +146,9 @@ test("loadCloudSyncConfig returns FileTransport by default", () => {
   process.env.M3E_DATA_DIR = os.tmpdir();
 
   const config = loadCloudSyncConfig();
-  assert.equal(config.enabled, true);
-  assert.ok(config.transport);
-  assert.equal(config.transport.mode, "file-mirror");
+  expect(config.enabled).toBe(true);
+  expect(config.transport).toBeTruthy();
+  expect(config.transport.mode).toBe("file-mirror");
 
   // Restore
   Object.keys(process.env).forEach((k) => {
@@ -173,9 +165,9 @@ test("loadCloudSyncConfig returns SupabaseTransport when configured", () => {
   process.env.M3E_SUPABASE_ANON_KEY = "test-key";
 
   const config = loadCloudSyncConfig();
-  assert.equal(config.enabled, true);
-  assert.ok(config.transport);
-  assert.equal(config.transport.mode, "supabase");
+  expect(config.enabled).toBe(true);
+  expect(config.transport).toBeTruthy();
+  expect(config.transport.mode).toBe("supabase");
 
   // Restore
   Object.keys(process.env).forEach((k) => {
@@ -192,8 +184,8 @@ test("loadCloudSyncConfig falls back to disabled when supabase env vars missing"
   delete process.env.M3E_SUPABASE_ANON_KEY;
 
   const config = loadCloudSyncConfig();
-  assert.equal(config.enabled, false);
-  assert.equal(config.transport, null);
+  expect(config.enabled).toBe(false);
+  expect(config.transport).toBe(null);
 
   // Restore
   Object.keys(process.env).forEach((k) => {

--- a/beta/tests/unit/supabase_transport_mock.test.js
+++ b/beta/tests/unit/supabase_transport_mock.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import { test, expect } from "vitest";
 
 const { SupabaseTransport } = require("../../dist/node/cloud_sync.js");
 
@@ -9,14 +8,9 @@ const { SupabaseTransport } = require("../../dist/node/cloud_sync.js");
 // Mock Supabase client
 // ---------------------------------------------------------------------------
 
-/**
- * Creates a mock SupabaseTransport with an injected fake client.
- * This avoids the dynamic import of @supabase/supabase-js.
- */
 function createMockTransport(mockData) {
   const transport = new SupabaseTransport("https://mock.supabase.co", "mock-key");
 
-  // Build a chainable query builder mock
   function createQueryBuilder(resolveData, resolveError) {
     const builder = {
       select: () => builder,
@@ -36,14 +30,10 @@ function createMockTransport(mockData) {
     },
   };
 
-  // Inject mock client directly
   transport.client = mockClient;
   return transport;
 }
 
-/**
- * Creates a mock transport with per-method control.
- */
 function createDetailedMockTransport(handlers) {
   const transport = new SupabaseTransport("https://mock.supabase.co", "mock-key");
 
@@ -92,7 +82,7 @@ function createDetailedMockTransport(handlers) {
 
 test("SupabaseTransport push succeeds when no conflict", async () => {
   const transport = createDetailedMockTransport({
-    maybeSingle: () => ({ data: null, error: null }), // no existing doc
+    maybeSingle: () => ({ data: null, error: null }),
     upsert: () => ({ data: null, error: null }),
   });
 
@@ -103,9 +93,9 @@ test("SupabaseTransport push succeeds when no conflict", async () => {
   };
 
   const result = await transport.push("doc1", doc, null, false);
-  assert.equal(result.ok, true);
-  assert.equal(result.documentId, "doc1");
-  assert.equal(result.savedAt, "2026-04-10T00:00:00.000Z");
+  expect(result.ok).toBe(true);
+  expect(result.documentId).toBe("doc1");
+  expect(result.savedAt).toBe("2026-04-10T00:00:00.000Z");
 });
 
 test("SupabaseTransport push detects conflict when baseSavedAt differs", async () => {
@@ -124,9 +114,9 @@ test("SupabaseTransport push detects conflict when baseSavedAt differs", async (
   };
 
   const result = await transport.push("doc1", doc, "2026-04-10T00:00:00.000Z", false);
-  assert.equal(result.ok, false);
-  assert.equal(result.conflict, true);
-  assert.equal(result.cloudSavedAt, "2026-04-10T00:00:10.000Z");
+  expect(result.ok).toBe(false);
+  expect(result.conflict).toBe(true);
+  expect(result.cloudSavedAt).toBe("2026-04-10T00:00:10.000Z");
 });
 
 test("SupabaseTransport push skips conflict check when force=true", async () => {
@@ -145,8 +135,8 @@ test("SupabaseTransport push skips conflict check when force=true", async () => 
   };
 
   const result = await transport.push("doc1", doc, "2026-04-10T00:00:00.000Z", true);
-  assert.equal(result.ok, true);
-  assert.equal(result.forced, true);
+  expect(result.ok).toBe(true);
+  expect(result.forced).toBe(true);
 });
 
 test("SupabaseTransport push skips conflict check when baseSavedAt is null", async () => {
@@ -162,7 +152,7 @@ test("SupabaseTransport push skips conflict check when baseSavedAt is null", asy
   };
 
   const result = await transport.push("doc1", doc, null, false);
-  assert.equal(result.ok, true);
+  expect(result.ok).toBe(true);
 });
 
 test("SupabaseTransport push returns error on fetch failure", async () => {
@@ -180,8 +170,8 @@ test("SupabaseTransport push returns error on fetch failure", async () => {
   };
 
   const result = await transport.push("doc1", doc, "2026-04-09T00:00:00.000Z", false);
-  assert.equal(result.ok, false);
-  assert.match(result.error, /connection refused/);
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/connection refused/);
 });
 
 test("SupabaseTransport push returns error on upsert failure", async () => {
@@ -200,8 +190,8 @@ test("SupabaseTransport push returns error on upsert failure", async () => {
   };
 
   const result = await transport.push("doc1", doc, null, false);
-  assert.equal(result.ok, false);
-  assert.match(result.error, /row too large/);
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/row too large/);
 });
 
 test("SupabaseTransport push generates savedAt when doc has none", async () => {
@@ -217,8 +207,8 @@ test("SupabaseTransport push generates savedAt when doc has none", async () => {
   };
 
   const result = await transport.push("doc1", doc, null, false);
-  assert.equal(result.ok, true);
-  assert.ok(result.savedAt.length > 0);
+  expect(result.ok).toBe(true);
+  expect(result.savedAt.length > 0).toBe(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -238,20 +228,20 @@ test("SupabaseTransport pull succeeds with existing doc", async () => {
   });
 
   const result = await transport.pull("doc1");
-  assert.equal(result.ok, true);
-  assert.equal(result.version, 1);
-  assert.equal(result.savedAt, "2026-04-10T00:00:00.000Z");
-  assert.equal(result.state.rootId, "r1");
-  assert.equal(result.documentId, "doc1");
+  expect(result.ok).toBe(true);
+  expect(result.version).toBe(1);
+  expect(result.savedAt).toBe("2026-04-10T00:00:00.000Z");
+  expect(result.state.rootId).toBe("r1");
+  expect(result.documentId).toBe("doc1");
 });
 
 test("SupabaseTransport pull returns error for missing doc", async () => {
   const transport = createMockTransport({ documents: { data: null } });
 
   const result = await transport.pull("missing");
-  assert.equal(result.ok, false);
-  assert.match(result.error, /not found/i);
-  assert.equal(result.documentId, "missing");
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/not found/i);
+  expect(result.documentId).toBe("missing");
 });
 
 test("SupabaseTransport pull returns error on fetch failure", async () => {
@@ -263,8 +253,8 @@ test("SupabaseTransport pull returns error on fetch failure", async () => {
   });
 
   const result = await transport.pull("doc1");
-  assert.equal(result.ok, false);
-  assert.match(result.error, /timeout/);
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/timeout/);
 });
 
 // ---------------------------------------------------------------------------
@@ -279,21 +269,21 @@ test("SupabaseTransport status returns exists=true with savedAt", async () => {
   });
 
   const result = await transport.status("doc1");
-  assert.equal(result.ok, true);
-  assert.equal(result.enabled, true);
-  assert.equal(result.mode, "supabase");
-  assert.equal(result.exists, true);
-  assert.equal(result.cloudSavedAt, "2026-04-10T00:00:00.000Z");
-  assert.equal(result.documentId, "doc1");
+  expect(result.ok).toBe(true);
+  expect(result.enabled).toBe(true);
+  expect(result.mode).toBe("supabase");
+  expect(result.exists).toBe(true);
+  expect(result.cloudSavedAt).toBe("2026-04-10T00:00:00.000Z");
+  expect(result.documentId).toBe("doc1");
 });
 
 test("SupabaseTransport status returns exists=false when no doc", async () => {
   const transport = createMockTransport({ documents: { data: null } });
 
   const result = await transport.status("missing");
-  assert.equal(result.ok, true);
-  assert.equal(result.exists, false);
-  assert.equal(result.cloudSavedAt, null);
+  expect(result.ok).toBe(true);
+  expect(result.exists).toBe(false);
+  expect(result.cloudSavedAt).toBe(null);
 });
 
 test("SupabaseTransport status returns ok=false on error", async () => {
@@ -305,6 +295,6 @@ test("SupabaseTransport status returns ok=false on error", async () => {
   });
 
   const result = await transport.status("doc1");
-  assert.equal(result.ok, false);
-  assert.equal(result.exists, false);
+  expect(result.ok).toBe(false);
+  expect(result.exists).toBe(false);
 });

--- a/beta/vitest.config.js
+++ b/beta/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/unit/**/*.test.js"],
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
- Converted all 20 test files from `node:test`/`node:assert` to `vitest` imports (`test`, `expect`, `describe`, `beforeAll`, `afterAll`, `beforeEach`, `afterEach`)
- Added `vitest` as devDependency and created `vitest.config.js`
- Updated `package.json` test scripts to use `npx vitest run` instead of `node --test`
- All 285 tests pass, 10 skipped (collab tests requiring `M3E_COLLAB=1`), zero "No test suite found" errors

## Test plan
- [x] `npx vitest run` passes with 21 test files, 285 tests passing
- [x] No remaining `node:test` or `node:assert` imports in test files
- [x] `mm_exporter.test.js` (already vitest) continues to pass
- [ ] Verify `npm run test:unit` works end-to-end (build + vitest)

Generated with [Claude Code](https://claude.com/claude-code)