### PR TITLE
fix(viewer): auto-fit zoom on enter/exit scope

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -948,6 +948,11 @@ function enterScope(scopeNodeId: string): boolean {
   setSingleSelection(node.id, false);
   render();
   fitDocument();
+  // Re-fit on next frame in case surrounding UI (breadcrumb/scope bar) reflowed
+  // and board dimensions shifted after the scope change.
+  requestAnimationFrame(() => {
+    fitDocument();
+  });
   setStatus(`Entered scope: ${uiLabel(node)}`);
   board.focus();
   return true;
@@ -979,6 +984,11 @@ function exitScope(): boolean {
   setSingleSelection(scopeRoot.parentId && doc.state.nodes[scopeRoot.parentId] ? scopeRoot.parentId : nextScopeId, false);
   render();
   fitDocument();
+  // Re-fit on next frame in case surrounding UI (breadcrumb/scope bar) reflowed
+  // and board dimensions shifted after the scope change.
+  requestAnimationFrame(() => {
+    fitDocument();
+  });
   setStatus("Returned to parent scope.");
   board.focus();
   return true;


### PR DESCRIPTION
## 概要
スコープ遷移時にズームが前の状態のまま残り、手動の fit ショートカット (Ctrl+0 / Alt+V) を押す必要があった問題を修正。

## 変更内容
- `beta/src/browser/viewer.ts`:
  - `enterScope` / `exitScope` 内で `fitDocument()` を呼んだ直後に `requestAnimationFrame` 経由でもう一度 `fitDocument()` を実行
  - スコープ変更に伴って breadcrumb / scope bar などの周辺 UI がリフローし、board の `getBoundingClientRect` が次フレームまで安定しないため、初回の fit が古い rect で計算されて視覚上 zoom が変わらないケースがあった
  - 2 段階 fit にすることで、初回レイアウトが確定しているパス（既存の挙動）と、UI リフローが挟まるパスの両方で期待どおり auto-fit する

## Acceptance
- [x] enterScope 後、新しいスコープのサブツリーに自動 fit
- [x] exitScope 後、親/ルートビューに自動 fit
- [x] 手動 fit ショートカット (Ctrl+0, Alt+V) は影響なし
- [x] 初期ロードパスは `fitDocument()` 既存の呼び出し経路のままで未変更

## テスト
- [x] `tsc -p tsconfig.browser.json --noEmit` 通過
- [x] `npm run test:unit` — viewer 関連ユニット通過（既存の dist 依存系 4 件失敗はベースライン同一・本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)