### PR TITLE
visual: HOME page v1 (standalone, mock fallback, BroadcastChannel)

### DIFF
--- a/beta/home.css
+++ b/beta/home.css
@@ -1,0 +1,286 @@
+/* HOME page styles. Companion to viewer.css (which provides theme tokens). */
+
+body.home-page {
+  overflow: auto;
+  background: var(--grid-bg);
+  color: var(--ink);
+}
+
+.home-app {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 24px 24px 64px;
+}
+
+/* ---------- top bar ---------- */
+.home-topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 0 24px;
+  border-bottom: 1px solid var(--grid-line);
+  margin-bottom: 16px;
+}
+
+.home-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.home-brand-mark {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}
+
+.home-brand-sub {
+  font-size: 14px;
+  color: #6a6a6a;
+}
+
+.home-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.home-search {
+  width: 240px;
+  padding: 6px 10px;
+  border: 1px solid var(--grid-line);
+  border-radius: 6px;
+  font: inherit;
+  background: #fff;
+}
+.home-search:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.home-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #444;
+  cursor: pointer;
+  user-select: none;
+}
+
+.home-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--grid-line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+.home-btn:hover {
+  border-color: var(--accent);
+}
+.home-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.home-btn-primary:hover {
+  filter: brightness(1.05);
+}
+
+/* ---------- main / list ---------- */
+.home-main {
+  display: block;
+}
+
+.home-status {
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--ink);
+  font-size: 13px;
+}
+.home-status.is-error {
+  background: #fde0e0;
+  color: var(--danger);
+}
+
+.home-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.home-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  padding: 10px;
+  background: #fff;
+  border: 1px solid var(--grid-line);
+  border-radius: 8px;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.home-row:hover {
+  border-color: var(--accent);
+  box-shadow: 0 1px 4px rgba(122, 53, 255, 0.08);
+}
+.home-row.is-archived {
+  background: #fafafa;
+  opacity: 0.85;
+}
+
+.home-row-link {
+  display: flex;
+  flex: 1 1 auto;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+  min-width: 0;
+}
+
+/* Thumbnail slot — placeholder in v1, real SVG in v2 (Q1). */
+.home-thumb-slot {
+  flex: 0 0 auto;
+  width: 96px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-soft);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.home-thumb-placeholder {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+}
+
+.home-row-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+}
+
+.home-row-line1 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.home-row-label {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.home-row-open-badge,
+.home-row-archived-badge {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.home-row-archived-badge {
+  background: #f0f0f0;
+  color: #666;
+}
+
+.home-row-meta {
+  font-size: 12px;
+  color: #6a6a6a;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.home-row-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.home-tag {
+  font-size: 11px;
+  padding: 2px 6px;
+  background: #f3efff;
+  color: var(--accent);
+  border-radius: 999px;
+}
+
+.home-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.home-icon-btn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: #555;
+  cursor: pointer;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.home-icon-btn:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.home-icon-btn-danger:hover {
+  background: #fde0e0;
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.home-empty {
+  margin-top: 48px;
+  text-align: center;
+  color: #888;
+  line-height: 1.6;
+}
+
+/* ---------- viewer toolbar Home button (used by viewer.html) ---------- */
+.home-toolbar-btn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--grid-line);
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+}
+.home-toolbar-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/beta/home.html
+++ b/beta/home.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>M3E — HOME</title>
+    <link rel="stylesheet" href="./viewer.css" />
+    <link rel="stylesheet" href="./home.css" />
+  </head>
+  <body class="home-page">
+    <div class="home-app">
+      <header class="home-topbar">
+        <div class="home-brand">
+          <span class="home-brand-mark" aria-hidden="true">M3E</span>
+          <span class="home-brand-sub">ドキュメント一覧</span>
+        </div>
+        <div class="home-topbar-actions">
+          <input
+            id="home-search"
+            class="home-search"
+            type="search"
+            placeholder="ラベル / タグで絞り込み"
+            spellcheck="false"
+            autocomplete="off"
+          />
+          <label class="home-toggle">
+            <input id="home-show-archived" type="checkbox" />
+            <span>ゴミ箱を表示</span>
+          </label>
+          <button id="home-new" class="home-btn home-btn-primary" type="button">
+            ＋ 新規作成
+          </button>
+        </div>
+      </header>
+
+      <main class="home-main">
+        <div id="home-status" class="home-status" hidden></div>
+        <ul id="home-list" class="home-list" aria-label="ドキュメント一覧"></ul>
+        <div id="home-empty" class="home-empty" hidden>
+          <p>ドキュメントがありません。</p>
+          <p>「＋ 新規作成」から最初のマップを作成してください。</p>
+        </div>
+      </main>
+    </div>
+
+    <!--
+      Per-row template. Cloned by home.ts for each DocSummary.
+      `data-id` is set on the <li> at clone time.
+    -->
+    <template id="home-row-template">
+      <li class="home-row" data-id="">
+        <a class="home-row-link" href="#" data-role="open">
+          <div class="home-thumb-slot" aria-hidden="true">
+            <!-- v1: placeholder. v2 will inject SVG thumbnail here (Q1). -->
+            <span class="home-thumb-placeholder">M3E</span>
+          </div>
+          <div class="home-row-body">
+            <div class="home-row-line1">
+              <span class="home-row-label" data-role="label"></span>
+              <span class="home-row-open-badge" data-role="open-badge" hidden>📖 開いてる</span>
+              <span class="home-row-archived-badge" data-role="archived-badge" hidden>🗑 ゴミ箱</span>
+            </div>
+            <div class="home-row-meta">
+              <span class="home-row-saved" data-role="saved"></span>
+              <span class="home-row-stats" data-role="stats"></span>
+            </div>
+            <div class="home-row-tags" data-role="tags"></div>
+          </div>
+        </a>
+        <div class="home-row-actions">
+          <button class="home-icon-btn" type="button" data-role="rename" title="リネーム">✎</button>
+          <button class="home-icon-btn" type="button" data-role="duplicate" title="複製">⎘</button>
+          <button class="home-icon-btn" type="button" data-role="tags-edit" title="タグ編集">🏷</button>
+          <button class="home-icon-btn home-icon-btn-danger" type="button" data-role="archive" title="ゴミ箱へ">🗑</button>
+          <button class="home-icon-btn" type="button" data-role="restore" title="復元" hidden>↺</button>
+          <button class="home-icon-btn home-icon-btn-danger" type="button" data-role="delete" title="完全削除" hidden>✕</button>
+        </div>
+      </li>
+    </template>
+
+    <script src="./dist/browser/home.js"></script>
+  </body>
+</html>

--- a/beta/package.json
+++ b/beta/package.json
@@ -4,9 +4,10 @@
   "version": "0.1.0",
   "description": "Rapid MVP viewer with TypeScript source",
   "scripts": {
-    "build": "tsc -p tsconfig.node.json && tsc -p tsconfig.browser.json",
+    "build": "tsc -p tsconfig.node.json && tsc -p tsconfig.browser.json && tsc -p tsconfig.home.json",
     "build:node": "tsc -p tsconfig.node.json",
-    "build:browser": "tsc -p tsconfig.browser.json",
+    "build:browser": "tsc -p tsconfig.browser.json && tsc -p tsconfig.home.json",
+    "build:home": "tsc -p tsconfig.home.json",
     "start": "node dist/node/start_viewer.js",
     "test": "npm run test:unit",
     "test:unit": "npm run build:node && npx vitest run",

--- a/beta/src/browser/home.ts
+++ b/beta/src/browser/home.ts
@@ -1,0 +1,594 @@
+// HOME page controller.
+//
+// Standalone entry for beta/home.html. Talks to the data-agent REST API
+// (see beta/src/shared/home_types.ts for the contract). When the API is
+// unavailable (e.g. data agent has not landed yet), falls back to mock data
+// so the UI can still be developed and demoed.
+//
+// Cross-tab "currently open" awareness uses BroadcastChannel (decision Q9).
+// HOME is read-only with respect to the broadcast — viewer pages send
+// `doc-open` / `doc-close` and HOME pings them on mount.
+
+// NOTE: The browser tsconfig uses `module: "none"` and concatenates files,
+// so we cannot `import` the shared DTO module here. The canonical contract
+// lives in beta/src/shared/home_types.ts (co-owned with the data agent);
+// the local declarations below MUST stay in sync with that file.
+
+interface DocSummary {
+  id: string;
+  label: string;
+  savedAt: string;
+  nodeCount: number;
+  charCount: number;
+  tags: string[];
+  archived: boolean;
+}
+interface DocListResponse { ok: true; docs: DocSummary[]; }
+interface DocIdResponse { ok: true; id: string; }
+interface DocOkResponse { ok: true; }
+interface ApiError {
+  ok: false;
+  error: { code: string; message: string; details?: unknown };
+}
+type HomeBroadcastMessage =
+  | { type: "doc-open"; docId: string; ts: number }
+  | { type: "doc-close"; docId: string; ts: number }
+  | { type: "ping"; ts: number };
+
+const HOME_BROADCAST_CHANNEL = "m3e:home:v1";
+
+// ---------------------------------------------------------------------------
+// Japanese UI strings (decision Q10: hardcoded JA in v1, dictionary in v2).
+// Keep all user-facing text here so future i18n work is mechanical.
+// ---------------------------------------------------------------------------
+const JA = {
+  loading: "読み込み中...",
+  loadError: "ドキュメント一覧の取得に失敗しました。モックデータを表示しています。",
+  emptyAll: "ドキュメントがありません。",
+  emptyTrash: "ゴミ箱は空です。",
+  newLabelPrompt: "新しいドキュメントのラベル（空欄で 'Untitled'）",
+  renamePrompt: "新しいラベル",
+  tagsPrompt: "タグ（カンマ区切り）",
+  confirmArchive: (label: string) => `「${label}」をゴミ箱に移動しますか？`,
+  confirmRestore: (label: string) => `「${label}」をゴミ箱から戻しますか？`,
+  confirmDelete: (label: string) => `「${label}」を完全に削除します。元に戻せません。`,
+  archived: "ゴミ箱に移動しました。",
+  restored: "ゴミ箱から戻しました。",
+  deleted: "完全に削除しました。",
+  duplicated: "複製しました。",
+  renamed: "ラベルを更新しました。",
+  tagsUpdated: "タグを更新しました。",
+  created: "新規ドキュメントを作成しました。",
+  apiError: "API エラー",
+} as const;
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+type ApiResult<T> = { ok: true; data: T } | { ok: false; error: ApiError["error"] };
+
+async function apiCall<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<ApiResult<T>> {
+  try {
+    const res = await fetch(path, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        ...(init.headers || {}),
+      },
+    });
+    let body: unknown = null;
+    const text = await res.text();
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = null;
+      }
+    }
+    if (!res.ok || !body || (body as { ok?: unknown }).ok !== true) {
+      const errBody = body as ApiError | null;
+      const error = errBody && errBody.ok === false
+        ? errBody.error
+        : { code: `HTTP_${res.status}`, message: res.statusText || "Request failed" };
+      return { ok: false, error };
+    }
+    return { ok: true, data: body as T };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "NETWORK_ERROR",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}
+
+const api = {
+  list: () => apiCall<DocListResponse>("/api/docs"),
+  create: (label?: string) =>
+    apiCall<DocIdResponse>("/api/docs/new", {
+      method: "POST",
+      body: JSON.stringify({ label: label ?? null }),
+    }),
+  duplicate: (id: string) =>
+    apiCall<DocIdResponse>(`/api/docs/${encodeURIComponent(id)}/duplicate`, {
+      method: "POST",
+      body: "{}",
+    }),
+  rename: (id: string, label: string) =>
+    apiCall<DocOkResponse>(`/api/docs/${encodeURIComponent(id)}/rename`, {
+      method: "POST",
+      body: JSON.stringify({ label }),
+    }),
+  archive: (id: string) =>
+    apiCall<DocOkResponse>(`/api/docs/${encodeURIComponent(id)}/archive`, {
+      method: "POST",
+      body: "{}",
+    }),
+  restore: (id: string) =>
+    apiCall<DocOkResponse>(`/api/docs/${encodeURIComponent(id)}/restore`, {
+      method: "POST",
+      body: "{}",
+    }),
+  setTags: (id: string, tags: string[]) =>
+    apiCall<DocOkResponse>(`/api/docs/${encodeURIComponent(id)}/tags`, {
+      method: "POST",
+      body: JSON.stringify({ tags }),
+    }),
+  delete: (id: string) =>
+    apiCall<DocOkResponse>(`/api/docs/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// Mock data fallback (used when GET /api/docs fails)
+// ---------------------------------------------------------------------------
+function buildMockDocs(): DocSummary[] {
+  const now = Date.now();
+  const iso = (offsetMs: number) => new Date(now - offsetMs).toISOString();
+  return [
+    {
+      id: "akaghef-beta",
+      label: "(モック) Rapid 開発マップ",
+      savedAt: iso(1000 * 60 * 5),
+      nodeCount: 412,
+      charCount: 18234,
+      tags: ["dev", "strategy"],
+      archived: false,
+    },
+    {
+      id: "mock-doc-2",
+      label: "(モック) リサーチ思考ボード",
+      savedAt: iso(1000 * 60 * 60 * 26),
+      nodeCount: 87,
+      charCount: 3210,
+      tags: ["research"],
+      archived: false,
+    },
+    {
+      id: "mock-doc-3",
+      label: "(モック) 旧プロジェクト",
+      savedAt: iso(1000 * 60 * 60 * 24 * 14),
+      nodeCount: 23,
+      charCount: 540,
+      tags: [],
+      archived: true,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+interface HomeState {
+  docs: DocSummary[];
+  /** Doc IDs currently open in some viewer tab, populated via BroadcastChannel. */
+  openDocIds: Set<string>;
+  /** Last-seen wall-clock per open docId; used to expire stale entries. */
+  openDocSeen: Map<string, number>;
+  showArchived: boolean;
+  filter: string;
+  isMock: boolean;
+}
+
+const state: HomeState = {
+  docs: [],
+  openDocIds: new Set(),
+  openDocSeen: new Map(),
+  showArchived: false,
+  filter: "",
+  isMock: false,
+};
+
+const STALE_OPEN_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+function $<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`#${id} missing`);
+  return el as T;
+}
+
+const els = {
+  list: () => $<HTMLUListElement>("home-list"),
+  empty: () => $<HTMLDivElement>("home-empty"),
+  status: () => $<HTMLDivElement>("home-status"),
+  search: () => $<HTMLInputElement>("home-search"),
+  showArchived: () => $<HTMLInputElement>("home-show-archived"),
+  newBtn: () => $<HTMLButtonElement>("home-new"),
+  rowTemplate: () => $<HTMLTemplateElement>("home-row-template"),
+};
+
+function setStatus(message: string | null, isError = false): void {
+  const el = els.status();
+  if (!message) {
+    el.hidden = true;
+    el.textContent = "";
+    el.classList.remove("is-error");
+    return;
+  }
+  el.hidden = false;
+  el.textContent = message;
+  el.classList.toggle("is-error", isError);
+}
+
+function formatSavedAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const diffMs = Date.now() - d.getTime();
+  const min = Math.round(diffMs / 60_000);
+  if (min < 1) return "たった今";
+  if (min < 60) return `${min}分前`;
+  const hours = Math.round(min / 60);
+  if (hours < 24) return `${hours}時間前`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}日前`;
+  return d.toLocaleString("ja-JP", { hour12: false });
+}
+
+function formatStats(d: DocSummary): string {
+  const nodes = d.nodeCount.toLocaleString("ja-JP");
+  const chars = d.charCount.toLocaleString("ja-JP");
+  return `ノード ${nodes} / 文字 ${chars}`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    c === "&" ? "&amp;" :
+    c === "<" ? "&lt;" :
+    c === ">" ? "&gt;" :
+    c === '"' ? "&quot;" : "&#39;",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+function pruneStaleOpenDocs(): void {
+  const cutoff = Date.now() - STALE_OPEN_MS;
+  for (const [id, seen] of state.openDocSeen) {
+    if (seen < cutoff) {
+      state.openDocSeen.delete(id);
+      state.openDocIds.delete(id);
+    }
+  }
+}
+
+function visibleDocs(): DocSummary[] {
+  const q = state.filter.trim().toLowerCase();
+  return state.docs.filter((d) => {
+    if (!state.showArchived && d.archived) return false;
+    if (state.showArchived && !d.archived) return false;
+    if (!q) return true;
+    if (d.label.toLowerCase().includes(q)) return true;
+    if (d.tags.some((t) => t.toLowerCase().includes(q))) return true;
+    return false;
+  });
+}
+
+function render(): void {
+  pruneStaleOpenDocs();
+  const list = els.list();
+  list.innerHTML = "";
+  const docs = visibleDocs();
+
+  if (docs.length === 0) {
+    els.empty().hidden = false;
+    els.empty().querySelector("p")!.textContent = state.showArchived
+      ? JA.emptyTrash
+      : JA.emptyAll;
+    return;
+  }
+  els.empty().hidden = true;
+
+  const tpl = els.rowTemplate();
+  for (const d of docs) {
+    const frag = tpl.content.cloneNode(true) as DocumentFragment;
+    const row = frag.querySelector<HTMLLIElement>(".home-row")!;
+    row.dataset.id = d.id;
+    if (d.archived) row.classList.add("is-archived");
+
+    const link = row.querySelector<HTMLAnchorElement>('[data-role="open"]')!;
+    link.href = `./viewer.html?localDocId=${encodeURIComponent(d.id)}`;
+
+    row.querySelector<HTMLElement>('[data-role="label"]')!.textContent = d.label || "(無題)";
+    row.querySelector<HTMLElement>('[data-role="saved"]')!.textContent = formatSavedAt(d.savedAt);
+    row.querySelector<HTMLElement>('[data-role="stats"]')!.textContent = formatStats(d);
+
+    const tagsEl = row.querySelector<HTMLElement>('[data-role="tags"]')!;
+    tagsEl.innerHTML = d.tags
+      .map((t) => `<span class="home-tag">${escapeHtml(t)}</span>`)
+      .join("");
+
+    const openBadge = row.querySelector<HTMLElement>('[data-role="open-badge"]')!;
+    openBadge.hidden = !state.openDocIds.has(d.id);
+
+    const archivedBadge = row.querySelector<HTMLElement>('[data-role="archived-badge"]')!;
+    archivedBadge.hidden = !d.archived;
+
+    // Action button visibility per archived state.
+    const archiveBtn = row.querySelector<HTMLButtonElement>('[data-role="archive"]')!;
+    const restoreBtn = row.querySelector<HTMLButtonElement>('[data-role="restore"]')!;
+    const deleteBtn = row.querySelector<HTMLButtonElement>('[data-role="delete"]')!;
+    archiveBtn.hidden = d.archived;
+    restoreBtn.hidden = !d.archived;
+    deleteBtn.hidden = !d.archived;
+
+    list.appendChild(row);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+function findDoc(id: string): DocSummary | undefined {
+  return state.docs.find((d) => d.id === id);
+}
+
+function reportError(prefix: string, error: ApiError["error"]): void {
+  setStatus(`${prefix}: ${error.code} — ${error.message}`, true);
+}
+
+async function reload(): Promise<void> {
+  const r = await api.list();
+  if (r.ok) {
+    state.docs = r.data.docs;
+    state.isMock = false;
+    setStatus(null);
+  } else {
+    state.docs = buildMockDocs();
+    state.isMock = true;
+    setStatus(`${JA.loadError} (${r.error.code}: ${r.error.message})`, true);
+  }
+  render();
+}
+
+async function handleNew(): Promise<void> {
+  const raw = window.prompt(JA.newLabelPrompt, "");
+  if (raw === null) return;
+  const label = raw.trim() || undefined;
+  if (state.isMock) {
+    state.docs.unshift({
+      id: `mock-${Date.now()}`,
+      label: label || "Untitled",
+      savedAt: new Date().toISOString(),
+      nodeCount: 1,
+      charCount: 0,
+      tags: [],
+      archived: false,
+    });
+    setStatus(`${JA.created} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.create(label);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  setStatus(JA.created);
+  await reload();
+}
+
+async function handleRename(id: string): Promise<void> {
+  const doc = findDoc(id);
+  if (!doc) return;
+  const next = window.prompt(JA.renamePrompt, doc.label);
+  if (next === null) return;
+  const label = next.trim();
+  if (!label || label === doc.label) return;
+  if (state.isMock) {
+    doc.label = label;
+    setStatus(`${JA.renamed} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.rename(id, label);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  doc.label = label;
+  setStatus(JA.renamed);
+  render();
+}
+
+async function handleDuplicate(id: string): Promise<void> {
+  if (state.isMock) {
+    const src = findDoc(id);
+    if (!src) return;
+    state.docs.unshift({
+      ...src,
+      id: `mock-${Date.now()}`,
+      label: `${src.label} (コピー)`,
+      savedAt: new Date().toISOString(),
+    });
+    setStatus(`${JA.duplicated} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.duplicate(id);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  setStatus(JA.duplicated);
+  await reload();
+}
+
+async function handleArchive(id: string): Promise<void> {
+  const doc = findDoc(id);
+  if (!doc) return;
+  if (!window.confirm(JA.confirmArchive(doc.label))) return;
+  if (state.isMock) {
+    doc.archived = true;
+    setStatus(`${JA.archived} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.archive(id);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  doc.archived = true;
+  setStatus(JA.archived);
+  render();
+}
+
+async function handleRestore(id: string): Promise<void> {
+  const doc = findDoc(id);
+  if (!doc) return;
+  if (!window.confirm(JA.confirmRestore(doc.label))) return;
+  if (state.isMock) {
+    doc.archived = false;
+    setStatus(`${JA.restored} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.restore(id);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  doc.archived = false;
+  setStatus(JA.restored);
+  render();
+}
+
+async function handleDelete(id: string): Promise<void> {
+  const doc = findDoc(id);
+  if (!doc) return;
+  if (!doc.archived) return; // Safety: only allow when archived.
+  if (!window.confirm(JA.confirmDelete(doc.label))) return;
+  if (state.isMock) {
+    state.docs = state.docs.filter((d) => d.id !== id);
+    setStatus(`${JA.deleted} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.delete(id);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  state.docs = state.docs.filter((d) => d.id !== id);
+  setStatus(JA.deleted);
+  render();
+}
+
+async function handleEditTags(id: string): Promise<void> {
+  const doc = findDoc(id);
+  if (!doc) return;
+  const current = doc.tags.join(", ");
+  const next = window.prompt(JA.tagsPrompt, current);
+  if (next === null) return;
+  const tags = next
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  if (state.isMock) {
+    doc.tags = tags;
+    setStatus(`${JA.tagsUpdated} (モック)`);
+    render();
+    return;
+  }
+  const r = await api.setTags(id, tags);
+  if (!r.ok) return reportError(JA.apiError, r.error);
+  doc.tags = tags;
+  setStatus(JA.tagsUpdated);
+  render();
+}
+
+// ---------------------------------------------------------------------------
+// Event wiring
+// ---------------------------------------------------------------------------
+function wireEvents(): void {
+  els.search().addEventListener("input", (e) => {
+    state.filter = (e.target as HTMLInputElement).value;
+    render();
+  });
+  els.showArchived().addEventListener("change", (e) => {
+    state.showArchived = (e.target as HTMLInputElement).checked;
+    render();
+  });
+  els.newBtn().addEventListener("click", () => void handleNew());
+
+  // Single delegated listener for row-level actions.
+  els.list().addEventListener("click", (ev) => {
+    const target = ev.target as HTMLElement;
+    const actionEl = target.closest<HTMLElement>("[data-role]");
+    const rowEl = target.closest<HTMLElement>(".home-row");
+    if (!rowEl || !actionEl) return;
+    const id = rowEl.dataset.id;
+    if (!id) return;
+    const role = actionEl.dataset.role;
+
+    // The "open" link is a real anchor; let the browser navigate.
+    if (role === "open") return;
+
+    ev.preventDefault();
+    switch (role) {
+      case "rename": void handleRename(id); break;
+      case "duplicate": void handleDuplicate(id); break;
+      case "archive": void handleArchive(id); break;
+      case "restore": void handleRestore(id); break;
+      case "delete": void handleDelete(id); break;
+      case "tags-edit": void handleEditTags(id); break;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// BroadcastChannel: receive viewer "open" announcements
+// ---------------------------------------------------------------------------
+function wireBroadcast(): void {
+  if (typeof BroadcastChannel === "undefined") return;
+  const ch = new BroadcastChannel(HOME_BROADCAST_CHANNEL);
+  ch.addEventListener("message", (ev) => {
+    const msg = ev.data as HomeBroadcastMessage | null;
+    if (!msg || typeof msg !== "object") return;
+    if (msg.type === "doc-open") {
+      state.openDocIds.add(msg.docId);
+      state.openDocSeen.set(msg.docId, msg.ts || Date.now());
+      render();
+    } else if (msg.type === "doc-close") {
+      state.openDocIds.delete(msg.docId);
+      state.openDocSeen.delete(msg.docId);
+      render();
+    }
+  });
+  // Ask any existing viewers to re-announce.
+  ch.postMessage({ type: "ping", ts: Date.now() } satisfies HomeBroadcastMessage);
+  // Periodically prune stale entries.
+  window.setInterval(() => {
+    const before = state.openDocIds.size;
+    pruneStaleOpenDocs();
+    if (state.openDocIds.size !== before) render();
+  }, 10_000);
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+function boot(): void {
+  setStatus(JA.loading);
+  wireEvents();
+  wireBroadcast();
+  void reload();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot, { once: true });
+} else {
+  boot();
+}

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -1,3 +1,57 @@
+// ---------------------------------------------------------------------------
+// HOME integration (decisions Q6 / Q9). Cross-tab "currently open" notification
+// is broadcast on a well-known channel so the standalone home.html can
+// highlight which docs are open in viewer tabs.
+// ---------------------------------------------------------------------------
+const HOME_BROADCAST_CHANNEL_NAME = "m3e:home:v1";
+const homeBroadcast: BroadcastChannel | null =
+  typeof BroadcastChannel !== "undefined"
+    ? new BroadcastChannel(HOME_BROADCAST_CHANNEL_NAME)
+    : null;
+function currentLocalDocId(): string | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("localDocId");
+  } catch {
+    return null;
+  }
+}
+function announceOpenDoc(): void {
+  if (!homeBroadcast) return;
+  const id = currentLocalDocId();
+  if (!id) return;
+  homeBroadcast.postMessage({ type: "doc-open", docId: id, ts: Date.now() });
+}
+function announceCloseDoc(): void {
+  if (!homeBroadcast) return;
+  const id = currentLocalDocId();
+  if (!id) return;
+  homeBroadcast.postMessage({ type: "doc-close", docId: id, ts: Date.now() });
+}
+function navigateToHome(): void {
+  announceCloseDoc();
+  window.location.href = "./home.html";
+}
+if (homeBroadcast) {
+  homeBroadcast.addEventListener("message", (ev) => {
+    const msg = ev?.data as { type?: string } | null;
+    if (msg && msg.type === "ping") announceOpenDoc();
+  });
+  window.addEventListener("pagehide", () => announceCloseDoc());
+  // Re-announce periodically so HOME can expire stale entries.
+  window.setInterval(announceOpenDoc, 10_000);
+  // Initial announcement after the document settles.
+  window.setTimeout(announceOpenDoc, 0);
+}
+
+const homeNavBtn = document.getElementById("home-btn");
+if (homeNavBtn) {
+  homeNavBtn.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    navigateToHome();
+  });
+}
+
 const fileInput = document.getElementById("file-input") as HTMLInputElement;
 const loadDefaultBtn = document.getElementById("load-default");
 const runAircraftVisualCheckBtn = document.getElementById("run-aircraft-visual-check");
@@ -959,7 +1013,8 @@ function exitScope(): boolean {
   }
   const scopeRoot = currentScopeRootNode();
   if (!scopeRoot || scopeRoot.id === doc.state.rootId) {
-    setStatus("Already at root scope.");
+    // Decision Q6: at root scope, exiting jumps straight to HOME (no toast).
+    navigateToHome();
     return false;
   }
   let nextScopeId = doc.state.rootId;

--- a/beta/src/shared/home_types.ts
+++ b/beta/src/shared/home_types.ts
@@ -1,0 +1,100 @@
+// HOME page shared types.
+//
+// Co-owned by `visual` and `data` agents.
+// Update via PR with cross-review (decision: reviews/HOME Re-implementation/Q7).
+//
+// Backend endpoints (RPC-style, decision Q3):
+//   GET    /api/docs                 -> { ok: true, docs: DocSummary[] }
+//   POST   /api/docs/new             body: { label?: string }            -> { ok: true, id: string }
+//   POST   /api/docs/:id/duplicate                                       -> { ok: true, id: string }
+//   POST   /api/docs/:id/rename      body: { label: string }             -> { ok: true }
+//   POST   /api/docs/:id/archive                                         -> { ok: true }
+//   POST   /api/docs/:id/restore                                         -> { ok: true }
+//   POST   /api/docs/:id/tags        body: { tags: string[] }            -> { ok: true }
+//   DELETE /api/docs/:id             (only when archived)                -> { ok: true }
+//
+// Errors (decision Q8): `{ ok: false, error: { code, message, details? } }`
+// with an appropriate HTTP status code.
+
+/** Summary entry returned by `GET /api/docs`. */
+export interface DocSummary {
+  /** Stable document identifier (also used as the localDocId query param). */
+  id: string;
+  /** Root-node text, displayed as the human label. */
+  label: string;
+  /** ISO-8601 timestamp of the last save. */
+  savedAt: string;
+  /** Total node count (computed at list time per Q4 = parse-on-list). */
+  nodeCount: number;
+  /** Total character count across `text` + `details` + `note`. */
+  charCount: number;
+  /** Tag list (stored on the documents row per Q5). */
+  tags: string[];
+  /** Whether the doc is in the trash (decision Q2 = trash folder/archive flag). */
+  archived: boolean;
+}
+
+/** Successful list response. */
+export interface DocListResponse {
+  ok: true;
+  docs: DocSummary[];
+}
+
+/** Successful create/duplicate response. */
+export interface DocIdResponse {
+  ok: true;
+  id: string;
+}
+
+/** Generic ok-only response (rename / archive / restore / tags / delete). */
+export interface DocOkResponse {
+  ok: true;
+}
+
+/** Error envelope shared by every HOME endpoint. */
+export interface ApiError {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+/** Known error codes. Backend may add more — UI must handle unknown gracefully. */
+export type HomeErrorCode =
+  | "DOC_NOT_FOUND"
+  | "DOC_NOT_ARCHIVED"
+  | "INVALID_LABEL"
+  | "INVALID_TAGS"
+  | "INTERNAL_ERROR";
+
+// ---------------------------------------------------------------------------
+// Cross-tab broadcast (decision Q9 = BroadcastChannel)
+// ---------------------------------------------------------------------------
+
+/** BroadcastChannel name used to coordinate "currently open" doc state. */
+export const HOME_BROADCAST_CHANNEL = "m3e:home:v1";
+
+/** Viewer announces it is showing a doc. */
+export interface OpenDocBroadcast {
+  type: "doc-open";
+  docId: string;
+  /** Wall-clock timestamp; receivers may use this to expire stale entries. */
+  ts: number;
+}
+
+/** Viewer is closing or navigating away from a doc. */
+export interface CloseDocBroadcast {
+  type: "doc-close";
+  docId: string;
+  ts: number;
+}
+
+/** HOME asks all viewers to re-announce themselves (used right after HOME mounts). */
+export interface PingBroadcast {
+  type: "ping";
+  ts: number;
+}
+
+export type HomeBroadcastMessage = OpenDocBroadcast | CloseDocBroadcast | PingBroadcast;

--- a/beta/tsconfig.home.json
+++ b/beta/tsconfig.home.json
@@ -9,6 +9,5 @@
     "declaration": false,
     "types": []
   },
-  "include": ["src/browser/**/*.ts"],
-  "exclude": ["src/browser/home.ts"]
+  "files": ["src/browser/home.ts"]
 }

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -5,12 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>M3E</title>
         <link rel="stylesheet" href="./viewer.css" />
+        <link rel="stylesheet" href="./home.css" />
         <link rel="stylesheet" href="./public/katex/katex.min.css" />
   </head>
   <body>
     <div class="app">
       <div class="overlay-ui">
         <div class="toolbar">
+          <a id="home-btn" class="home-toolbar-btn" href="./home.html" title="HOME へ戻る" aria-label="HOME">🏠</a>
           <div class="hamburger-wrap">
             <button id="hamburger-btn" class="hamburger-btn" type="button" aria-label="Menu" aria-expanded="false">&#9776;</button>
             <div id="hamburger-menu" class="hamburger-menu" hidden>


### PR DESCRIPTION
## Summary
- Standalone `beta/home.html` + `beta/home.css` + `beta/src/browser/home.ts` document-list page.
- Talks to RPC-style `/api/docs` (Q3); falls back to mock data when the data agent's API is not yet up.
- BroadcastChannel `m3e:home:v1` (Q9) so HOME can flag docs already open in a viewer tab.
- Viewer toolbar gains a 🏠 Home button (left of hamburger) and `exitScope` at root jumps to HOME (Q6).
- `beta/src/shared/home_types.ts` drafted as the co-owned DTO contract (Q7) — needs data review.
- New `beta/tsconfig.home.json` so home.ts globals don't collide with viewer.ts.

All decisions in `reviews/HOME Re-implementation` (Q1–Q10) are honored:
- Q1 thumbnail deferred to v2 — DOM slot reserved.
- Q2 trash via archived flag, restore + hard-delete (only when archived) supported.
- Q4 stats parsed at list time (UI just consumes nodeCount/charCount).
- Q5 tags stored on documents row (UI consumes `tags: string[]`).
- Q8 errors expected as `{ ok:false, error:{ code, message, details? } }`.
- Q10 JA hardcoded, all strings centralized in a `JA` constants object for easy v2 i18n.

## Hand-off to data
The HOME UI now expects:
- `GET /api/docs`
- `POST /api/docs/new`, `/:id/duplicate`, `/:id/rename`, `/:id/archive`, `/:id/restore`, `/:id/tags`
- `DELETE /api/docs/:id` (only when archived)

Until those land the page renders mock rows (visibly labeled "(モック)") so the UX is reviewable.

## Test plan
- [x] `npx tsc -p tsconfig.browser.json` clean
- [x] `npx tsc -p tsconfig.home.json` clean
- [x] `npx tsc -p tsconfig.node.json` clean
- [ ] Manual: open `beta/home.html`, verify mock list renders, search/toggle/actions work
- [ ] Manual: open `beta/viewer.html?localDocId=akaghef-beta`, verify 🏠 button + Backspace at root → HOME
- [ ] Manual: open viewer + HOME in two tabs, verify "📖 開いてる" badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)