### PR TITLE
data: Rapid/Deep/Binding data model (spec + types + schema + CRUD stubs)

### DIFF
--- a/beta/src/node/rapid_mvp.ts
+++ b/beta/src/node/rapid_mvp.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 import Database from "better-sqlite3";
 import type { TreeNode, AppState, SavedDoc, AliasAccess, GraphLink, LinkDirection, LinkStyle } from "../shared/types";
+import type { SemanticNode, SemanticEdge, Binding, BindType } from "../shared/binding_types";
 
 type SqliteDatabase = InstanceType<typeof Database>;
 
@@ -570,7 +571,245 @@ class RapidMvpModel {
       db.exec(`ALTER TABLE documents ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`);
     }
 
+    // Additive migration for the Rapid / Deep / Binding layer.
+    // See dev-docs/03_Spec/Rapid_Deep_Binding.md.
+    // Schema is purely additive; no FK enforcement here — referential integrity
+    // is checked at the model / stub-method layer.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS semantic_nodes (
+        id              TEXT PRIMARY KEY,
+        label           TEXT NOT NULL,
+        domain          TEXT NOT NULL,
+        role            TEXT NOT NULL,
+        level           TEXT NOT NULL,
+        status          TEXT NOT NULL,
+        attributes_json TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS semantic_edges (
+        id        TEXT PRIMARY KEY,
+        src       TEXT NOT NULL,
+        dst       TEXT NOT NULL,
+        edge_type TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS bindings (
+        id           TEXT PRIMARY KEY,
+        syntactic_id TEXT NOT NULL,
+        span_start   INTEGER NOT NULL,
+        span_end     INTEGER NOT NULL,
+        semantic_id  TEXT NOT NULL,
+        bind_type    TEXT NOT NULL,
+        confidence   REAL NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_bindings_syntactic ON bindings(syntactic_id);
+      CREATE INDEX IF NOT EXISTS idx_bindings_semantic  ON bindings(semantic_id);
+    `);
+
     return db;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rapid / Deep / Binding — CRUD stubs.
+  //
+  // These are the minimal persistence entry points. No inference, no AI, no
+  // propagation logic — those live in a follow-up PR per the spec (§7).
+  //
+  // Referential integrity is enforced here (not in SQLite) so that the additive
+  // migration never fails on pre-existing DBs.
+  // ---------------------------------------------------------------------------
+
+  private static readonly BIND_TYPES: ReadonlySet<BindType> = new Set<BindType>([
+    "defines", "mentions", "uses", "motivates", "examples", "states", "proves",
+  ]);
+
+  private static validateSemanticNode(node: SemanticNode): void {
+    if (!node || typeof node.id !== "string" || node.id.length === 0) {
+      throw new Error("SemanticNode.id is required.");
+    }
+    if (typeof node.label !== "string") {
+      throw new Error("SemanticNode.label must be a string.");
+    }
+    for (const key of ["domain", "role", "level", "status"] as const) {
+      if (typeof node[key] !== "string" || (node[key] as string).length === 0) {
+        throw new Error(`SemanticNode.${key} is required.`);
+      }
+    }
+    if (!node.attributes || typeof node.attributes !== "object") {
+      throw new Error("SemanticNode.attributes must be an object.");
+    }
+  }
+
+  private static validateBinding(binding: Binding): void {
+    if (!binding || typeof binding.id !== "string" || binding.id.length === 0) {
+      throw new Error("Binding.id is required.");
+    }
+    if (typeof binding.syntacticId !== "string" || binding.syntacticId.length === 0) {
+      throw new Error("Binding.syntacticId is required.");
+    }
+    if (typeof binding.semanticId !== "string" || binding.semanticId.length === 0) {
+      throw new Error("Binding.semanticId is required.");
+    }
+    if (!Number.isInteger(binding.spanStart) || binding.spanStart < 0) {
+      throw new Error("Binding.spanStart must be a non-negative integer.");
+    }
+    if (!Number.isInteger(binding.spanEnd) || binding.spanEnd < binding.spanStart) {
+      throw new Error("Binding.spanEnd must be an integer >= spanStart.");
+    }
+    if (!RapidMvpModel.BIND_TYPES.has(binding.bindType)) {
+      throw new Error(`Binding.bindType is invalid: ${String(binding.bindType)}`);
+    }
+    if (
+      typeof binding.confidence !== "number" ||
+      !Number.isFinite(binding.confidence) ||
+      binding.confidence < 0 ||
+      binding.confidence > 1
+    ) {
+      throw new Error("Binding.confidence must be a finite number in [0, 1].");
+    }
+  }
+
+  static createSemanticNode(dbPath: string, node: SemanticNode): void {
+    RapidMvpModel.validateSemanticNode(node);
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      db.prepare(
+        `INSERT INTO semantic_nodes (id, label, domain, role, level, status, attributes_json)
+         VALUES (@id, @label, @domain, @role, @level, @status, @attributes_json)`,
+      ).run({
+        id: node.id,
+        label: node.label,
+        domain: node.domain,
+        role: node.role,
+        level: node.level,
+        status: node.status,
+        attributes_json: JSON.stringify(node.attributes ?? {}),
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  static addSemanticEdge(dbPath: string, edge: SemanticEdge): void {
+    if (!edge || typeof edge.id !== "string" || edge.id.length === 0) {
+      throw new Error("SemanticEdge.id is required.");
+    }
+    if (typeof edge.src !== "string" || typeof edge.dst !== "string") {
+      throw new Error("SemanticEdge.src and .dst are required.");
+    }
+    if (edge.src === edge.dst) {
+      throw new Error("SemanticEdge cannot connect a node to itself.");
+    }
+    if (typeof edge.edgeType !== "string" || edge.edgeType.length === 0) {
+      throw new Error("SemanticEdge.edgeType is required.");
+    }
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      // Referential check: both endpoints must exist in semantic_nodes.
+      const missing = db
+        .prepare(
+          `SELECT id FROM (SELECT @src AS id UNION ALL SELECT @dst AS id)
+             WHERE id NOT IN (SELECT id FROM semantic_nodes)`,
+        )
+        .all({ src: edge.src, dst: edge.dst }) as Array<{ id: string }>;
+      if (missing.length > 0) {
+        throw new Error(`SemanticEdge references missing semantic_node(s): ${missing.map((r) => r.id).join(", ")}`);
+      }
+      db.prepare(
+        `INSERT INTO semantic_edges (id, src, dst, edge_type)
+         VALUES (@id, @src, @dst, @edge_type)`,
+      ).run({ id: edge.id, src: edge.src, dst: edge.dst, edge_type: edge.edgeType });
+    } finally {
+      db.close();
+    }
+  }
+
+  static addBinding(dbPath: string, binding: Binding): void {
+    RapidMvpModel.validateBinding(binding);
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      // Referential check: semantic node must exist. We do NOT check syntacticId
+      // here because syntactic ids live in state_json (per Q3 tentative choice),
+      // not in a dedicated table yet.
+      const hit = db
+        .prepare(`SELECT 1 AS hit FROM semantic_nodes WHERE id = ?`)
+        .get(binding.semanticId) as { hit: number } | undefined;
+      if (!hit) {
+        throw new Error(`Binding references missing semantic_node: ${binding.semanticId}`);
+      }
+      db.prepare(
+        `INSERT INTO bindings (id, syntactic_id, span_start, span_end, semantic_id, bind_type, confidence)
+         VALUES (@id, @syntactic_id, @span_start, @span_end, @semantic_id, @bind_type, @confidence)`,
+      ).run({
+        id: binding.id,
+        syntactic_id: binding.syntacticId,
+        span_start: binding.spanStart,
+        span_end: binding.spanEnd,
+        semantic_id: binding.semanticId,
+        bind_type: binding.bindType,
+        confidence: binding.confidence,
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  static listBindings(dbPath: string, syntacticId: string): Binding[] {
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const rows = db
+        .prepare(
+          `SELECT id, syntactic_id AS syntacticId, span_start AS spanStart,
+                  span_end AS spanEnd, semantic_id AS semanticId,
+                  bind_type AS bindType, confidence
+             FROM bindings WHERE syntactic_id = ? ORDER BY span_start, id`,
+        )
+        .all(syntacticId) as Binding[];
+      return rows;
+    } finally {
+      db.close();
+    }
+  }
+
+  static listOccurrences(dbPath: string, semanticId: string): Binding[] {
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const rows = db
+        .prepare(
+          `SELECT id, syntactic_id AS syntacticId, span_start AS spanStart,
+                  span_end AS spanEnd, semantic_id AS semanticId,
+                  bind_type AS bindType, confidence
+             FROM bindings WHERE semantic_id = ? ORDER BY syntactic_id, span_start, id`,
+        )
+        .all(semanticId) as Binding[];
+      return rows;
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Delete a semantic node.
+   *
+   * Orphan handling per spec §4.3: bindings that reference the deleted node are
+   * NOT cascade-deleted. They remain in the table with a now-dangling
+   * `semantic_id`, so the UI can surface them as "broken" for explicit human
+   * resolution. Edges pointing to/from the node, however, ARE removed — a typed
+   * relation to a non-existent node has no meaningful UI representation.
+   */
+  static deleteSemanticNode(dbPath: string, id: string): void {
+    if (typeof id !== "string" || id.length === 0) {
+      throw new Error("id is required.");
+    }
+    const db = RapidMvpModel.openSqlite(dbPath);
+    try {
+      const result = db.prepare(`DELETE FROM semantic_nodes WHERE id = ?`).run(id);
+      if (result.changes === 0) {
+        throw new Error(`Semantic node not found: ${id}`);
+      }
+      db.prepare(`DELETE FROM semantic_edges WHERE src = ? OR dst = ?`).run(id, id);
+      // bindings are intentionally left orphaned.
+    } finally {
+      db.close();
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/beta/src/shared/binding_types.ts
+++ b/beta/src/shared/binding_types.ts
@@ -1,0 +1,113 @@
+"use strict";
+
+/**
+ * Rapid / Deep / Binding — shared data-model types.
+ *
+ * See dev-docs/03_Spec/Rapid_Deep_Binding.md for the contract and the open design
+ * questions (Q1..Q5).
+ *
+ * This file defines pure data shapes only. No behavior. No AI. No UI.
+ */
+
+// ---------------------------------------------------------------------------
+// Open-string enums (see Q1 / Q2 in the spec). Typed as string literal unions
+// where we have a working vocabulary, and as `string` where the vocabulary is
+// intentionally open for v1.
+// ---------------------------------------------------------------------------
+
+/** Domain axis of the semantic coordinate — e.g. "knot", "manifold", "bridge". */
+export type Domain = string;
+
+/** Role axis of the semantic coordinate — e.g. "object", "representation", "move". */
+export type Role = string;
+
+/** Abstraction band. */
+export type Level = "introductory" | "technical" | "meta";
+
+/** Editorial state of a semantic node. */
+export type Status = "accepted" | "candidate" | "ambiguous";
+
+/**
+ * Typed relation between two semantic nodes. Open-ended; the listed values are
+ * the working vocabulary from the idea doc.
+ */
+export type EdgeType =
+  | "depends_on"
+  | "represents"
+  | "equivalent_under"
+  | "constructed_by"
+  | "invariant_of";
+
+/**
+ * Type of a binding between a syntactic span and a semantic node. Fixed vocabulary
+ * per idea doc §5.
+ */
+export type BindType =
+  | "defines"
+  | "mentions"
+  | "uses"
+  | "motivates"
+  | "examples"
+  | "states"
+  | "proves";
+
+// ---------------------------------------------------------------------------
+// Core shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * A node in the Semantic Structure (Deep mode). Not a tree node — the semantic
+ * structure is a typed multilayer graph. Each node carries structural coordinates
+ * `(domain, role, level)` so that parallel theories can be rendered as aligned
+ * columns / rows in the matrix view.
+ */
+export interface SemanticNode {
+  id: string;
+  label: string;
+  domain: Domain;
+  role: Role;
+  level: Level;
+  status: Status;
+  /** Free-form string-valued attributes. Use for tentative marks, source refs, etc. */
+  attributes: Record<string, string>;
+}
+
+/**
+ * A typed directed edge in the Semantic Structure.
+ *
+ * `src` and `dst` reference {@link SemanticNode.id}.
+ * Undirected relations (e.g. `equivalent_under`) are modeled as directed edges
+ * here; the UI layer decides whether to render the arrowhead.
+ */
+export interface SemanticEdge {
+  id: string;
+  src: string;
+  dst: string;
+  edgeType: EdgeType;
+}
+
+/**
+ * A span-level, typed correspondence between a syntactic unit and a semantic node.
+ *
+ * Many-to-many: one `syntacticId` may have many bindings, one `semanticId` may
+ * have many bindings.
+ *
+ * `syntacticId` — see Q3 in the spec. For v1 this is a `TreeNode.id` from the
+ * existing M3E `nodes` table (the current mind-map is treated as the syntactic
+ * layer).
+ *
+ * `spanStart` / `spanEnd` — character offsets (see Q4). Half-open `[start, end)`.
+ * `spanStart === spanEnd` encodes a cursor / zero-width binding and is permitted.
+ *
+ * `confidence` — in `[0, 1]`. Human-confirmed bindings should carry `1.0`.
+ * AI-proposed bindings carry the model's confidence.
+ */
+export interface Binding {
+  id: string;
+  syntacticId: string;
+  spanStart: number;
+  spanEnd: number;
+  semanticId: string;
+  bindType: BindType;
+  confidence: number;
+}

--- a/beta/tests/unit/rapid_deep_binding.test.js
+++ b/beta/tests/unit/rapid_deep_binding.test.js
@@ -1,0 +1,147 @@
+import { test, expect } from "vitest";
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+function tmpDb(tag) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `m3e-binding-${tag}-`));
+  return path.join(dir, "test.sqlite");
+}
+
+function baseNode(id, overrides = {}) {
+  return {
+    id,
+    label: `Node ${id}`,
+    domain: "knot",
+    role: "object",
+    level: "technical",
+    status: "accepted",
+    attributes: {},
+    ...overrides,
+  };
+}
+
+function baseBinding(id, semanticId, overrides = {}) {
+  return {
+    id,
+    syntacticId: `syn_${id}`,
+    spanStart: 0,
+    spanEnd: 10,
+    semanticId,
+    bindType: "mentions",
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+test("createSemanticNode + listBindings round trip", () => {
+  const db = tmpDb("roundtrip");
+  RapidMvpModel.createSemanticNode(db, baseNode("n1", { label: "Knot K" }));
+  RapidMvpModel.addBinding(db, baseBinding("b1", "n1", { syntacticId: "para17", spanStart: 45, spanEnd: 78, bindType: "defines", confidence: 0.92 }));
+
+  const bindings = RapidMvpModel.listBindings(db, "para17");
+  expect(bindings).toHaveLength(1);
+  expect(bindings[0]).toMatchObject({
+    id: "b1",
+    syntacticId: "para17",
+    spanStart: 45,
+    spanEnd: 78,
+    semanticId: "n1",
+    bindType: "defines",
+    confidence: 0.92,
+  });
+});
+
+test("listOccurrences finds all bindings for a semantic node", () => {
+  const db = tmpDb("occ");
+  RapidMvpModel.createSemanticNode(db, baseNode("lift"));
+  RapidMvpModel.addBinding(db, baseBinding("b1", "lift", { syntacticId: "p1", spanStart: 0, spanEnd: 5 }));
+  RapidMvpModel.addBinding(db, baseBinding("b2", "lift", { syntacticId: "p2", spanStart: 10, spanEnd: 20 }));
+
+  const occ = RapidMvpModel.listOccurrences(db, "lift");
+  expect(occ).toHaveLength(2);
+  expect(occ.map((b) => b.id).sort()).toEqual(["b1", "b2"]);
+});
+
+test("listBindings / listOccurrences return [] for unknown ids", () => {
+  const db = tmpDb("empty");
+  expect(RapidMvpModel.listBindings(db, "nope")).toEqual([]);
+  expect(RapidMvpModel.listOccurrences(db, "nope")).toEqual([]);
+});
+
+test("addBinding rejects unknown semantic node (FK-like check)", () => {
+  const db = tmpDb("fkbind");
+  expect(() => RapidMvpModel.addBinding(db, baseBinding("b1", "ghost"))).toThrow(
+    /missing semantic_node/i,
+  );
+});
+
+test("addSemanticEdge rejects unknown endpoints", () => {
+  const db = tmpDb("fkedge");
+  RapidMvpModel.createSemanticNode(db, baseNode("a"));
+  expect(() => RapidMvpModel.addSemanticEdge(db, { id: "e1", src: "a", dst: "b", edgeType: "depends_on" })).toThrow(
+    /missing semantic_node/i,
+  );
+});
+
+test("addSemanticEdge rejects self loop", () => {
+  const db = tmpDb("selfloop");
+  RapidMvpModel.createSemanticNode(db, baseNode("a"));
+  expect(() => RapidMvpModel.addSemanticEdge(db, { id: "e1", src: "a", dst: "a", edgeType: "depends_on" })).toThrow(
+    /itself/,
+  );
+});
+
+test("addBinding rejects invalid confidence and span", () => {
+  const db = tmpDb("inv");
+  RapidMvpModel.createSemanticNode(db, baseNode("n1"));
+  expect(() => RapidMvpModel.addBinding(db, baseBinding("b1", "n1", { confidence: 1.5 }))).toThrow(/confidence/i);
+  expect(() => RapidMvpModel.addBinding(db, baseBinding("b1", "n1", { confidence: -0.1 }))).toThrow(/confidence/i);
+  expect(() => RapidMvpModel.addBinding(db, baseBinding("b1", "n1", { spanStart: 10, spanEnd: 5 }))).toThrow(/spanEnd/);
+  expect(() => RapidMvpModel.addBinding(db, baseBinding("b1", "n1", { spanStart: -1 }))).toThrow(/spanStart/);
+});
+
+test("addBinding rejects invalid bindType", () => {
+  const db = tmpDb("bt");
+  RapidMvpModel.createSemanticNode(db, baseNode("n1"));
+  expect(() => RapidMvpModel.addBinding(db, baseBinding("b1", "n1", { bindType: "wiggles" }))).toThrow(/bindType/);
+});
+
+test("deleteSemanticNode orphans bindings but removes incident edges", () => {
+  const db = tmpDb("orphan");
+  RapidMvpModel.createSemanticNode(db, baseNode("a"));
+  RapidMvpModel.createSemanticNode(db, baseNode("b"));
+  RapidMvpModel.addSemanticEdge(db, { id: "e1", src: "a", dst: "b", edgeType: "depends_on" });
+  RapidMvpModel.addBinding(db, baseBinding("bind1", "a", { syntacticId: "syn1" }));
+
+  RapidMvpModel.deleteSemanticNode(db, "a");
+
+  // Binding survives as orphan (semantic_id still "a", but node is gone)
+  const occ = RapidMvpModel.listOccurrences(db, "a");
+  expect(occ).toHaveLength(1);
+  expect(occ[0].id).toBe("bind1");
+
+  // Incident edge is gone
+  expect(() => RapidMvpModel.addSemanticEdge(db, { id: "e2", src: "a", dst: "b", edgeType: "depends_on" })).toThrow(
+    /missing semantic_node/i,
+  );
+});
+
+test("deleteSemanticNode throws when node not found", () => {
+  const db = tmpDb("delnope");
+  expect(() => RapidMvpModel.deleteSemanticNode(db, "ghost")).toThrow(/not found/i);
+});
+
+test("schema coexists with existing documents table (additive migration)", () => {
+  const db = tmpDb("coexist");
+  // Simulate pre-existing doc usage.
+  const model = new RapidMvpModel("Root");
+  model.saveToSqlite(db, "doc-1");
+  // New binding tables should now exist — inserting a semantic node must succeed.
+  RapidMvpModel.createSemanticNode(db, baseNode("n1"));
+  // And the original document should still be loadable.
+  const reopened = RapidMvpModel.loadFromSqlite(db, "doc-1");
+  expect(reopened.state.nodes[reopened.state.rootId].text).toBe("Root");
+});

--- a/dev-docs/03_Spec/Rapid_Deep_Binding.md
+++ b/dev-docs/03_Spec/Rapid_Deep_Binding.md
@@ -1,0 +1,301 @@
+# Rapid / Deep / Binding — Data-Model Spec
+
+Status: draft (data-model + contract only; no implementation logic, no UI, no AI in this PR)
+Source idea: [`dev-docs/ideas/tree_structure_rapid_deep.md`](../ideas/tree_structure_rapid_deep.md)
+
+This document formalizes the three layers that M3E's "Rapid / Deep" modes operate on, plus the
+binding layer that connects them, and the encoder/decoder contract that produces and consumes
+them. The implementation in this PR is intentionally minimal: only types, schema, and CRUD
+stubs. The semantic/AI inference side is deferred — it is the button-triggered step described
+in the idea doc.
+
+---
+
+## 1. Three layers
+
+### 1.1 Syntactic Tree (Rapid mode)
+
+- **What it is:** the document as presented. Sections, paragraphs, theorem blocks, lists,
+  figures, in the linear order in which the human author chose to present them.
+- **Properties:** fully determined by the source (PDF / markdown / note). Lossless.
+  Deterministic. No inference. Revising it means re-parsing, not re-thinking.
+- **Rapid mode = read-only projection of the Syntactic Tree.**
+
+### 1.2 Semantic Structure (Deep mode)
+
+- **What it is:** a typed multilayer graph of notions. Not a tree. Revisable.
+- **Nodes** carry structural coordinates:
+  - `domain` — which parallel theory / world the node lives in (e.g. `knot`, `link`,
+    `manifold`, `bridge`, `general`).
+  - `role` — which layer the node plays within its domain (e.g. `object`, `representation`,
+    `move`, `invariant`, `theorem`, `method`).
+  - `level` — abstraction band (e.g. `introductory`, `technical`, `meta`).
+  - `status` — editorial state (`accepted`, `candidate`, `ambiguous`).
+- **Edges** are typed: `depends_on`, `represents`, `equivalent_under`, `constructed_by`,
+  `invariant_of`, …
+- **Deep mode = editable construction of the Semantic Structure.** Non-unique, revisable.
+
+### 1.3 Binding (the bridge)
+
+The binding is the **explicit correspondence channel** between Syntactic and Semantic. It is
+what makes the transformation inspectable and editable.
+
+- Many-to-many. One paragraph can mention several notions; one notion can appear in many
+  paragraphs.
+- **Span-level**, not block-level: a binding records a `(span_start, span_end)` offset into
+  the syntactic unit, so one paragraph can bind different substrings to different notions.
+- **Typed**: `bindType ∈ {defines, mentions, uses, motivates, examples, states, proves}`.
+- Carries **confidence** ∈ [0, 1] so that AI-proposed bindings and human-accepted bindings
+  can coexist.
+
+---
+
+## 2. Binding as a sparse 3-tensor
+
+Per the idea doc, the correct formalization is:
+
+```
+χ : I × A × B → {0, 1}
+```
+
+where
+- `I` = syntactic positions (document unit id + span),
+- `A` = domain axis (knot / manifold / …),
+- `B` = role axis (object / representation / move / invariant / …).
+
+`χ(i, a, b) = 1` iff the syntactic position `i` binds to the semantic slot `(a, b)`.
+
+Extended with label / confidence / context:
+
+```
+χ(i, a, b, t, r, c)
+  t  = binding type (defines / mentions / uses / ...)
+  r  = confidence
+  c  = context / version
+```
+
+Practical projections:
+
+- **Rapid-side lookup** — given a syntactic position `i`, what notions does it bind to?
+  `listBindings(syntacticId) → Binding[]`
+- **Deep-side lookup** — given a semantic node, where does it occur in the document?
+  `listOccurrences(semanticId) → Binding[]`
+
+---
+
+## 3. Matrix-view example (knot / link / manifold)
+
+The parallel-structure requirement from the idea doc. Semantic nodes laid out on the
+`domain × role` grid:
+
+|                    | **knot**         | **link**            | **manifold**     |
+|--------------------|------------------|---------------------|------------------|
+| **object**         | `K`              | `L`                 | `M`              |
+| **representation** | diagram          | framed diagram      | surgery          |
+| **move**           | Reidemeister     | framed moves        | Kirby            |
+| **invariant**      | J(K) (Jones)     | …                   | Z(M) (RT-type)   |
+
+Horizontal edges = cross-domain correspondence / analogy (e.g. `represents`).
+Vertical edges = within-domain dependency (e.g. `invariant_of`, `constructed_by`).
+
+**Bridge nodes** (e.g. *framed link*) sit across columns and connect the knot world to the
+manifold world. They are first-class semantic nodes, typically with `domain = "bridge"`.
+
+---
+
+## 4. Encoder / Decoder contract
+
+```
+Syntactic Tree  ⇌  Canonical Semantic Form
+               E   N   D
+```
+
+- **E (Encoder):** `E : S → (P(M), P(R), P(B), U)` — from a syntactic node/span, propose
+  semantic node candidates `M`, relation candidates `R`, binding candidates `B`, and
+  residual/uncertainty metadata `U`. The encoder proposes; it does not commit.
+- **N (Normalizer):** canonicalize the proposals — merge duplicates, resolve aliases, assign
+  `(domain, role)` coordinates, keep uncertainty rather than forcing a decision.
+- **D (Decoder):** `D : (M, R, B) → view` — generate a user-facing view (Rapid textbook
+  order, Deep concept graph, matrix view by role). **Decoder ≠ inverse of encoder.** It is
+  a view generator.
+
+### 4.1 Accuracy principle
+
+The encoder must separate:
+- **Hard facts** — section nesting, theorem/proof boundaries, repeated-term spans, citation
+  references. Deterministic.
+- **Soft inferences** — "this sentence defines a notion", "this notion belongs to the knot
+  domain". Probabilistic, stored with confidence.
+
+Mixing these two channels is the main source of drift.
+
+### 4.2 Laziness principle (button-triggered)
+
+- **Automatic, cheap, deterministic:**
+  - id preservation on syntactic node moves,
+  - span redistribution on paragraph splits,
+  - label propagation on semantic renames.
+- **On-demand, expensive, AI-driven (button-triggered):**
+  - notion extraction from newly-added text,
+  - rebinding after large edits,
+  - inference of missing semantic relations,
+  - ambiguity resolution.
+
+State can be marked `fresh | stale | partially_stale` to hint (not force) the user to press
+the "Refresh semantic links" button. **Never autorun the AI encoder on every keystroke.**
+
+### 4.3 Edit-propagation rules
+
+- Syntactic node moved → bindings stay (ids persist).
+- Syntactic node split → bindings redistributed by span math.
+- Semantic nodes merged → bindings unioned.
+- Semantic node deleted → bindings become orphaned and must be explicitly resolved
+  (kept as `bindType` with dangling `semantic_id`, surfaced in UI for review).
+
+---
+
+## 5. Data model (this PR)
+
+### 5.1 TypeScript types — `beta/src/shared/binding_types.ts`
+
+```ts
+export type Domain = string;                  // open string; see Q1
+export type Role = string;                    // open string; see Q2
+export type Level = "introductory" | "technical" | "meta";
+export type Status = "accepted" | "candidate" | "ambiguous";
+
+export type EdgeType =
+  | "depends_on" | "represents" | "equivalent_under"
+  | "constructed_by" | "invariant_of";        // open; see Q1/Q2
+
+export type BindType =
+  | "defines" | "mentions" | "uses" | "motivates"
+  | "examples" | "states" | "proves";
+
+export interface SemanticNode {
+  id: string;
+  label: string;
+  domain: Domain;
+  role: Role;
+  level: Level;
+  status: Status;
+  attributes: Record<string, string>;
+}
+
+export interface SemanticEdge {
+  id: string;
+  src: string;          // SemanticNode.id
+  dst: string;          // SemanticNode.id
+  edgeType: EdgeType;
+}
+
+export interface Binding {
+  id: string;
+  syntacticId: string;  // points to the syntactic unit; see Q3
+  spanStart: number;    // char offset; see Q4
+  spanEnd: number;
+  semanticId: string;   // SemanticNode.id
+  bindType: BindType;
+  confidence: number;   // [0, 1]
+}
+```
+
+### 5.2 SQLite schema — additive migration in `beta/src/node/rapid_mvp.ts`
+
+```sql
+CREATE TABLE IF NOT EXISTS semantic_nodes (
+  id              TEXT PRIMARY KEY,
+  label           TEXT NOT NULL,
+  domain          TEXT NOT NULL,
+  role            TEXT NOT NULL,
+  level           TEXT NOT NULL,
+  status          TEXT NOT NULL,
+  attributes_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS semantic_edges (
+  id        TEXT PRIMARY KEY,
+  src       TEXT NOT NULL,
+  dst       TEXT NOT NULL,
+  edge_type TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bindings (
+  id           TEXT PRIMARY KEY,
+  syntactic_id TEXT NOT NULL,
+  span_start   INTEGER NOT NULL,
+  span_end     INTEGER NOT NULL,
+  semantic_id  TEXT NOT NULL,
+  bind_type    TEXT NOT NULL,
+  confidence   REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_bindings_syntactic ON bindings(syntactic_id);
+CREATE INDEX IF NOT EXISTS idx_bindings_semantic  ON bindings(semantic_id);
+```
+
+SQLite does not enforce true FKs here (additive-migration principle; we do not want to break
+pre-existing `documents` rows). Referential integrity is enforced **at the model layer** in
+`validate()` / stub methods.
+
+### 5.3 `RapidMvpModel` stubs (signatures only)
+
+```
+createSemanticNode(node: SemanticNode): void
+addSemanticEdge(edge: SemanticEdge): void
+addBinding(binding: Binding): void
+listBindings(syntacticId: string): Binding[]
+listOccurrences(semanticId: string): Binding[]
+deleteSemanticNode(id: string): void          // leaves bindings orphaned; see §4.3
+```
+
+No inference. No AI. CRUD and invariant checks only. Tests cover:
+- round-trip insert / list,
+- orphan-binding behavior on `deleteSemanticNode`,
+- empty-result behavior on absent syntactic / semantic ids,
+- rejection of malformed confidence / span values.
+
+---
+
+## 6. Open design questions (pooled, not decided here)
+
+These go into `ROOT/SYSTEM/DEV/reviews/Rapid Deep Binding/Q1..Q5` per canvas-protocol
+ambiguity-pooling. Interim choices carry `attributes.tentative="yes"`; none carry
+`selected="yes"`.
+
+- **Q1 — Domain enum.** Fixed list (`knot | manifold | component | force | bridge | general`)
+  vs free string vs hierarchical path (`math.topology.knot`)?
+  *Tentative:* free string (typed as `Domain = string`). Lets early users extend without
+  a schema change; hierarchical/fixed can be enforced later at the normalizer layer.
+- **Q2 — Role enum.** Fixed (`object | representation | move | invariant | theorem | method`)
+  vs free string?
+  *Tentative:* free string (`Role = string`), same reasoning as Q1.
+- **Q3 — Where does the Syntactic Tree live?** Re-use the existing M3E `nodes` table
+  (treat the current mind-map as the syntactic layer) vs introduce a dedicated
+  `syntactic_nodes` table?
+  *Tentative:* re-use existing `nodes`. `Binding.syntacticId` is interpreted as a
+  `TreeNode.id`. Keeps PR scope minimal; a separate table can be split out later without
+  breaking the binding schema.
+- **Q4 — Span addressing.** Character offset into `details` / `note`, vs token range, vs
+  node-id only (no span)?
+  *Tentative:* character offset into the concatenation `text + details + note` of the
+  bound `TreeNode`. Simple, deterministic, survives edits via redistribution (§4.3).
+  Token-level is a later upgrade.
+- **Q5 — Encoder trigger.** Explicit button per scope vs auto-on-idle vs both?
+  *Tentative:* **explicit button only** for v1 (matches §4.2 and the idea-doc Section 10
+  conclusion). Auto-on-idle can be added behind a flag later.
+
+---
+
+## 7. What this PR does **not** do
+
+- No encoder implementation. No AI inference calls.
+- No UI for Deep mode / matrix view / binding editing.
+- No PDF → Syntactic Tree importer changes.
+- No propagation / rebinding logic (spec'd in §4.3; to be implemented in a follow-up).
+- No REST API additions in `start_viewer.ts` (spec'd here; endpoints to be added in a
+  follow-up PR once UI requirements are clearer).
+
+The deliverable is the **foundation**: the types, the schema, the method signatures, and a
+single spec document that agents and humans can refer back to as the canonical definition
+of the Rapid / Deep / Binding triad.


### PR DESCRIPTION
## Summary

Formalizes the **largest data-model decision of M3E so far**: the separation of
**Rapid mode (Syntactic Tree)** from **Deep mode (Semantic Structure)**, bridged
by an explicit **Binding layer** that behaves as a sparse 3-tensor
chi(syntactic_idx, domain, role) with typed many-to-many span-level correspondences.

This PR is intentionally the *smallest deliverable*: spec + data model only.
**No impl logic, no UI, no AI.**

Source idea: [`dev-docs/ideas/tree_structure_rapid_deep.md`](dev-docs/ideas/tree_structure_rapid_deep.md)

### What ships

- `dev-docs/03_Spec/Rapid_Deep_Binding.md` — canonical spec. Three layers;
  binding tensor; encoder/decoder contract (laziness / accuracy / propagation);
  matrix-view example (knot/link/manifold x object/representation/move/invariant);
  pooled design Qs.
- `beta/src/shared/binding_types.ts` — `SemanticNode`, `SemanticEdge`, `Binding`
  plus `Domain` / `Role` / `EdgeType` / `BindType`.
- `beta/src/node/rapid_mvp.ts` — additive SQLite migration (`semantic_nodes`,
  `semantic_edges`, `bindings` + indexes) and static CRUD stubs
  (`createSemanticNode`, `addSemanticEdge`, `addBinding`, `listBindings`,
  `listOccurrences`, `deleteSemanticNode`) with FK-like validation. No
  inference, no propagation — spec'd for follow-up.
- `beta/tests/unit/rapid_deep_binding.test.js` — 11 tests: round-trip CRUD,
  FK checks, invalid-confidence/span/bindType rejection, orphan-binding
  behavior on delete, additive-migration coexistence with existing `documents`.

### Pooled design questions (NOT decided here)

Per canvas-protocol ambiguity-pooling, the spec records five open Qs with
tentative interim choices (no `selected="yes"`):

- **Q1 — Domain enum:** fixed list vs free string vs hierarchical. *Tentative:* free string.
- **Q2 — Role enum:** fixed vs free string. *Tentative:* free string.
- **Q3 — Where does the Syntactic Tree live:** re-use existing `nodes` table vs
  separate `syntactic_nodes` table. *Tentative:* re-use existing `nodes`
  (`Binding.syntacticId` = `TreeNode.id`).
- **Q4 — Span addressing:** char offset vs token range vs node-id only.
  *Tentative:* char offset into `text + details + note` concatenation.
- **Q5 — Encoder trigger:** explicit button vs auto-on-idle vs both.
  *Tentative:* explicit button only for v1.

These should be seeded into `ROOT/SYSTEM/DEV/reviews/Rapid Deep Binding/Q1..Q5`
on the canvas when the map API is reachable.

### What this PR does NOT do (deferred)

- No encoder/AI implementation.
- No UI for Deep mode / matrix view / binding editing.
- No PDF -> Syntactic Tree importer changes.
- No propagation / rebinding logic (spec'd in Section 4.3).
- No REST API additions in `start_viewer.ts`.

### Branch note

`dev-data2` is locked by a stale worktree, so this PR is on
`feat/rapid-deep-binding` branched off `origin/dev-beta` (as instructed).

## Test plan

- [x] `npx tsc -p tsconfig.node.json` — clean
- [x] `npx vitest run tests/unit/rapid_deep_binding.test.js` — **11/11 pass**
- [x] `npx vitest run tests/unit/rapid_mvp.test.js tests/unit/data_model_integrity.test.js` — no regressions (49/49 pass including new suite)
- [x] Verified the 3 pre-existing test failures (`backup`, `flash_ingest`, `persistence_db_behavior`) are present on `origin/dev-beta` baseline and unrelated to this change.