### PR TITLE
fix(server): replace hardcoded rapid-main with configurable DEFAULT_DOC_ID

### DIFF
--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -66,6 +66,7 @@ const DEFAULT_DB_FILE = "M3E_dataV1.sqlite";
 const DB_FILE = process.env.M3E_DB_FILE || DEFAULT_DB_FILE;
 const SQLITE_DB_PATH = path.join(DATA_DIR, DB_FILE);
 const FIRST_RUN_MARKER = path.join(DATA_DIR, ".m3e-launched");
+const DEFAULT_DOC_ID = process.env.M3E_DOC_ID || "akaghef-beta";
 const TUTORIAL_SCOPE_ID = "n_1775650869381_rns0cp";
 const cloudSyncConfig = loadCloudSyncConfig();
 const CLOUD_SYNC_ENABLED = cloudSyncConfig.enabled;
@@ -922,7 +923,7 @@ async function handleAiApi(req: http.IncomingMessage, res: http.ServerResponse):
 
 function startServer(): void {
   // Initialize audit log file for the default document
-  initAuditFile(DATA_DIR, "rapid-main");
+  initAuditFile(DATA_DIR, DEFAULT_DOC_ID);
 
   const server = createAppServer();
 
@@ -949,7 +950,7 @@ function startServer(): void {
       autoSyncHandle = startAutoSync(cloudTransport, cloudSyncConfig.autoSyncIntervalMs, {
         getLocalState: async () => {
           try {
-            const model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, "rapid-main");
+            const model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, DEFAULT_DOC_ID);
             return {
               version: 1,
               savedAt: new Date().toISOString(),
@@ -959,7 +960,7 @@ function startServer(): void {
             return null;
           }
         },
-        getDocId: () => "rapid-main",
+        getDocId: () => DEFAULT_DOC_ID,
         getBaseSavedAt: () => null,
         getBaseDocVersion: () => null,
         onPushSuccess: (result) => {
@@ -1053,7 +1054,7 @@ async function handleCollabApi(
     }
     const entity = registerEntity(body.displayName, body.role, body.capabilities ?? ["read", "write"]);
     // Track presence for default doc on register
-    touchPresence("rapid-main", entity.entityId, body.displayName, body.role);
+    touchPresence(DEFAULT_DOC_ID, entity.entityId, body.displayName, body.role);
     sendJson(res, 200, { ok: true, entityId: entity.entityId, token: entity.token, priority: entity.priority });
     return;
   }
@@ -1071,14 +1072,14 @@ async function handleCollabApi(
       const body = JSON.parse(rawBody) as { lockIds?: string[]; docId?: string };
       heartbeat(entity.entityId, body.lockIds ?? []);
       // Refresh presence on heartbeat
-      touchPresence(body.docId ?? "rapid-main", entity.entityId, entity.displayName, entity.role);
+      touchPresence(body.docId ?? DEFAULT_DOC_ID, entity.entityId, entity.displayName, entity.role);
       sendJson(res, 200, { ok: true });
       return;
     }
     case "unregister": {
       if (req.method !== "DELETE") { sendJson(res, 405, { ok: false, error: "Method not allowed." }); return; }
       // Remove from all doc presence (use default doc for now)
-      removePresence("rapid-main", entity.entityId);
+      removePresence(DEFAULT_DOC_ID, entity.entityId);
       unregisterEntity(entity.entityId);
       sendJson(res, 200, { ok: true });
       return;


### PR DESCRIPTION
## Summary
- Replaced 6 hardcoded `"rapid-main"` occurrences in `start_viewer.ts` with a `DEFAULT_DOC_ID` constant
- Default value is `"akaghef-beta"` to match the browser-side default (`viewer.ts` line 66)
- Configurable via `M3E_DOC_ID` environment variable for flexible deployment

## Changes
- `beta/src/node/start_viewer.ts`: Added `DEFAULT_DOC_ID` constant (line 69), replaced all 6 usages

## Test plan
- [x] TypeScript type check passes (`npx tsc -p tsconfig.node.json --noEmit`)
- [x] No remaining `"rapid-main"` in `start_viewer.ts`
- [ ] Manual: start server, verify doc operations use `akaghef-beta` by default
- [ ] Manual: set `M3E_DOC_ID=custom-id` and verify override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)