### PR TITLE
feat(data): add/remove link API

### DIFF
--- a/beta/src/node/rapid_mvp.ts
+++ b/beta/src/node/rapid_mvp.ts
@@ -261,6 +261,15 @@ class RapidMvpModel {
     return id;
   }
 
+  removeLink(linkId: string): void {
+    const links = this._ensureLinks();
+    if (!links[linkId]) {
+      throw new Error(`Link not found: ${linkId}`);
+    }
+    this._pushHistory();
+    delete links[linkId];
+  }
+
   addSibling(nodeId: string, text = "New Sibling", after = true): string {
     const node = this._requireNode(nodeId);
     if (node.parentId === null) {

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -54,6 +54,8 @@ import type {
   FlashIngestBatchRequest,
   FlashApproveRequest,
   FlashDraftStatus,
+  LinkDirection,
+  LinkStyle,
 } from "../shared/types";
 import type {
   DocErrorCode,
@@ -737,6 +739,125 @@ function readRequestBody(req: http.IncomingMessage): Promise<string> {
       reject(err);
     });
   });
+}
+
+type LinkRouteAction =
+  | { kind: "create"; docId: string }
+  | { kind: "delete"; docId: string; linkId: string };
+
+function parseLinkRoute(urlPath: string, method: string): LinkRouteAction | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  const createMatch = pathname.match(/^\/api\/docs\/([^/]+)\/links\/?$/);
+  if (createMatch && method === "POST") {
+    return { kind: "create", docId: decodeURIComponent(createMatch[1]) };
+  }
+  const deleteMatch = pathname.match(/^\/api\/docs\/([^/]+)\/links\/([^/]+)\/?$/);
+  if (deleteMatch && method === "DELETE") {
+    return {
+      kind: "delete",
+      docId: decodeURIComponent(deleteMatch[1]),
+      linkId: decodeURIComponent(deleteMatch[2]),
+    };
+  }
+  return null;
+}
+
+async function handleLinkApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: LinkRouteAction,
+): Promise<void> {
+  if (!route.docId) {
+    sendJson(res, 400, { ok: false, error: "Document id is required." });
+    return;
+  }
+
+  let model: RapidMvpModel;
+  try {
+    model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, route.docId);
+  } catch (err) {
+    const message = (err as Error).message || "Unknown error";
+    if (message === "Document not found.") {
+      sendJson(res, 404, { ok: false, error: message });
+    } else {
+      sendJson(res, 500, { ok: false, error: message });
+    }
+    return;
+  }
+
+  try {
+    if (route.kind === "create") {
+      let body: {
+        sourceNodeId?: unknown;
+        targetNodeId?: unknown;
+        relationType?: unknown;
+        label?: unknown;
+        direction?: unknown;
+        style?: unknown;
+      };
+      try {
+        const raw = await readRequestBody(req);
+        body = raw.trim().length > 0 ? JSON.parse(raw) : {};
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          sendJson(res, 400, { ok: false, error: "Invalid JSON body." });
+          return;
+        }
+        throw err;
+      }
+      if (typeof body.sourceNodeId !== "string" || typeof body.targetNodeId !== "string") {
+        sendJson(res, 400, { ok: false, error: "sourceNodeId and targetNodeId are required strings." });
+        return;
+      }
+      const options: {
+        relationType?: string;
+        label?: string;
+        direction?: LinkDirection;
+        style?: LinkStyle;
+      } = {};
+      if (typeof body.relationType === "string") options.relationType = body.relationType;
+      if (typeof body.label === "string") options.label = body.label;
+      if (typeof body.direction === "string") options.direction = body.direction as LinkDirection;
+      if (typeof body.style === "string") options.style = body.style as LinkStyle;
+
+      let linkId: string;
+      try {
+        linkId = model.addLink(body.sourceNodeId, body.targetNodeId, options);
+      } catch (err) {
+        sendJson(res, 400, { ok: false, error: (err as Error).message });
+        return;
+      }
+      model.saveToSqlite(SQLITE_DB_PATH, route.docId);
+      const savedAt = new Date().toISOString();
+      const sourceTabId = (req.headers["x-m3e-tab-id"] as string) || null;
+      broadcastDocUpdate(route.docId, savedAt, sourceTabId);
+      const link = model.state.links?.[linkId];
+      sendJson(res, 200, { ok: true, link });
+      return;
+    }
+
+    if (route.kind === "delete") {
+      try {
+        model.removeLink(route.linkId);
+      } catch (err) {
+        const message = (err as Error).message || "Unknown error";
+        if (message.startsWith("Link not found")) {
+          sendJson(res, 404, { ok: false, error: message });
+          return;
+        }
+        sendJson(res, 400, { ok: false, error: message });
+        return;
+      }
+      model.saveToSqlite(SQLITE_DB_PATH, route.docId);
+      const savedAt = new Date().toISOString();
+      const sourceTabId = (req.headers["x-m3e-tab-id"] as string) || null;
+      broadcastDocUpdate(route.docId, savedAt, sourceTabId);
+      sendJson(res, 200, { ok: true });
+      return;
+    }
+  } catch (err) {
+    sendJson(res, 500, { ok: false, error: (err as Error).message || "Unknown error." });
+  }
 }
 
 async function handleApi(req: http.IncomingMessage, res: http.ServerResponse, docId: string): Promise<boolean> {
@@ -1457,6 +1578,12 @@ export function createAppServer(): http.Server {
     const homeRoute = parseHomeRoute(req.url ?? "/", req.method ?? "GET");
     if (homeRoute) {
       await handleHomeApi(req, res, homeRoute);
+      return;
+    }
+
+    const linkRoute = parseLinkRoute(req.url ?? "/", req.method ?? "GET");
+    if (linkRoute) {
+      await handleLinkApi(req, res, linkRoute);
       return;
     }
 

--- a/beta/tests/unit/rapid_mvp.test.js
+++ b/beta/tests/unit/rapid_mvp.test.js
@@ -86,6 +86,61 @@ test("addLink stores graph link in state", () => {
   expect(model.state.links[linkId].style).toBe("dashed");
 });
 
+test("addLink throws when endpoint nodes are missing", () => {
+  const model = new RapidMvpModel("Root");
+  const rootId = model.state.rootId;
+  const a = model.addNode(rootId, "A");
+
+  expect(() => model.addLink(a, "missing-id")).toThrow();
+  expect(() => model.addLink(a, a)).toThrow(/cannot connect a node to itself/);
+});
+
+test("addLink lazily initializes state.links when undefined", () => {
+  const model = new RapidMvpModel("Root");
+  const rootId = model.state.rootId;
+  const a = model.addNode(rootId, "A");
+  const b = model.addNode(rootId, "B");
+  delete model.state.links;
+
+  const linkId = model.addLink(a, b);
+
+  expect(model.state.links[linkId].sourceNodeId).toBe(a);
+});
+
+test("removeLink deletes the specified link", () => {
+  const model = new RapidMvpModel("Root");
+  const rootId = model.state.rootId;
+  const a = model.addNode(rootId, "A");
+  const b = model.addNode(rootId, "B");
+  const l1 = model.addLink(a, b);
+  const l2 = model.addLink(b, a);
+
+  model.removeLink(l1);
+
+  expect(model.state.links[l1]).toBeUndefined();
+  expect(model.state.links[l2]).toBeDefined();
+});
+
+test("removeLink throws for unknown link id", () => {
+  const model = new RapidMvpModel("Root");
+
+  expect(() => model.removeLink("missing-link")).toThrow(/Link not found/);
+});
+
+test("addLink allows duplicate links between same pair (tentative policy)", () => {
+  const model = new RapidMvpModel("Root");
+  const rootId = model.state.rootId;
+  const a = model.addNode(rootId, "A");
+  const b = model.addNode(rootId, "B");
+
+  const l1 = model.addLink(a, b);
+  const l2 = model.addLink(a, b);
+
+  expect(l1).not.toBe(l2);
+  expect(Object.keys(model.state.links)).toContain(l1);
+  expect(Object.keys(model.state.links)).toContain(l2);
+});
+
 test("deleteNode removes graph links touching deleted nodes", () => {
   const model = new RapidMvpModel("Root");
   const rootId = model.state.rootId;


### PR DESCRIPTION
## Summary
- Add `RapidMvpModel.removeLink(linkId)` alongside the existing `addLink`, with history push and validation; `state.links` is initialized lazily.
- Expose dedicated REST endpoints on port 4173:
  - `POST   /api/docs/:docId/links`  body `{sourceNodeId, targetNodeId, relationType?, label?, direction?, style?}` -> `{ok, link}`
  - `DELETE /api/docs/:docId/links/:linkId` -> `{ok: true}`
- Endpoints load, mutate, and save the whole document via the existing SQLite path, so `AppState.links` round-trips without migration.
- Unit tests cover removeLink, duplicate-pair links, lazy links-map init, and error paths (invalid endpoints, unknown linkId).

## TENTATIVE decisions (see DEV/reviews/Link API on akaghef-beta)
- **Q1 API shape** — tentative: dedicated REST endpoints (this PR). Alt: whole-doc POST only.
- **Q2 duplicate-link policy** — tentative: allow multiple links between the same node pair (no dedup at addLink).
- **Q3 self-link policy** — tentative: reject (preserves existing addLink behavior). Alt: allow self-links.

Reverse any tentative decision by editing the Qn node with `selected="yes"` on the preferred option; follow-up PR will adjust.

## Test plan
- [x] `cd beta && npx tsc --noEmit -p tsconfig.node.json` clean
- [x] `cd beta && npm run build:node && npx vitest run tests/unit/rapid_mvp.test.js` — 22 passed
- [ ] Smoke: `curl -X POST http://localhost:4173/api/docs/<docId>/links -d '{"sourceNodeId":"...","targetNodeId":"..."}'` then `DELETE /api/docs/<docId>/links/<linkId>`; verify the doc reloads with the link added/removed.