### PR TITLE
data: HOME page document management API

### DIFF
--- a/beta/src/node/rapid_mvp.ts
+++ b/beta/src/node/rapid_mvp.ts
@@ -12,6 +12,30 @@ type SqliteDocumentRow = {
   stateJson: string;
 };
 
+type SqliteDocumentListRow = {
+  id: string;
+  version: number;
+  savedAt: string;
+  stateJson: string;
+  tags: string | null;
+  archived: number | null;
+};
+
+export interface DocumentSummary {
+  id: string;
+  label: string;
+  savedAt: string;
+  nodeCount: number;
+  charCount: number;
+  tags: string[];
+  archived: boolean;
+}
+
+export interface ListDocumentsOptions {
+  /** When true, archived documents are also returned. Default: false. */
+  includeArchived?: boolean;
+}
+
 class RapidMvpModel {
   state: AppState;
   undoStack: AppState[];
@@ -534,7 +558,220 @@ class RapidMvpModel {
         state_json TEXT NOT NULL
       )
     `);
+
+    // ALTER TABLE migration for HOME page (tags, archived).
+    // SQLite has no IF NOT EXISTS for ADD COLUMN, so we inspect pragma first.
+    const cols = db.prepare(`PRAGMA table_info(documents)`).all() as Array<{ name: string }>;
+    const colNames = new Set(cols.map((c) => c.name));
+    if (!colNames.has("tags")) {
+      db.exec(`ALTER TABLE documents ADD COLUMN tags TEXT`);
+    }
+    if (!colNames.has("archived")) {
+      db.exec(`ALTER TABLE documents ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`);
+    }
+
     return db;
+  }
+
+  // ---------------------------------------------------------------------------
+  // HOME page support: document-level CRUD & metadata
+  // ---------------------------------------------------------------------------
+
+  private static parseTagsColumn(raw: string | null): string[] {
+    if (!raw) return [];
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith("[")) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (Array.isArray(parsed)) {
+          return parsed
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim())
+            .filter((t) => t.length > 0);
+        }
+      } catch {
+        // fall through to comma-split
+      }
+    }
+    return trimmed
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+  }
+
+  private static computeStateMetrics(stateJson: string): { label: string; nodeCount: number; charCount: number } {
+    let label = "Untitled";
+    let nodeCount = 0;
+    let charCount = 0;
+    try {
+      const state = JSON.parse(stateJson) as Partial<AppState>;
+      const nodes = (state?.nodes ?? {}) as Record<string, TreeNode>;
+      const ids = Object.keys(nodes);
+      nodeCount = ids.length;
+      for (const id of ids) {
+        const n = nodes[id]!;
+        charCount += (n.text?.length ?? 0) + (n.details?.length ?? 0) + (n.note?.length ?? 0);
+      }
+      const rootId = state?.rootId;
+      if (rootId && nodes[rootId] && typeof nodes[rootId]!.text === "string") {
+        const t = nodes[rootId]!.text.trim();
+        if (t.length > 0) label = t;
+      }
+    } catch {
+      // Treat as empty document — keep defaults.
+    }
+    return { label, nodeCount, charCount };
+  }
+
+  static listDocuments(dbPath: string, options: ListDocumentsOptions = {}): DocumentSummary[] {
+    const includeArchived = Boolean(options.includeArchived);
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const sql = includeArchived
+        ? `SELECT id, version, saved_at AS savedAt, state_json AS stateJson, tags, archived FROM documents ORDER BY saved_at DESC`
+        : `SELECT id, version, saved_at AS savedAt, state_json AS stateJson, tags, archived FROM documents WHERE COALESCE(archived, 0) = 0 ORDER BY saved_at DESC`;
+      const rows = db.prepare(sql).all() as SqliteDocumentListRow[];
+      return rows.map((row) => {
+        const metrics = RapidMvpModel.computeStateMetrics(row.stateJson);
+        return {
+          id: row.id,
+          label: metrics.label,
+          savedAt: row.savedAt,
+          nodeCount: metrics.nodeCount,
+          charCount: metrics.charCount,
+          tags: RapidMvpModel.parseTagsColumn(row.tags),
+          archived: Number(row.archived ?? 0) === 1,
+        };
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  static documentExists(dbPath: string, documentId: string): boolean {
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const row = db.prepare(`SELECT 1 AS hit FROM documents WHERE id = ?`).get(documentId) as { hit: number } | undefined;
+      return Boolean(row);
+    } finally {
+      db.close();
+    }
+  }
+
+  static createDocument(dbPath: string, documentId: string, rootLabel = "Untitled"): void {
+    if (RapidMvpModel.documentExists(dbPath, documentId)) {
+      throw new Error("Document already exists.");
+    }
+    const model = new RapidMvpModel(rootLabel);
+    model.saveToSqlite(dbPath, documentId);
+  }
+
+  static duplicateDocument(dbPath: string, sourceId: string, newId: string): void {
+    if (RapidMvpModel.documentExists(dbPath, newId)) {
+      throw new Error("Document already exists.");
+    }
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const src = db
+        .prepare(`SELECT version, saved_at AS savedAt, state_json AS stateJson, tags FROM documents WHERE id = ?`)
+        .get(sourceId) as { version: number; savedAt: string; stateJson: string; tags: string | null } | undefined;
+      if (!src) {
+        throw new Error("Document not found.");
+      }
+      db.prepare(
+        `INSERT INTO documents (id, version, saved_at, state_json, tags, archived)
+         VALUES (@id, @version, @savedAt, @stateJson, @tags, 0)`,
+      ).run({
+        id: newId,
+        version: src.version,
+        savedAt: new Date().toISOString(),
+        stateJson: src.stateJson,
+        tags: src.tags,
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  static renameDocument(dbPath: string, documentId: string, newLabel: string): void {
+    const trimmed = newLabel.trim();
+    if (trimmed.length === 0) {
+      throw new Error("Invalid label.");
+    }
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const row = db
+        .prepare(`SELECT version, saved_at AS savedAt, state_json AS stateJson FROM documents WHERE id = ?`)
+        .get(documentId) as SqliteDocumentRow & { savedAt: string } | undefined;
+      if (!row) {
+        throw new Error("Document not found.");
+      }
+      const state = JSON.parse(row.stateJson) as AppState;
+      const root = state?.nodes?.[state.rootId];
+      if (root) {
+        root.text = trimmed;
+      }
+      db.prepare(
+        `UPDATE documents SET state_json = @stateJson, saved_at = @savedAt WHERE id = @id`,
+      ).run({
+        id: documentId,
+        stateJson: JSON.stringify(state),
+        savedAt: new Date().toISOString(),
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  static setDocumentTags(dbPath: string, documentId: string, tags: string[]): void {
+    if (!Array.isArray(tags) || !tags.every((t) => typeof t === "string")) {
+      throw new Error("Invalid tags.");
+    }
+    const cleaned = Array.from(new Set(tags.map((t) => t.trim()).filter((t) => t.length > 0)));
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const result = db
+        .prepare(`UPDATE documents SET tags = ? WHERE id = ?`)
+        .run(JSON.stringify(cleaned), documentId);
+      if (result.changes === 0) {
+        throw new Error("Document not found.");
+      }
+    } finally {
+      db.close();
+    }
+  }
+
+  static setArchived(dbPath: string, documentId: string, archived: boolean): void {
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const result = db
+        .prepare(`UPDATE documents SET archived = ? WHERE id = ?`)
+        .run(archived ? 1 : 0, documentId);
+      if (result.changes === 0) {
+        throw new Error("Document not found.");
+      }
+    } finally {
+      db.close();
+    }
+  }
+
+  static deleteDocument(dbPath: string, documentId: string): void {
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const row = db
+        .prepare(`SELECT COALESCE(archived, 0) AS archived FROM documents WHERE id = ?`)
+        .get(documentId) as { archived: number } | undefined;
+      if (!row) {
+        throw new Error("Document not found.");
+      }
+      if (Number(row.archived) !== 1) {
+        throw new Error("Document is not archived.");
+      }
+      db.prepare(`DELETE FROM documents WHERE id = ?`).run(documentId);
+    } finally {
+      db.close();
+    }
   }
 
   saveToFile(filePath: string): void {

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -55,6 +55,10 @@ import type {
   FlashApproveRequest,
   FlashDraftStatus,
 } from "../shared/types";
+import type {
+  DocErrorCode,
+  DocSummary,
+} from "../shared/home_types";
 
 // After compilation, this file lives at dist/node/start_viewer.js.
 // ROOT must point two levels up to the mvp/ directory.
@@ -231,6 +235,224 @@ function parseDocId(urlPath: string): string | null {
     return "";
   }
   return decodeURIComponent(raw);
+}
+
+type HomeRouteAction =
+  | { kind: "list" }
+  | { kind: "new" }
+  | { kind: "duplicate"; docId: string }
+  | { kind: "rename"; docId: string }
+  | { kind: "archive"; docId: string }
+  | { kind: "restore"; docId: string }
+  | { kind: "tags"; docId: string }
+  | { kind: "delete"; docId: string };
+
+function parseHomeRoute(urlPath: string, method: string): HomeRouteAction | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+
+  if (pathname === "/api/docs" && method === "GET") {
+    return { kind: "list" };
+  }
+  if (pathname === "/api/docs/new" && method === "POST") {
+    return { kind: "new" };
+  }
+
+  const subMatch = pathname.match(/^\/api\/docs\/([^/]+)\/(duplicate|rename|archive|restore|tags)$/);
+  if (subMatch && method === "POST") {
+    const id = decodeURIComponent(subMatch[1]);
+    const action = subMatch[2] as "duplicate" | "rename" | "archive" | "restore" | "tags";
+    return { kind: action, docId: id };
+  }
+
+  // DELETE /api/docs/:id  (single segment, no sub-path)
+  const idMatch = pathname.match(/^\/api\/docs\/([^/]+)$/);
+  if (idMatch && method === "DELETE") {
+    return { kind: "delete", docId: decodeURIComponent(idMatch[1]) };
+  }
+
+  return null;
+}
+
+function sendHomeError(
+  res: http.ServerResponse,
+  status: number,
+  code: DocErrorCode | string,
+  message: string,
+  details?: unknown,
+): void {
+  const payload: { ok: false; error: { code: string; message: string; details?: unknown } } = {
+    ok: false,
+    error: { code, message },
+  };
+  if (details !== undefined) payload.error.details = details;
+  sendJson(res, status, payload);
+}
+
+function newDocId(): string {
+  return `doc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function handleHomeApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: HomeRouteAction,
+): Promise<boolean> {
+  try {
+    if (route.kind === "list") {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const includeArchived = url.searchParams.get("includeArchived") === "true";
+      const docs = RapidMvpModel.listDocuments(SQLITE_DB_PATH, { includeArchived }) as DocSummary[];
+      sendJson(res, 200, { docs });
+      return true;
+    }
+
+    if (route.kind === "new") {
+      let label: string | undefined;
+      try {
+        const raw = await readRequestBody(req);
+        if (raw.trim().length > 0) {
+          const parsed = JSON.parse(raw) as { label?: unknown };
+          if (parsed && typeof parsed.label === "string") {
+            label = parsed.label.trim();
+          }
+        }
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          sendHomeError(res, 400, "INVALID_BODY", "Invalid JSON body.");
+          return true;
+        }
+        throw err;
+      }
+      if (label !== undefined && label.length === 0) {
+        sendHomeError(res, 400, "INVALID_LABEL", "Label cannot be empty.");
+        return true;
+      }
+      const id = newDocId();
+      RapidMvpModel.createDocument(SQLITE_DB_PATH, id, label && label.length > 0 ? label : "Untitled");
+      sendJson(res, 200, { ok: true, id });
+      return true;
+    }
+
+    if (route.kind === "duplicate") {
+      if (!RapidMvpModel.documentExists(SQLITE_DB_PATH, route.docId)) {
+        sendHomeError(res, 404, "DOC_NOT_FOUND", `Document not found: ${route.docId}`);
+        return true;
+      }
+      const newId = newDocId();
+      RapidMvpModel.duplicateDocument(SQLITE_DB_PATH, route.docId, newId);
+      sendJson(res, 200, { ok: true, id: newId });
+      return true;
+    }
+
+    if (route.kind === "rename") {
+      let label: string;
+      try {
+        const raw = await readRequestBody(req);
+        const parsed = JSON.parse(raw) as { label?: unknown };
+        if (!parsed || typeof parsed.label !== "string") {
+          sendHomeError(res, 400, "INVALID_LABEL", "label (string) is required.");
+          return true;
+        }
+        label = parsed.label;
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          sendHomeError(res, 400, "INVALID_BODY", "Invalid JSON body.");
+          return true;
+        }
+        throw err;
+      }
+      if (label.trim().length === 0) {
+        sendHomeError(res, 400, "INVALID_LABEL", "Label cannot be empty.");
+        return true;
+      }
+      try {
+        RapidMvpModel.renameDocument(SQLITE_DB_PATH, route.docId, label);
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg === "Document not found.") {
+          sendHomeError(res, 404, "DOC_NOT_FOUND", `Document not found: ${route.docId}`);
+          return true;
+        }
+        throw err;
+      }
+      sendJson(res, 200, { ok: true });
+      return true;
+    }
+
+    if (route.kind === "archive" || route.kind === "restore") {
+      try {
+        RapidMvpModel.setArchived(SQLITE_DB_PATH, route.docId, route.kind === "archive");
+      } catch (err) {
+        if ((err as Error).message === "Document not found.") {
+          sendHomeError(res, 404, "DOC_NOT_FOUND", `Document not found: ${route.docId}`);
+          return true;
+        }
+        throw err;
+      }
+      sendJson(res, 200, { ok: true });
+      return true;
+    }
+
+    if (route.kind === "tags") {
+      let tags: string[];
+      try {
+        const raw = await readRequestBody(req);
+        const parsed = JSON.parse(raw) as { tags?: unknown };
+        if (!parsed || !Array.isArray(parsed.tags) || !parsed.tags.every((t) => typeof t === "string")) {
+          sendHomeError(res, 400, "INVALID_TAGS", "tags must be a string[].");
+          return true;
+        }
+        tags = parsed.tags as string[];
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          sendHomeError(res, 400, "INVALID_BODY", "Invalid JSON body.");
+          return true;
+        }
+        throw err;
+      }
+      try {
+        RapidMvpModel.setDocumentTags(SQLITE_DB_PATH, route.docId, tags);
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg === "Document not found.") {
+          sendHomeError(res, 404, "DOC_NOT_FOUND", `Document not found: ${route.docId}`);
+          return true;
+        }
+        if (msg === "Invalid tags.") {
+          sendHomeError(res, 400, "INVALID_TAGS", msg);
+          return true;
+        }
+        throw err;
+      }
+      sendJson(res, 200, { ok: true });
+      return true;
+    }
+
+    if (route.kind === "delete") {
+      try {
+        RapidMvpModel.deleteDocument(SQLITE_DB_PATH, route.docId);
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg === "Document not found.") {
+          sendHomeError(res, 404, "DOC_NOT_FOUND", `Document not found: ${route.docId}`);
+          return true;
+        }
+        if (msg === "Document is not archived.") {
+          sendHomeError(res, 409, "NOT_ARCHIVED", "Document must be archived before delete. Call /archive first.");
+          return true;
+        }
+        throw err;
+      }
+      sendJson(res, 200, { ok: true });
+      return true;
+    }
+
+    sendHomeError(res, 405, "METHOD_NOT_ALLOWED", "Method not allowed.");
+    return true;
+  } catch (err) {
+    sendHomeError(res, 500, "INTERNAL_ERROR", (err as Error).message || "Unknown error.");
+    return true;
+  }
 }
 
 function parseSyncRoute(urlPath: string): { action: "status" | "push" | "pull"; docId: string } | null {
@@ -1229,6 +1451,12 @@ export function createAppServer(): http.Server {
       }
       const list = getPresenceList(presenceDocId);
       sendJson(res, 200, { ok: true, documentId: presenceDocId, count: list.length, users: list });
+      return;
+    }
+
+    const homeRoute = parseHomeRoute(req.url ?? "/", req.method ?? "GET");
+    if (homeRoute) {
+      await handleHomeApi(req, res, homeRoute);
       return;
     }
 

--- a/beta/src/shared/home_types.ts
+++ b/beta/src/shared/home_types.ts
@@ -1,0 +1,91 @@
+"use strict";
+
+/**
+ * Shared types for the HOME page (document list / management).
+ *
+ * Owner: data role. visual imports these read-only.
+ * If visual needs an extension, file a request and let data update this file.
+ *
+ * See dev-docs/03_Spec/REST_API.md "Document Management API" section
+ * and M3E map node "HOME Re-implementation" for the design context.
+ */
+
+/** Summary row returned by `GET /api/docs`. One per document. */
+export interface DocSummary {
+  /** Document id (primary key in the documents table). */
+  id: string;
+  /** Display label — root node's text when available, else id. */
+  label: string;
+  /** ISO-8601 timestamp of the last save. */
+  savedAt: string;
+  /** Total number of nodes in the document (computed from state_json). */
+  nodeCount: number;
+  /** Approx character count across node text/details/note (computed from state_json). */
+  charCount: number;
+  /** Tag list. Empty array if none. */
+  tags: string[];
+  /** True when the doc has been moved to the trash (archived=1). */
+  archived: boolean;
+}
+
+/** Response body of `GET /api/docs`. */
+export interface DocListResponse {
+  docs: DocSummary[];
+}
+
+/** Body for `POST /api/docs/new`. */
+export interface DocNewRequest {
+  /** Optional initial root label. Defaults to "Untitled" when omitted. */
+  label?: string;
+}
+
+/** Response body of `POST /api/docs/new` and `POST /api/docs/:id/duplicate`. */
+export interface DocCreateResponse {
+  ok: true;
+  id: string;
+}
+
+/** Body for `POST /api/docs/:id/rename`. */
+export interface DocRenameRequest {
+  /** New label. Empty / whitespace-only is rejected with INVALID_LABEL. */
+  label: string;
+}
+
+/** Body for `POST /api/docs/:id/tags`. */
+export interface DocTagsRequest {
+  /** Full replacement of the tag list. Each entry is trimmed; empties removed. */
+  tags: string[];
+}
+
+/** Generic success envelope shared by mutation endpoints. */
+export interface DocOkResponse {
+  ok: true;
+}
+
+/**
+ * Structured error envelope used by HOME API endpoints (Q8 = structured/extensible).
+ *
+ * `code` is a stable machine-readable identifier; UI selects messaging from it.
+ * `message` is a human-readable fallback (English; visual may localise via home_i18n).
+ * `details` is optional context (validation errors, conflicting state, etc.).
+ */
+export interface DocErrorResponse {
+  ok: false;
+  error: {
+    code: DocErrorCode | string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+/** Known error codes. Extensible — string union allows future codes. */
+export type DocErrorCode =
+  | "DOC_NOT_FOUND"
+  | "DOC_ALREADY_EXISTS"
+  | "INVALID_LABEL"
+  | "INVALID_TAGS"
+  | "INVALID_BODY"
+  | "NOT_ARCHIVED"
+  | "ALREADY_ARCHIVED"
+  | "METHOD_NOT_ALLOWED"
+  | "INTERNAL_ERROR";

--- a/beta/tests/unit/home_documents.test.js
+++ b/beta/tests/unit/home_documents.test.js
@@ -1,0 +1,113 @@
+import { test, expect } from "vitest";
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+function makeTempDb() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-home-test-"));
+  return path.join(base, "data.sqlite");
+}
+
+test("listDocuments returns empty array for fresh database", () => {
+  const dbPath = makeTempDb();
+  const docs = RapidMvpModel.listDocuments(dbPath);
+  expect(docs).toEqual([]);
+});
+
+test("createDocument + listDocuments returns DocSummary", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "doc-a", "Alpha");
+  const docs = RapidMvpModel.listDocuments(dbPath);
+  expect(docs.length).toBe(1);
+  const d = docs[0];
+  expect(d.id).toBe("doc-a");
+  expect(d.label).toBe("Alpha");
+  expect(d.archived).toBe(false);
+  expect(d.tags).toEqual([]);
+  expect(d.nodeCount).toBeGreaterThan(0);
+  expect(typeof d.charCount).toBe("number");
+  expect(typeof d.savedAt).toBe("string");
+});
+
+test("createDocument throws when id already exists", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "dup", "X");
+  expect(() => RapidMvpModel.createDocument(dbPath, "dup", "Y")).toThrow(/already exists/);
+});
+
+test("renameDocument updates the root node label", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "r", "Old");
+  RapidMvpModel.renameDocument(dbPath, "r", "New Label");
+  const docs = RapidMvpModel.listDocuments(dbPath);
+  expect(docs[0].label).toBe("New Label");
+});
+
+test("renameDocument rejects empty label", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "r", "Old");
+  expect(() => RapidMvpModel.renameDocument(dbPath, "r", "   ")).toThrow(/Invalid label/);
+});
+
+test("setDocumentTags persists and dedupes tags", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "t", "T");
+  RapidMvpModel.setDocumentTags(dbPath, "t", ["alpha", "beta", "alpha", "  ", "gamma"]);
+  const docs = RapidMvpModel.listDocuments(dbPath);
+  expect(docs[0].tags.sort()).toEqual(["alpha", "beta", "gamma"]);
+});
+
+test("archive hides docs from default list and restore brings them back", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "x", "Visible");
+  RapidMvpModel.setArchived(dbPath, "x", true);
+  expect(RapidMvpModel.listDocuments(dbPath).length).toBe(0);
+  expect(RapidMvpModel.listDocuments(dbPath, { includeArchived: true }).length).toBe(1);
+  expect(RapidMvpModel.listDocuments(dbPath, { includeArchived: true })[0].archived).toBe(true);
+  RapidMvpModel.setArchived(dbPath, "x", false);
+  expect(RapidMvpModel.listDocuments(dbPath).length).toBe(1);
+});
+
+test("deleteDocument requires archived state", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "d", "Doomed");
+  expect(() => RapidMvpModel.deleteDocument(dbPath, "d")).toThrow(/not archived/);
+  RapidMvpModel.setArchived(dbPath, "d", true);
+  RapidMvpModel.deleteDocument(dbPath, "d");
+  expect(RapidMvpModel.documentExists(dbPath, "d")).toBe(false);
+});
+
+test("duplicateDocument copies state and tags but assigns new id", () => {
+  const dbPath = makeTempDb();
+  RapidMvpModel.createDocument(dbPath, "src", "Source");
+  RapidMvpModel.setDocumentTags(dbPath, "src", ["work"]);
+  RapidMvpModel.duplicateDocument(dbPath, "src", "dup");
+  const docs = RapidMvpModel.listDocuments(dbPath);
+  const dup = docs.find((d) => d.id === "dup");
+  expect(dup).toBeTruthy();
+  expect(dup.label).toBe("Source");
+  expect(dup.tags).toEqual(["work"]);
+  expect(dup.archived).toBe(false);
+});
+
+test("listDocuments tolerates pre-existing rows without tags/archived columns (migration)", () => {
+  const dbPath = makeTempDb();
+  // First call creates the table with new columns via migration code path.
+  RapidMvpModel.createDocument(dbPath, "legacy", "Legacy");
+  // Manually insert to simulate legacy row with NULL tags/archived.
+  const Database = require("better-sqlite3");
+  const db = new Database(dbPath);
+  db.prepare(
+    "INSERT INTO documents (id, version, saved_at, state_json) VALUES (?, 1, ?, ?)",
+  ).run("legacy2", new Date().toISOString(), JSON.stringify({ rootId: "r1", nodes: { r1: { id: "r1", parentId: null, children: [], text: "L2" } }, links: {} }));
+  db.close();
+
+  const docs = RapidMvpModel.listDocuments(dbPath);
+  const l2 = docs.find((d) => d.id === "legacy2");
+  expect(l2).toBeTruthy();
+  expect(l2.tags).toEqual([]);
+  expect(l2.archived).toBe(false);
+  expect(l2.label).toBe("L2");
+});

--- a/dev-docs/03_Spec/REST_API.md
+++ b/dev-docs/03_Spec/REST_API.md
@@ -24,6 +24,14 @@ M3E_ROOT=C:\Users\chiec\dev\M3E
 
 | メソッド | パス | 概要 | 参照先 |
 |----------|------|------|--------|
+| `GET` | `/api/docs` | ドキュメント一覧（HOME） | 本文書 |
+| `POST` | `/api/docs/new` | ドキュメント新規作成 | 本文書 |
+| `POST` | `/api/docs/{docId}/duplicate` | ドキュメント複製 | 本文書 |
+| `POST` | `/api/docs/{docId}/rename` | ルートラベル変更 | 本文書 |
+| `POST` | `/api/docs/{docId}/archive` | ゴミ箱へ移動 | 本文書 |
+| `POST` | `/api/docs/{docId}/restore` | ゴミ箱から復元 | 本文書 |
+| `POST` | `/api/docs/{docId}/tags` | タグ更新 | 本文書 |
+| `DELETE` | `/api/docs/{docId}` | 物理削除（archived のみ） | 本文書 |
 | `GET` | `/api/docs/{docId}` | ドキュメント読み込み | 本文書 |
 | `POST` | `/api/docs/{docId}` | ドキュメント保存 | 本文書 |
 | `GET` | `/api/sync/status/{docId}` | クラウド同期ステータス | 本文書 |
@@ -41,6 +49,139 @@ M3E_ROOT=C:\Users\chiec\dev\M3E
 | `POST` | `/api/flash/draft/{id}/approve` | Flash ドラフト承認 | 本文書 |
 | `DELETE` | `/api/flash/draft/{id}` | Flash ドラフト破棄 | 本文書 |
 | `GET` | `/{path}` | 静的ファイル配信 | — |
+
+---
+
+## Document Management API (HOME)
+
+HOME ページ（一覧 / 新規 / 複製 / 改名 / タグ / アーカイブ / 削除）を支えるドキュメント単位の管理 API。
+個々のドキュメント本文（state）の読み書きは下の Document API を引き続き使う。
+
+DTO 定義は `beta/src/shared/home_types.ts` にある。所有者は data ロール、visual はインポート専用。
+
+### エラー契約
+
+すべての本セクション API は失敗時に下記の構造化エラーを返す（HTTP ステータスコードは 400/404/409/500 のいずれか）。
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "DOC_NOT_FOUND",
+    "message": "Document not found: foo",
+    "details": null
+  }
+}
+```
+
+主な `code`:
+
+- `DOC_NOT_FOUND` (404): 指定 `docId` の行が存在しない
+- `DOC_ALREADY_EXISTS` (409): 新規/複製先 id が既存
+- `INVALID_LABEL` (400): label が空または空白のみ
+- `INVALID_TAGS` (400): tags が string[] でない
+- `INVALID_BODY` (400): JSON パース失敗
+- `NOT_ARCHIVED` (409): 物理削除を archived=0 の doc に対して呼んだ
+- `METHOD_NOT_ALLOWED` (405)
+- `INTERNAL_ERROR` (500)
+
+### `GET /api/docs`
+
+ドキュメント一覧を返す。
+
+クエリパラメータ:
+
+- `includeArchived` (boolean, 任意): `true` でゴミ箱（archived=1）も含む。既定は `false`
+
+成功レスポンス (200):
+
+```json
+{
+  "docs": [
+    {
+      "id": "doc_1234_abcdef",
+      "label": "Research notes",
+      "savedAt": "2026-04-14T11:29:23.052Z",
+      "nodeCount": 42,
+      "charCount": 1830,
+      "tags": ["work", "draft"],
+      "archived": false
+    }
+  ]
+}
+```
+
+`label` はルートノードの text、`nodeCount` / `charCount` は state_json をパースして集計する。
+
+### `POST /api/docs/new`
+
+新規ドキュメントを作成する。
+
+リクエストボディ（任意）:
+
+```json
+{ "label": "新規メモ" }
+```
+
+`label` を省略すると `"Untitled"` が使われる。
+
+成功レスポンス (200):
+
+```json
+{ "ok": true, "id": "doc_1234_abcdef" }
+```
+
+### `POST /api/docs/{docId}/duplicate`
+
+`docId` のドキュメントを複製し、新しい id を返す。state と tags はコピー、archived は 0、savedAt は現在時刻。
+
+成功レスポンス (200):
+
+```json
+{ "ok": true, "id": "doc_5678_xyz123" }
+```
+
+### `POST /api/docs/{docId}/rename`
+
+ドキュメントのルートノード text を更新する（HOME 一覧上のラベルと一致）。
+
+リクエストボディ:
+
+```json
+{ "label": "新しい名前" }
+```
+
+成功レスポンス (200): `{ "ok": true }`
+
+### `POST /api/docs/{docId}/archive`
+
+ドキュメントをゴミ箱に移動（archived=1）。一覧の既定からは消えるが state は保持される。
+
+成功レスポンス (200): `{ "ok": true }`
+
+### `POST /api/docs/{docId}/restore`
+
+ゴミ箱から復元（archived=0）。
+
+成功レスポンス (200): `{ "ok": true }`
+
+### `POST /api/docs/{docId}/tags`
+
+タグを完全置換する。重複・空白文字列は除去。
+
+リクエストボディ:
+
+```json
+{ "tags": ["work", "draft"] }
+```
+
+成功レスポンス (200): `{ "ok": true }`
+
+### `DELETE /api/docs/{docId}`
+
+物理削除。**archived=1 のドキュメントに対してのみ許可**。それ以外は `409 NOT_ARCHIVED` を返す。
+
+成功レスポンス (200): `{ "ok": true }`
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds backend for HOME re-implementation: list / new / duplicate / rename / archive / restore / tags / delete endpoints under `/api/docs/...`
- Schema migration via `ALTER TABLE` adds `tags TEXT` and `archived INTEGER DEFAULT 0` columns; existing rows tolerated (NULL coerced to defaults)
- New shared DTO file `beta/src/shared/home_types.ts` (data-owned, visual imports read-only) with `DocSummary` and structured `DocErrorResponse` (Q8 contract)
- DELETE only succeeds when `archived=1` (otherwise 409 `NOT_ARCHIVED`)
- REST_API.md updated with full endpoint reference + error-code table

## Files
- `beta/src/shared/home_types.ts` (new)
- `beta/src/node/rapid_mvp.ts` (migration + 7 static management methods)
- `beta/src/node/start_viewer.ts` (`parseHomeRoute` + `handleHomeApi`)
- `beta/tests/unit/home_documents.test.js` (10 tests)
- `dev-docs/03_Spec/REST_API.md`

## Test plan
- [x] `npx tsc -p tsconfig.node.json --noEmit` clean
- [x] `npx vitest run tests/unit/home_documents.test.js` — 10/10 pass
- [x] Full vitest suite — only 3 pre-existing failures (unrelated: persistence_db_behavior + backup filename format), no new regressions
- [ ] visual side can drop their mock and hit the real API once merged

## Notes for visual
- DTOs live at `beta/src/shared/home_types.ts` — please import rather than redefine
- Error envelope shape: `{ ok: false, error: { code, message, details? } }`
- `GET /api/docs?includeArchived=true` to render the trash view

🤖 Generated with [Claude Code](https://claude.com/claude-code)