### PR TITLE
data: alias commands (setAccess, rename, resolve, editVia)

### DIFF
--- a/beta/src/node/rapid_mvp.ts
+++ b/beta/src/node/rapid_mvp.ts
@@ -231,6 +231,88 @@ class RapidMvpModel {
     return id;
   }
 
+  /**
+   * Change an alias node's access level (read / write).
+   * Per Scope_and_Alias.md: default is read, write aliases can forward edits to target.
+   */
+  setAliasAccess(aliasId: string, access: AliasAccess): void {
+    const node = this._requireNode(aliasId);
+    if (node.nodeType !== "alias") {
+      throw new Error(`Node ${aliasId} is not an alias.`);
+    }
+    if (access !== "read" && access !== "write") {
+      throw new Error(`Invalid alias access: ${String(access)}`);
+    }
+    this._pushHistory();
+    node.access = access;
+  }
+
+  /**
+   * Rename an alias: updates aliasLabel (not target). Per spec, alias rename
+   * is aliasLabel editing by default. Pass empty/undefined to clear aliasLabel
+   * (alias then displays target's current label).
+   */
+  renameAlias(aliasId: string, aliasLabel: string | null | undefined): void {
+    const node = this._requireNode(aliasId);
+    if (node.nodeType !== "alias") {
+      throw new Error(`Node ${aliasId} is not an alias.`);
+    }
+    this._pushHistory();
+    const trimmed = (aliasLabel ?? "").trim();
+    if (trimmed.length === 0) {
+      node.aliasLabel = undefined;
+    } else {
+      node.aliasLabel = trimmed;
+    }
+    // Refresh visible text (not applicable if broken — keep "(deleted)" display)
+    if (!node.isBroken) {
+      if (trimmed.length > 0) {
+        node.text = trimmed;
+      } else if (node.targetNodeId) {
+        const target = this.state.nodes[node.targetNodeId];
+        if (target) node.text = this._displayLabel(target);
+      }
+    }
+  }
+
+  /**
+   * Resolve alias to its canonical target node. Returns null if broken or missing.
+   * alias -> alias chains are already forbidden, so single hop is sufficient.
+   */
+  resolveAliasTarget(aliasId: string): TreeNode | null {
+    const node = this._requireNode(aliasId);
+    if (node.nodeType !== "alias") {
+      throw new Error(`Node ${aliasId} is not an alias.`);
+    }
+    if (node.isBroken || !node.targetNodeId) return null;
+    return this.state.nodes[node.targetNodeId] ?? null;
+  }
+
+  /**
+   * Edit the target node's text through a write-alias. Read-aliases and
+   * broken aliases cannot forward edits. Per spec section "access control".
+   */
+  editViaAlias(aliasId: string, newText: string): void {
+    const node = this._requireNode(aliasId);
+    if (node.nodeType !== "alias") {
+      throw new Error(`Node ${aliasId} is not an alias.`);
+    }
+    if (node.isBroken) {
+      throw new Error(`Alias ${aliasId} is broken; cannot forward edits.`);
+    }
+    if ((node.access ?? "read") !== "write") {
+      throw new Error(`Alias ${aliasId} is read-only; cannot forward edits to target.`);
+    }
+    if (!node.targetNodeId) {
+      throw new Error(`Alias ${aliasId} has no target.`);
+    }
+    const target = this.state.nodes[node.targetNodeId];
+    if (!target) {
+      throw new Error(`Alias ${aliasId} target is missing.`);
+    }
+    this.editNode(target.id, newText);
+  }
+
   addLink(sourceNodeId: string, targetNodeId: string, options?: {
     relationType?: string;
     label?: string;

--- a/beta/tests/unit/alias_commands.test.js
+++ b/beta/tests/unit/alias_commands.test.js
@@ -1,0 +1,127 @@
+"use strict";
+
+import { test, expect } from "vitest";
+
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+function makeModel() {
+  const m = new RapidMvpModel("Root");
+  const root = m.state.rootId;
+  const target = m.addNode(root, "Target");
+  const aliasId = m.addAlias(root, target, { aliasLabel: "MyAlias" });
+  return { m, root, target, aliasId };
+}
+
+// --- setAliasAccess ---
+
+test("setAliasAccess toggles read<->write", () => {
+  const { m, aliasId } = makeModel();
+  expect(m.state.nodes[aliasId].access).toBe("read");
+
+  m.setAliasAccess(aliasId, "write");
+  expect(m.state.nodes[aliasId].access).toBe("write");
+
+  m.setAliasAccess(aliasId, "read");
+  expect(m.state.nodes[aliasId].access).toBe("read");
+
+  expect(m.validate()).toEqual([]);
+});
+
+test("setAliasAccess rejects non-alias node", () => {
+  const { m, target } = makeModel();
+  expect(() => m.setAliasAccess(target, "write")).toThrow(/not an alias/);
+});
+
+test("setAliasAccess rejects invalid access value", () => {
+  const { m, aliasId } = makeModel();
+  expect(() => m.setAliasAccess(aliasId, "admin")).toThrow(/invalid alias access/i);
+});
+
+// --- renameAlias ---
+
+test("renameAlias updates aliasLabel and display text", () => {
+  const { m, aliasId } = makeModel();
+  m.renameAlias(aliasId, "Renamed");
+  expect(m.state.nodes[aliasId].aliasLabel).toBe("Renamed");
+  expect(m.state.nodes[aliasId].text).toBe("Renamed");
+});
+
+test("renameAlias with empty clears aliasLabel and falls back to target text", () => {
+  const { m, aliasId } = makeModel();
+  m.renameAlias(aliasId, "");
+  expect(m.state.nodes[aliasId].aliasLabel).toBeUndefined();
+  expect(m.state.nodes[aliasId].text).toBe("Target");
+});
+
+test("renameAlias rejects non-alias", () => {
+  const { m, target } = makeModel();
+  expect(() => m.renameAlias(target, "x")).toThrow(/not an alias/);
+});
+
+test("renameAlias on broken alias only updates label, not '(deleted)' text", () => {
+  const { m, aliasId, target } = makeModel();
+  m.deleteNode(target);
+  expect(m.state.nodes[aliasId].isBroken).toBe(true);
+  m.renameAlias(aliasId, "NewLabel");
+  expect(m.state.nodes[aliasId].aliasLabel).toBe("NewLabel");
+  // broken display preserved
+  expect(m.state.nodes[aliasId].text).toMatch(/deleted/);
+});
+
+// --- resolveAliasTarget ---
+
+test("resolveAliasTarget returns canonical node", () => {
+  const { m, aliasId, target } = makeModel();
+  const resolved = m.resolveAliasTarget(aliasId);
+  expect(resolved).not.toBeNull();
+  expect(resolved.id).toBe(target);
+});
+
+test("resolveAliasTarget returns null for broken alias", () => {
+  const { m, aliasId, target } = makeModel();
+  m.deleteNode(target);
+  expect(m.resolveAliasTarget(aliasId)).toBeNull();
+});
+
+test("resolveAliasTarget rejects non-alias", () => {
+  const { m, target } = makeModel();
+  expect(() => m.resolveAliasTarget(target)).toThrow(/not an alias/);
+});
+
+// --- editViaAlias ---
+
+test("editViaAlias with write access edits target", () => {
+  const { m, aliasId, target } = makeModel();
+  m.setAliasAccess(aliasId, "write");
+  m.editViaAlias(aliasId, "Edited via alias");
+  expect(m.state.nodes[target].text).toBe("Edited via alias");
+});
+
+test("editViaAlias blocked on read-only alias", () => {
+  const { m, aliasId, target } = makeModel();
+  expect(() => m.editViaAlias(aliasId, "nope")).toThrow(/read-only/);
+  expect(m.state.nodes[target].text).toBe("Target");
+});
+
+test("editViaAlias blocked on broken alias", () => {
+  const { m, aliasId, target } = makeModel();
+  m.setAliasAccess(aliasId, "write");
+  m.deleteNode(target);
+  expect(() => m.editViaAlias(aliasId, "nope")).toThrow(/broken/);
+});
+
+test("editViaAlias rejects non-alias", () => {
+  const { m, target } = makeModel();
+  expect(() => m.editViaAlias(target, "x")).toThrow(/not an alias/);
+});
+
+// --- combined validation ---
+
+test("alias commands leave model valid after sequence", () => {
+  const { m, aliasId, target } = makeModel();
+  m.setAliasAccess(aliasId, "write");
+  m.renameAlias(aliasId, "Write Ref");
+  m.editViaAlias(aliasId, "New Target Text");
+  expect(m.state.nodes[target].text).toBe("New Target Text");
+  expect(m.validate()).toEqual([]);
+});


### PR DESCRIPTION
## Summary
Adds explicit alias operation commands to `RapidMvpModel` per `dev-docs/03_Spec/Scope_and_Alias.md` implementation memo. Model-layer alias type, validation, and broken-propagation were already present; this PR fills in the remaining operations:

- **`setAliasAccess(aliasId, "read"|"write")`** — toggle access level
- **`renameAlias(aliasId, label)`** — edits `aliasLabel` only (per spec "alias rename is aliasLabel editing by default"). Empty label clears; broken aliases preserve `(deleted)` display
- **`resolveAliasTarget(aliasId)`** — returns canonical `TreeNode` or `null` when broken/missing
- **`editViaAlias(aliasId, text)`** — forwards edit to target; rejected for read-only or broken aliases (access-control invariant from spec section "access control")

## Key spec invariants enforced
- alias -> alias forbidden (pre-existing, preserved)
- default access is `read`; write aliases forward edits, read aliases do not
- broken aliases cannot forward edits or resolve
- `aliasLabel` overrides display; when cleared, target label is shown
- all commands push history (undo-able)

## Tests
`beta/tests/unit/alias_commands.test.js` — 15 new unit tests covering happy paths, error paths, and broken-state interactions. Full suite: **321 passed** (was 306). The 3 pre-existing unrelated failures (backup / persistence / flash_ingest) are unchanged.

## Open Qs
- Write-alias edit scope: spec "Beta 実装でまだ保留にすること" leaves undecided whether `editViaAlias` covers body/metadata too. Currently only `text` (via `editNode`). Raise if we need details/note forwarding.
- No scoped-API (PR #43) integration yet — that PR is on `feat/scope-param` and not merged. Once merged, add tests that confirm `readScopedState`/`writeScopedState` preserve cross-scope alias pointers and mark aliases broken when target scope is pruned.

## Coordination
- No overlap with data2's PR #43 (`feat/scope-param`): that PR touches scope subtree I/O; this PR only adds instance methods to the model. Merge order-independent.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.node.json` clean
- [x] `npx vitest run alias_commands` — 15/15 pass
- [x] full suite: no regressions (same 3 pre-existing unrelated failures)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>