### PR TITLE
data2: add scope param to /api/docs/{docId} for subtree access

### DIFF
--- a/beta/src/node/rapid_mvp.ts
+++ b/beta/src/node/rapid_mvp.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 import Database from "better-sqlite3";
 import type { TreeNode, AppState, SavedDoc, AliasAccess, GraphLink, LinkDirection, LinkStyle } from "../shared/types";
+import type { ScopedReadResult, ScopedWriteResult } from "../shared/scope_types";
 
 type SqliteDatabase = InstanceType<typeof Database>;
 
@@ -772,6 +773,318 @@ class RapidMvpModel {
     } finally {
       db.close();
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scoped read / write (agent subtree access)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Collect all node ids in the subtree rooted at `scopeId`, limited to
+   * `depth` levels (0 = scope only, undefined = unlimited).
+   */
+  static collectSubtreeIds(
+    state: AppState,
+    scopeId: string,
+    depth: number | undefined,
+  ): string[] | null {
+    if (!state.nodes[scopeId]) {
+      return null;
+    }
+    const maxDepth = depth === undefined ? Infinity : Math.max(0, Math.floor(depth));
+    const ids: string[] = [];
+    const stack: Array<{ id: string; d: number }> = [{ id: scopeId, d: 0 }];
+    while (stack.length > 0) {
+      const { id, d } = stack.pop()!;
+      const node = state.nodes[id];
+      if (!node) continue;
+      ids.push(id);
+      if (d >= maxDepth) continue;
+      for (let i = node.children.length - 1; i >= 0; i -= 1) {
+        stack.push({ id: node.children[i]!, d: d + 1 });
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * Build a SavedDoc containing only the subtree rooted at `scopeId`.
+   * Links are included only when BOTH endpoints are inside the subtree.
+   */
+  static readScopedState(
+    dbPath: string,
+    documentId: string,
+    scopeId: string,
+    depth?: number,
+  ): ScopedReadResult {
+    let model: RapidMvpModel;
+    try {
+      model = RapidMvpModel.loadFromSqlite(dbPath, documentId);
+    } catch (err) {
+      // bubble as standard error — callers distinguish doc-not-found at the handler level
+      throw err;
+    }
+
+    const state = model.toJSON();
+    const ids = RapidMvpModel.collectSubtreeIds(state, scopeId, depth);
+    if (!ids) {
+      return {
+        ok: false,
+        error: {
+          code: "SCOPE_NOT_FOUND",
+          message: `Scope node not found in document: ${scopeId}`,
+          details: { documentId, scopeId },
+        },
+      };
+    }
+    const idSet = new Set(ids);
+    const subNodes: Record<string, TreeNode> = {};
+    for (const id of ids) {
+      const src = state.nodes[id]!;
+      // Deep clone and — for the scope root — detach parent/children above depth limit
+      const clone: TreeNode = JSON.parse(JSON.stringify(src));
+      if (id === scopeId) {
+        clone.parentId = null;
+      }
+      // Filter children to those actually present in the subtree slice
+      clone.children = clone.children.filter((c) => idSet.has(c));
+      subNodes[id] = clone;
+    }
+
+    const subLinks: Record<string, GraphLink> = {};
+    const srcLinks = state.links ?? {};
+    for (const [linkId, link] of Object.entries(srcLinks)) {
+      if (idSet.has(link.sourceNodeId) && idSet.has(link.targetNodeId)) {
+        subLinks[linkId] = { ...link };
+      }
+    }
+
+    const doc: SavedDoc = {
+      version: 1,
+      savedAt: new Date().toISOString(),
+      state: {
+        rootId: scopeId,
+        nodes: subNodes,
+        links: subLinks,
+      },
+    };
+    return { ok: true, doc, nodeCount: ids.length };
+  }
+
+  /**
+   * Replace only the subtree rooted at `scopeId` within `documentId`.
+   *
+   * Validation rules (conservative):
+   *   - scopeId must exist in the stored doc
+   *   - incomingState.rootId must equal scopeId
+   *   - incomingState.nodes[scopeId] must exist
+   *   - every child reference inside incoming nodes must also be inside
+   *     incomingState.nodes (no references escaping the subtree)
+   *   - every parentId (except the scope root's own) must also be inside
+   *     incomingState.nodes — scope root's parentId is ignored and the
+   *     stored parent is preserved
+   *   - incoming links may only reference nodes inside the subtree
+   *
+   * On success, nodes outside the subtree are preserved unchanged; nodes
+   * inside the old subtree are removed and replaced by the new subtree,
+   * and links wholly inside the old subtree are removed and replaced by
+   * the new links.
+   */
+  static writeScopedState(
+    dbPath: string,
+    documentId: string,
+    scopeId: string,
+    incomingState: AppState,
+  ): ScopedWriteResult {
+    const model = RapidMvpModel.loadFromSqlite(dbPath, documentId);
+    const stored = model.toJSON();
+
+    if (!stored.nodes[scopeId]) {
+      return {
+        ok: false,
+        error: {
+          code: "SCOPE_NOT_FOUND",
+          message: `Scope node not found in document: ${scopeId}`,
+          details: { documentId, scopeId },
+        },
+      };
+    }
+
+    if (!incomingState || typeof incomingState !== "object") {
+      return {
+        ok: false,
+        error: { code: "SCOPE_INVALID", message: "Missing or invalid incoming state." },
+      };
+    }
+
+    if (incomingState.rootId !== scopeId) {
+      return {
+        ok: false,
+        error: {
+          code: "SCOPE_WRITE_ROOT_MISMATCH",
+          message: `Incoming state.rootId (${incomingState.rootId}) must equal scope (${scopeId}).`,
+        },
+      };
+    }
+
+    const incomingNodes = incomingState.nodes ?? {};
+    const incomingIds = new Set(Object.keys(incomingNodes));
+    if (!incomingNodes[scopeId]) {
+      return {
+        ok: false,
+        error: { code: "SCOPE_INVALID", message: `Incoming nodes missing scope root: ${scopeId}` },
+      };
+    }
+
+    // Disallow references outside the incoming subtree
+    for (const [id, node] of Object.entries(incomingNodes)) {
+      for (const childId of node.children ?? []) {
+        if (!incomingIds.has(childId)) {
+          return {
+            ok: false,
+            error: {
+              code: "SCOPE_WRITE_OUTSIDE_REFERENCE",
+              message: `Node ${id} references child outside subtree: ${childId}`,
+              details: { nodeId: id, childId },
+            },
+          };
+        }
+      }
+      if (id !== scopeId) {
+        if (node.parentId === null || node.parentId === undefined) {
+          return {
+            ok: false,
+            error: {
+              code: "SCOPE_WRITE_OUTSIDE_REFERENCE",
+              message: `Non-root node ${id} must have a parent within the subtree.`,
+              details: { nodeId: id },
+            },
+          };
+        }
+        if (!incomingIds.has(node.parentId)) {
+          return {
+            ok: false,
+            error: {
+              code: "SCOPE_WRITE_OUTSIDE_REFERENCE",
+              message: `Node ${id} references parent outside subtree: ${node.parentId}`,
+              details: { nodeId: id, parentId: node.parentId },
+            },
+          };
+        }
+      }
+    }
+
+    // Links inside the incoming subtree — reject any that reference outside
+    const incomingLinks = incomingState.links ?? {};
+    for (const [linkId, link] of Object.entries(incomingLinks)) {
+      if (!incomingIds.has(link.sourceNodeId) || !incomingIds.has(link.targetNodeId)) {
+        return {
+          ok: false,
+          error: {
+            code: "SCOPE_WRITE_OUTSIDE_REFERENCE",
+            message: `Link ${linkId} references node outside subtree.`,
+            details: { linkId },
+          },
+        };
+      }
+    }
+
+    // Compute the old subtree under scope (full subtree, no depth limit)
+    const oldIds = RapidMvpModel.collectSubtreeIds(stored, scopeId, undefined)!;
+    const oldIdSet = new Set(oldIds);
+
+    // Detect collisions: incoming nodes (other than scopeId) whose ids already
+    // exist OUTSIDE the old subtree would corrupt the doc — reject.
+    for (const id of incomingIds) {
+      if (id === scopeId) continue;
+      if (stored.nodes[id] && !oldIdSet.has(id)) {
+        return {
+          ok: false,
+          error: {
+            code: "SCOPE_WRITE_OUTSIDE_REFERENCE",
+            message: `Incoming node id collides with existing node outside subtree: ${id}`,
+            details: { nodeId: id },
+          },
+        };
+      }
+    }
+
+    // Build merged state:
+    //   - keep stored nodes outside the old subtree
+    //   - swap in incoming nodes for the subtree
+    //   - preserve scope root's original parentId (reject attempts to mutate it)
+    const storedScope = stored.nodes[scopeId]!;
+    const incomingScope = incomingNodes[scopeId]!;
+    if (
+      incomingScope.parentId !== undefined &&
+      incomingScope.parentId !== null &&
+      incomingScope.parentId !== storedScope.parentId
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "SCOPE_WRITE_PARENT_MUTATION",
+          message: `Cannot mutate scope root's parent. Expected ${storedScope.parentId}, got ${incomingScope.parentId}.`,
+          details: { expected: storedScope.parentId, received: incomingScope.parentId },
+        },
+      };
+    }
+
+    const mergedNodes: Record<string, TreeNode> = {};
+    for (const [id, node] of Object.entries(stored.nodes)) {
+      if (!oldIdSet.has(id)) {
+        mergedNodes[id] = node;
+      }
+    }
+    for (const [id, node] of Object.entries(incomingNodes)) {
+      const clone: TreeNode = JSON.parse(JSON.stringify(node));
+      if (id === scopeId) {
+        clone.parentId = storedScope.parentId;
+      }
+      mergedNodes[id] = clone;
+    }
+
+    // Links: drop any stored link that touches the old subtree (source or target
+    // inside), because those endpoints may no longer exist after replacement.
+    // The caller is expected to re-create cross-subtree links from outside.
+    const mergedLinks: Record<string, GraphLink> = {};
+    const srcLinks = stored.links ?? {};
+    for (const [linkId, link] of Object.entries(srcLinks)) {
+      const touchesOld = oldIdSet.has(link.sourceNodeId) || oldIdSet.has(link.targetNodeId);
+      if (!touchesOld) {
+        mergedLinks[linkId] = link;
+      }
+    }
+    for (const [linkId, link] of Object.entries(incomingLinks)) {
+      mergedLinks[linkId] = link;
+    }
+
+    const mergedState: AppState = {
+      ...stored,
+      rootId: stored.rootId,
+      nodes: mergedNodes,
+      links: mergedLinks,
+    };
+
+    const mergedModel = RapidMvpModel.fromJSON(mergedState);
+    const errors = mergedModel.validate();
+    if (errors.length > 0) {
+      return {
+        ok: false,
+        error: {
+          code: "SCOPE_INVALID",
+          message: `Invalid model after scoped write: ${errors.join(" | ")}`,
+          details: { errors },
+        },
+      };
+    }
+
+    mergedModel.saveToSqlite(dbPath, documentId);
+    return {
+      ok: true,
+      savedAt: new Date().toISOString(),
+      replacedNodeCount: incomingIds.size,
+    };
   }
 
   saveToFile(filePath: string): void {

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -745,8 +745,43 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse, do
     return true;
   }
 
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const scopeParam = url.searchParams.get("scope");
+  const depthParam = url.searchParams.get("depth");
+
   if (req.method === "GET") {
     try {
+      if (scopeParam && scopeParam.trim().length > 0) {
+        const scopeId = scopeParam.trim();
+        let depth: number | undefined;
+        if (depthParam !== null) {
+          const n = Number(depthParam);
+          if (!Number.isFinite(n) || n < 0) {
+            sendJson(res, 400, {
+              ok: false,
+              error: { code: "SCOPE_INVALID", message: `Invalid depth parameter: ${depthParam}` },
+            });
+            return true;
+          }
+          depth = Math.floor(n);
+        }
+        const result = RapidMvpModel.readScopedState(SQLITE_DB_PATH, docId, scopeId, depth);
+        if (!result.ok) {
+          sendJson(res, 404, { ok: false, error: result.error });
+          return true;
+        }
+        sendJson(res, 200, {
+          version: result.doc.version,
+          savedAt: result.doc.savedAt,
+          state: result.doc.state,
+          scope: {
+            rootId: scopeId,
+            depth: depth === undefined ? null : depth,
+            nodeCount: result.nodeCount,
+          },
+        });
+        return true;
+      }
       const model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, docId);
       sendJson(res, 200, {
         version: 1,
@@ -782,6 +817,31 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse, do
       const nodesObj = (candidate.state as Record<string, unknown>).nodes;
       if (typeof nodesObj === "object" && nodesObj !== null && Object.keys(nodesObj).length === 0) {
         sendJson(res, 400, { error: "State contains no nodes — refusing to save empty document." });
+        return true;
+      }
+
+      // Scoped write: only replace the subtree rooted at scope.
+      if (scopeParam && scopeParam.trim().length > 0) {
+        const scopeId = scopeParam.trim();
+        const result = RapidMvpModel.writeScopedState(
+          SQLITE_DB_PATH,
+          docId,
+          scopeId,
+          candidate.state as never,
+        );
+        if (!result.ok) {
+          const status = result.error.code === "SCOPE_NOT_FOUND" ? 404 : 400;
+          sendJson(res, status, { ok: false, error: result.error });
+          return true;
+        }
+        const sourceTabId = (req.headers["x-m3e-tab-id"] as string) || null;
+        broadcastDocUpdate(docId, result.savedAt, sourceTabId);
+        sendJson(res, 200, {
+          ok: true,
+          savedAt: result.savedAt,
+          documentId: docId,
+          scope: { rootId: scopeId, replacedNodeCount: result.replacedNodeCount },
+        });
         return true;
       }
 

--- a/beta/src/shared/scope_types.ts
+++ b/beta/src/shared/scope_types.ts
@@ -1,0 +1,83 @@
+import type { AppState, SavedDoc } from "./types";
+
+/**
+ * Structured error returned for scope-related failures on /api/docs/{docId}.
+ *
+ * Shape follows the HOME-API convention:
+ *   { ok: false, error: { code, message, details? } }
+ */
+export type ScopeErrorCode =
+  | "SCOPE_NOT_FOUND"
+  | "SCOPE_INVALID"
+  | "SCOPE_WRITE_ROOT_MISMATCH"
+  | "SCOPE_WRITE_OUTSIDE_REFERENCE"
+  | "SCOPE_WRITE_PARENT_MUTATION";
+
+export interface ScopeErrorPayload {
+  ok: false;
+  error: {
+    code: ScopeErrorCode;
+    message: string;
+    details?: unknown;
+  };
+}
+
+/**
+ * Options for readScopedState.
+ *
+ *  - scopeId: node id that will become the root of the returned subtree.
+ *  - depth:   0 = scope node only (no children); N>0 = descend N levels;
+ *             undefined = unlimited (full subtree).
+ */
+export interface ReadScopedOptions {
+  scopeId: string;
+  depth?: number;
+}
+
+/**
+ * Options for writeScopedState.
+ *
+ * The request body is expected to contain an AppState-shaped `state`
+ * where `rootId` equals `scopeId` and `nodes[scopeId]` exists.
+ *
+ * Any node referenced by `nodes[*].children` or `nodes[*].parentId`
+ * (other than the scope's own parent) must live inside the incoming
+ * subtree — references to nodes outside the scope are rejected.
+ */
+export interface WriteScopedOptions {
+  scopeId: string;
+  incomingState: AppState;
+}
+
+/** Successful scoped GET response body. */
+export interface ScopedReadResponse {
+  version: number;
+  savedAt: string;
+  state: AppState;
+  /** Echoed back so clients can confirm what scope was used. */
+  scope: {
+    rootId: string;
+    depth: number | null;
+    nodeCount: number;
+  };
+}
+
+/** Successful scoped POST response body. */
+export interface ScopedWriteResponse {
+  ok: true;
+  savedAt: string;
+  documentId: string;
+  scope: {
+    rootId: string;
+    replacedNodeCount: number;
+  };
+}
+
+/** Internal result type for readScopedState / writeScopedState helpers. */
+export type ScopedReadResult =
+  | { ok: true; doc: SavedDoc; nodeCount: number }
+  | { ok: false; error: ScopeErrorPayload["error"] };
+
+export type ScopedWriteResult =
+  | { ok: true; savedAt: string; replacedNodeCount: number }
+  | { ok: false; error: ScopeErrorPayload["error"] };

--- a/beta/tests/unit/scope_param.test.js
+++ b/beta/tests/unit/scope_param.test.js
@@ -1,0 +1,182 @@
+import { test, expect } from "vitest";
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+function makeTempDb() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-scope-test-"));
+  return path.join(base, "data.sqlite");
+}
+
+/**
+ * Build a doc:
+ *     root
+ *     ├── A
+ *     │   ├── A1
+ *     │   └── A2
+ *     └── B
+ *         └── B1
+ * with a link A1 <-> B1 (crosses subtrees), and a link A1 <-> A2 (inside A).
+ */
+function seedDoc(dbPath, docId) {
+  const model = new RapidMvpModel("root");
+  const rootId = model.state.rootId;
+  const a = model.addNode(rootId, "A");
+  const a1 = model.addNode(a, "A1");
+  const a2 = model.addNode(a, "A2");
+  const b = model.addNode(rootId, "B");
+  const b1 = model.addNode(b, "B1");
+  model.addLink(a1, a2, { label: "inside-A" });
+  model.addLink(a1, b1, { label: "cross-subtree" });
+  model.saveToSqlite(dbPath, docId);
+  return { rootId, a, a1, a2, b, b1 };
+}
+
+test("readScopedState returns subtree rooted at scope", () => {
+  const dbPath = makeTempDb();
+  const ids = seedDoc(dbPath, "d1");
+  const result = RapidMvpModel.readScopedState(dbPath, "d1", ids.a);
+  expect(result.ok).toBe(true);
+  expect(result.doc.state.rootId).toBe(ids.a);
+  expect(Object.keys(result.doc.state.nodes).sort()).toEqual([ids.a, ids.a1, ids.a2].sort());
+  expect(result.doc.state.nodes[ids.a].parentId).toBe(null);
+  expect(result.nodeCount).toBe(3);
+});
+
+test("readScopedState excludes links crossing subtree boundary", () => {
+  const dbPath = makeTempDb();
+  const ids = seedDoc(dbPath, "d1");
+  const result = RapidMvpModel.readScopedState(dbPath, "d1", ids.a);
+  expect(result.ok).toBe(true);
+  const links = Object.values(result.doc.state.links ?? {});
+  expect(links.length).toBe(1);
+  expect(links[0].label).toBe("inside-A");
+});
+
+test("readScopedState depth=0 returns only the scope node", () => {
+  const dbPath = makeTempDb();
+  const ids = seedDoc(dbPath, "d1");
+  const result = RapidMvpModel.readScopedState(dbPath, "d1", ids.a, 0);
+  expect(result.ok).toBe(true);
+  expect(Object.keys(result.doc.state.nodes)).toEqual([ids.a]);
+  expect(result.doc.state.nodes[ids.a].children).toEqual([]);
+});
+
+test("readScopedState returns SCOPE_NOT_FOUND for missing scope", () => {
+  const dbPath = makeTempDb();
+  seedDoc(dbPath, "d1");
+  const result = RapidMvpModel.readScopedState(dbPath, "d1", "no-such-id");
+  expect(result.ok).toBe(false);
+  expect(result.error.code).toBe("SCOPE_NOT_FOUND");
+});
+
+test("writeScopedState replaces only the subtree and preserves outside nodes", () => {
+  const dbPath = makeTempDb();
+  const ids = seedDoc(dbPath, "d1");
+
+  // Build a new subtree under A:  A -> A_new
+  const newSubtree = {
+    rootId: ids.a,
+    nodes: {
+      [ids.a]: {
+        id: ids.a,
+        parentId: ids.rootId, // caller may echo; server preserves stored parent anyway
+        children: ["a_new"],
+        nodeType: "text",
+        text: "A-updated",
+        collapsed: false,
+        details: "",
+        note: "",
+        attributes: {},
+        link: "",
+      },
+      a_new: {
+        id: "a_new",
+        parentId: ids.a,
+        children: [],
+        nodeType: "text",
+        text: "fresh child",
+        collapsed: false,
+        details: "",
+        note: "",
+        attributes: {},
+        link: "",
+      },
+    },
+    links: {},
+  };
+
+  const result = RapidMvpModel.writeScopedState(dbPath, "d1", ids.a, newSubtree);
+  expect(result.ok).toBe(true);
+  expect(result.replacedNodeCount).toBe(2);
+
+  // Reload — verify outside nodes preserved, subtree replaced
+  const reloaded = RapidMvpModel.loadFromSqlite(dbPath, "d1");
+  const state = reloaded.toJSON();
+  expect(state.rootId).toBe(ids.rootId);
+  expect(state.nodes[ids.b]).toBeTruthy();
+  expect(state.nodes[ids.b1]).toBeTruthy();
+  expect(state.nodes[ids.a].text).toBe("A-updated");
+  expect(state.nodes[ids.a].parentId).toBe(ids.rootId); // preserved
+  expect(state.nodes[ids.a].children).toEqual(["a_new"]);
+  expect(state.nodes["a_new"]).toBeTruthy();
+  // Old A1/A2 are gone
+  expect(state.nodes[ids.a1]).toBeUndefined();
+  expect(state.nodes[ids.a2]).toBeUndefined();
+
+  // Cross-subtree link (A1<->B1) is removed because A1 is gone; validate() would fail otherwise.
+  // Inside-A link (A1<->A2) is removed because the old subtree was replaced.
+  const linkLabels = Object.values(state.links ?? {}).map((l) => l.label);
+  expect(linkLabels).not.toContain("inside-A");
+  expect(linkLabels).not.toContain("cross-subtree");
+});
+
+test("writeScopedState rejects incoming rootId mismatch", () => {
+  const dbPath = makeTempDb();
+  const ids = seedDoc(dbPath, "d1");
+  const bad = {
+    rootId: "some-other-id",
+    nodes: {},
+    links: {},
+  };
+  const result = RapidMvpModel.writeScopedState(dbPath, "d1", ids.a, bad);
+  expect(result.ok).toBe(false);
+  expect(result.error.code).toBe("SCOPE_WRITE_ROOT_MISMATCH");
+});
+
+test("writeScopedState rejects references to nodes outside subtree", () => {
+  const dbPath = makeTempDb();
+  const ids = seedDoc(dbPath, "d1");
+  const bad = {
+    rootId: ids.a,
+    nodes: {
+      [ids.a]: {
+        id: ids.a,
+        parentId: ids.rootId,
+        children: [ids.b1], // b1 lives outside subtree
+        nodeType: "text",
+        text: "A",
+        collapsed: false,
+        details: "",
+        note: "",
+        attributes: {},
+        link: "",
+      },
+    },
+    links: {},
+  };
+  const result = RapidMvpModel.writeScopedState(dbPath, "d1", ids.a, bad);
+  expect(result.ok).toBe(false);
+  expect(result.error.code).toBe("SCOPE_WRITE_OUTSIDE_REFERENCE");
+});
+
+test("writeScopedState returns SCOPE_NOT_FOUND when scope missing", () => {
+  const dbPath = makeTempDb();
+  seedDoc(dbPath, "d1");
+  const body = { rootId: "ghost", nodes: { ghost: {} }, links: {} };
+  const result = RapidMvpModel.writeScopedState(dbPath, "d1", "ghost", body);
+  expect(result.ok).toBe(false);
+  expect(result.error.code).toBe("SCOPE_NOT_FOUND");
+});

--- a/dev-docs/03_Spec/REST_API.md
+++ b/dev-docs/03_Spec/REST_API.md
@@ -295,6 +295,140 @@ Body:
 - ツリーの循環検出（DFS）
 - 孤立ノードの検出
 
+### Scope parameter (`scope=<nodeId>`)
+
+`GET` と `POST` の両方に対して、クエリパラメータ `scope` を指定することで
+ドキュメント全体ではなく **`scope` ノードを root とする部分木（subtree）** に
+対する読み書きへ切り替えられる。
+
+主なユースケースは AI エージェントや人間が「対象のノード ID をコピペして
+部分木だけをやり取りする」ワークフロー。`scope` を付けなかった場合は
+従来通りドキュメント全体を対象とする（互換性あり）。
+
+#### `GET /api/docs/{docId}?scope=<nodeId>&depth=N`
+
+`scope` ノードを root とする部分木を返す。
+
+クエリパラメータ:
+
+- `scope` (string, 必須): 部分木の root として扱うノード ID
+- `depth` (integer, 任意): 下降する階層数
+  - 未指定: 無制限（フル部分木）
+  - `0`: `scope` ノードのみ（子なし）
+  - `N > 0`: `scope` から N 階層下まで
+
+成功レスポンス (200):
+
+```json
+{
+  "version": 1,
+  "savedAt": "2026-04-14T00:00:00.000Z",
+  "state": {
+    "rootId": "<scope>",
+    "nodes": { "<scope>": { ... }, "<descendant>": { ... } },
+    "links": { "<linkId>": { ... } }
+  },
+  "scope": {
+    "rootId": "<scope>",
+    "depth": null,
+    "nodeCount": 3
+  }
+}
+```
+
+- `state.rootId` は必ず `scope` になる。
+- `state.nodes` には `scope` とその子孫のみが含まれる。
+- `state.links` は **両端点が部分木内に存在するリンクだけ** を返す（部分木を
+  またぐリンクは除外される）。
+- レスポンスルートの `scope.rootId` / `scope.depth` / `scope.nodeCount` は
+  クライアントが渡したスコープの確認用。
+
+エラー:
+
+| status | code | 条件 |
+|--------|------|------|
+| 400 | `SCOPE_INVALID` | `depth` が数値として不正 |
+| 404 | `SCOPE_NOT_FOUND` | `scope` に一致するノードがドキュメント内に存在しない |
+
+エラー body 形式:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "SCOPE_NOT_FOUND",
+    "message": "Scope node not found in document: <id>",
+    "details": { "documentId": "...", "scopeId": "..." }
+  }
+}
+```
+
+#### `POST /api/docs/{docId}?scope=<nodeId>`
+
+`scope` ノードを root とする部分木だけを丸ごと置き換える。
+部分木の外側のノード・リンクは保持される。
+
+クエリパラメータ:
+
+- `scope` (string, 必須): 置き換え対象の部分木 root
+
+Body:
+
+```json
+{
+  "state": {
+    "rootId": "<scope>",
+    "nodes": { "<scope>": { ... }, ... },
+    "links": { ... }
+  }
+}
+```
+
+制約（**conservative**。将来的に緩めるのは容易だが、一度通した書き込みを
+遡って拒否することは不可能なため、初版は厳しめ）:
+
+- `state.rootId === scope` 必須。
+- `state.nodes[scope]` 必須。
+- `state.nodes[scope].parentId` は `null` または **保存済みドキュメントでの
+  scope ノードの元の `parentId`** と一致していなければならない。異なる値を
+  渡すと `SCOPE_WRITE_PARENT_MUTATION` で拒否される。
+- 部分木内のノードの `parentId` / `children` は **すべて body 内の nodes を
+  参照していなければならない**。スコープ外のノード ID を参照すると
+  `SCOPE_WRITE_OUTSIDE_REFERENCE` で拒否される。
+- 部分木内の links も両端点が body 内 nodes に含まれる必要がある。
+- 部分木外に既に存在する ID と衝突する新規ノードは拒否される。
+
+成功レスポンス (200):
+
+```json
+{
+  "ok": true,
+  "savedAt": "2026-04-14T00:00:00.000Z",
+  "documentId": "<docId>",
+  "scope": { "rootId": "<scope>", "replacedNodeCount": 5 }
+}
+```
+
+エラー:
+
+| status | code | 条件 |
+|--------|------|------|
+| 404 | `SCOPE_NOT_FOUND` | 保存済みドキュメントに `scope` が存在しない |
+| 400 | `SCOPE_INVALID` | body が不正 / 結果がモデルバリデーションを通らない |
+| 400 | `SCOPE_WRITE_ROOT_MISMATCH` | `state.rootId !== scope` |
+| 400 | `SCOPE_WRITE_OUTSIDE_REFERENCE` | 部分木外のノードを参照している |
+| 400 | `SCOPE_WRITE_PARENT_MUTATION` | scope の親を付け替えようとしている |
+
+エラー body は GET と同じ `{ok:false, error:{code, message, details?}}` 形式。
+
+#### 置換時のリンクの扱い
+
+部分木置換時、**置換前の部分木に触れていたリンク**（いずれかの端点が古い部分木
+に含まれていたもの）はすべて削除される。理由: 旧部分木のノードは削除される
+ため、部分木をまたぐリンクはそのままでは dangling になる。クロススコープな
+リンクを維持したい場合、クライアント側で `scope` を付けずに全ドキュメント
+POST を行うか、置換後に対象のリンクを再作成する必要がある。
+
 ---
 
 ## Audit Log API


### PR DESCRIPTION
## Summary
- Adds `scope=<nodeId>` query param to `GET` and `POST /api/docs/{docId}`, letting agents/users operate on a subtree by copy-pasting a node ID instead of shipping the whole document.
- `GET` also accepts `depth=N` (default unlimited; 0 = scope node only). Links crossing the subtree boundary are excluded.
- `POST` replaces only the subtree, preserving everything outside. Conservative validation: rejects writes that mutate scope's parent or reference nodes outside the incoming subtree (structured `SCOPE_WRITE_*` errors, 400 / 404).
- No `scope` param → existing full-doc behavior unchanged.

## Changes
- `beta/src/shared/scope_types.ts` (new) — TS types and structured error codes.
- `beta/src/node/rapid_mvp.ts` — static helpers `readScopedState`, `writeScopedState`, `collectSubtreeIds`.
- `beta/src/node/start_viewer.ts` — GET/POST handlers parse `scope`/`depth` and delegate.
- `beta/tests/unit/scope_param.test.js` (new) — 8 unit tests covering read, depth limits, cross-boundary links, replace-preserves-outside, rootId/parent/outside-reference validation, and `SCOPE_NOT_FOUND`.
- `dev-docs/03_Spec/REST_API.md` — documents the new query params, response shapes, and every structured error code. Notes the link-drop behavior on subtree replacement.

## Test plan
- [x] `npx tsc -p tsconfig.node.json --noEmit` clean
- [x] `npx tsc -p tsconfig.browser.json --noEmit` clean
- [x] `npx vitest run tests/unit/scope_param.test.js` — 8/8 passing
- [x] Full suite: 314 passed; 3 pre-existing failures (persistence_db_behavior × 2, backup × 1, flash_ingest × 1) reproduced on unmodified `dev-beta` — unrelated to this change.
- [ ] Manual: `curl "http://localhost:4173/api/docs/rapid-main?scope=<id>"` returns the subtree; POSTing that body back with a modification round-trips cleanly.

## Notes / design choices (documented in REST_API.md)
- `depth` default = unlimited, as spec'd.
- On subtree replacement, any stored link touching the old subtree is dropped (not just both-endpoints-inside), because a cross-subtree link to a deleted node would dangle. Documented explicitly; clients that want to keep cross-subtree links should POST the whole doc.
- Scope root's `parentId` is preserved from the stored doc; attempts to change it return `SCOPE_WRITE_PARENT_MUTATION` (conservative — easier to relax later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)