### PR TITLE
fix(dist): add missing launch_node.bat and fix VM test automation

### DIFF
--- a/install/dist/scripts/launch_node.bat
+++ b/install/dist/scripts/launch_node.bat
@@ -1,0 +1,29 @@
+@echo off
+setlocal EnableExtensions
+
+call "%~dp0..\common_env.bat"
+if errorlevel 1 exit /b %errorlevel%
+
+if not exist "%M3E_LOGS%" mkdir "%M3E_LOGS%" >nul 2>&1
+
+>> "%M3E_STARTUP_LOG%" echo [%date% %time%] [INFO] Launch requested
+
+if not exist "%M3E_NODE_EXE%" (
+  >> "%M3E_STARTUP_LOG%" echo [%date% %time%] [ERROR] Missing runtime: %M3E_NODE_EXE%
+  echo [ERROR] Missing runtime: %M3E_NODE_EXE%
+  echo Please re-run setup.
+  exit /b 61
+)
+
+if not exist "%M3E_START_JS%" (
+  >> "%M3E_STARTUP_LOG%" echo [%date% %time%] [ERROR] Missing start_viewer.js: %M3E_START_JS%
+  echo [ERROR] Missing start_viewer.js: %M3E_START_JS%
+  echo Please re-run setup.
+  exit /b 62
+)
+
+pushd "%M3E_APP%" >nul
+start "" /B "%M3E_NODE_EXE%" "%M3E_START_JS%" %*
+popd >nul
+
+exit /b 0

--- a/scripts/ops/run_test.bat
+++ b/scripts/ops/run_test.bat
@@ -13,7 +13,12 @@ REM ============================================================
 set "PKG_ROOT=%~dp0"
 if "%PKG_ROOT:~-1%"=="\" set "PKG_ROOT=%PKG_ROOT:~0,-1%"
 
-set "SHARED_REPORTS=C:\M3E_test_reports"
+REM Try VBox shared folder first (auto-mount Y:), fall back to local path
+if exist "Y:\" (
+  set "SHARED_REPORTS=Y:"
+) else (
+  set "SHARED_REPORTS=C:\M3E_test_reports"
+)
 for /f %%T in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "TS=%%T"
 if "%TS%"=="" set "TS=%date:~0,4%%date:~5,2%%date:~8,2%_%time:~0,2%%time:~3,2%"
 set "REPORT_DIR=%SHARED_REPORTS%\test_%TS%"

--- a/scripts/ops/vm_test.bat
+++ b/scripts/ops/vm_test.bat
@@ -18,7 +18,7 @@ REM ============================================================
 set "VM_NAME=M3E-Test"
 set "SNAPSHOT=clean"
 set "GUEST_USER=m3etest"
-set "GUEST_PASS=m3etest"
+set "GUEST_PASS="
 set "WAIT_BOOT=60"
 set "WAIT_TEST=300"
 
@@ -67,7 +67,7 @@ ping -n %WAIT_BOOT% 127.0.0.1 >nul
 REM Verify guest is responsive (retry up to 5 times, 30s apart)
 set /a RETRY=0
 :guest_wait
-"%VBOX%" guestcontrol "%VM_NAME%" run --username "%GUEST_USER%" --password "%GUEST_PASS%" --exe "C:\Windows\System32\cmd.exe" -- cmd /c "echo ready" >nul 2>&1
+"%VBOX%" guestcontrol "%VM_NAME%" run --username "%GUEST_USER%" --password "%GUEST_PASS%" --exe "C:\Windows\System32\hostname.exe" --timeout 10000 --wait-stdout >nul 2>&1
 if not errorlevel 1 goto :guest_ok
 set /a RETRY+=1
 if %RETRY% GEQ 5 (
@@ -86,9 +86,9 @@ echo [4/5] Running test inside VM (timeout %WAIT_TEST%s)...
 "%VBOX%" guestcontrol "%VM_NAME%" run ^
     --username "%GUEST_USER%" ^
     --password "%GUEST_PASS%" ^
-    --exe "C:\Windows\System32\cmd.exe" ^
+    --exe "Z:\run_test.bat" ^
     --timeout %WAIT_TEST%000 ^
-    -- cmd /c "Z:\run_test.bat"
+    --wait-stdout
 
 set "TEST_RC=%errorlevel%"
 if "%TEST_RC%"=="0" (
@@ -121,9 +121,9 @@ echo Running test inside VM...
 "%VBOX%" guestcontrol "%VM_NAME%" run ^
     --username "%GUEST_USER%" ^
     --password "%GUEST_PASS%" ^
-    --exe "C:\Windows\System32\cmd.exe" ^
+    --exe "Z:\run_test.bat" ^
     --timeout %WAIT_TEST%000 ^
-    -- cmd /c "Z:\run_test.bat"
+    --wait-stdout
 set "TEST_RC=%errorlevel%"
 echo.
 echo ============================================================


### PR DESCRIPTION
## Summary

Fixes two separate but related issues uncovered during VM-based distribution testing today.

### 1. Launch bug (user-visible)

`install/dist/launch.bat` calls `%~dp0scripts\launch_node.bat`, but that file **did not exist** in the distribution. Result: clicking the Start menu shortcut (or running `launch.bat` directly) silently exits, M3E never opens.

- VM tests missed this because `run_test.bat` spawns `node.exe` + `start_viewer.js` directly, bypassing `launch.bat`.
- Added `install/dist/scripts/launch_node.bat` that validates runtime/start_viewer.js presence, logs to `startup.log`, and spawns node in the background from `%M3E_APP%`.
- `setup_internal.bat:92-94` already copies the `scripts/` tree, so no setup change is needed — the new file will be picked up in the next distribution build.

### 2. VM test automation (`scripts/ops/vm_test.bat`, `scripts/ops/run_test.bat`)

Three problems that broke end-to-end cold runs:

| Problem | Root cause | Fix |
|---|---|---|
| guestcontrol fails with "password wrong" | Windows 11 no longer honours plaintext `DefaultPassword` in registry; autologon only works with a blank password | Set `GUEST_PASS=""`, `m3etest` account uses blank password. Combined with `LimitBlankPasswordUse=0` on the VM |
| Test process hangs until timeout | `--exe cmd.exe -- cmd /c "script.bat"` makes cmd.exe open interactively in guestcontrol; stdout stream never closes | Use `--exe "Z:\run_test.bat" --wait-stdout` directly (no cmd wrapper). Same fix applied to the readiness probe: `--exe hostname.exe --wait-stdout` |
| Host never sees test reports | `run_test.bat` wrote to `C:\M3E_test_reports` (local VM path), not the VBox shared folder | Prefer `Y:\` (auto-mounted shared folder) with fallback to local path |

### VM setup notes (for the `clean` snapshot, one-time)

The reviewer's VM snapshot needs to be refreshed with these guest-side states captured:
1. `net user m3etest ""` (blank password)
2. `reg add "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v LimitBlankPasswordUse /t REG_DWORD /d 0 /f` (allow blank-password network logon for guestcontrol RPC)
3. Shut down cleanly, then re-take the `clean` snapshot.

Without step 2, guestcontrol cannot log in as a blank-password user. Without step 1, autologon prompts at boot and the snapshot-cold run stalls.

### Result

Cold run (`scripts\ops\vm_test.bat`) now completes end-to-end:

```
Setup:   PASS
Verify:  PASS
Launch:  PASS (port 39876)
Smoke:   PASS
```

Reports land in `C:\M3E_test_reports\test_<timestamp>\` on the host automatically.

## Test plan

- [ ] Apply VM setup notes above and re-take `clean` snapshot
- [ ] `scripts\ops\vm_test.bat` → expect all four steps PASS, `report.txt` appears in host's `C:\M3E_test_reports\`
- [ ] After test completes, in the VM: double-click the M3E Start-menu shortcut → viewer opens (this verifies the launch_node.bat fix end-to-end, not just via the test harness)
- [ ] Merge decision deferred to the data-structure-breaking-change branch owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)