### PR TITLE
feat(data): linear-text-box edit API

### DIFF
--- a/backlog/linear-api-qs-260414.md
+++ b/backlog/linear-api-qs-260414.md
@@ -1,0 +1,26 @@
+# Linear API — Qn pool (pending map sync)
+
+Route: `ROOT/SYSTEM/DEV/reviews/Linear API/Qn`
+Agent: data
+Date: 2026-04-14
+Tentative decisions taken (attributes.tentative="yes"). Operator: please promote to map when map server is reachable.
+
+## Q1: PUT semantics — full replace vs append?
+- tentative: **full replace**. PUT writes `linearNotesByScope[scopeId] = body.text` verbatim.
+- rationale: matches HTTP PUT idempotency; appending is a client-side UX concern and keeps the server stateless.
+- reversal cost: low on wire format (new endpoint or extra `mode` param); medium on client integrations already deployed.
+
+## Q2: Debounce strategy — server-side or client-side?
+- tentative: **client-side only**. Server accepts every PUT; each write bumps docVersion + fires SSE.
+- rationale: server coalescing would require per-scope timers and complicates SSE fan-out; client already owns keystroke cadence.
+- reversal cost: low; a future server-side coalescer can be added without breaking the API.
+
+## Q3: DELETE of missing key — 404 or 200?
+- tentative: **200 idempotent** (`removed: false` when key was absent).
+- rationale: DELETE is idempotent per REST conventions; 404 reserved for unknown scopeId (node missing).
+- reversal cost: low.
+
+## Q4: Empty string vs delete?
+- tentative: **distinct**. PUT with `""` preserves the key (explicit empty); DELETE removes the key entirely.
+- rationale: lets UI distinguish "cleared by user" from "never set".
+- reversal cost: low.

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -545,6 +545,128 @@ async function handleBackupApi(
   sendJson(res, 200, { ok: true, documentId: route.docId, backups });
 }
 
+// ---------------------------------------------------------------------------
+// Linear-note-box API (per-scope text editor backing store)
+// ---------------------------------------------------------------------------
+
+function parseLinearNoteRoute(urlPath: string): { docId: string; scopeId: string } | null {
+  const pathname = new URL(urlPath, "http://localhost").pathname;
+  const match = pathname.match(/^\/api\/docs\/([^/]+)\/linear\/([^/]+)$/);
+  if (!match) return null;
+  return {
+    docId: decodeURIComponent(match[1]),
+    scopeId: decodeURIComponent(match[2]),
+  };
+}
+
+async function handleLinearNoteApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: { docId: string; scopeId: string },
+): Promise<void> {
+  const { docId, scopeId } = route;
+  if (!docId || !scopeId) {
+    sendJson(res, 400, { ok: false, error: "Document id and scope id are required." });
+    return;
+  }
+
+  let model: RapidMvpModel;
+  try {
+    model = RapidMvpModel.loadFromSqlite(SQLITE_DB_PATH, docId);
+  } catch (err) {
+    const message = (err as Error).message || "Unknown error";
+    if (message === "Document not found.") {
+      sendJson(res, 404, { ok: false, error: message });
+    } else {
+      sendJson(res, 500, { ok: false, error: message });
+    }
+    return;
+  }
+
+  const state = model.toJSON();
+  // Validate scopeId is an existing nodeId.
+  if (!state.nodes || !state.nodes[scopeId]) {
+    sendJson(res, 404, { ok: false, error: `Scope node not found: ${scopeId}` });
+    return;
+  }
+
+  if (req.method === "GET") {
+    const map = state.linearNotesByScope ?? {};
+    const text = typeof map[scopeId] === "string" ? map[scopeId] : "";
+    sendJson(res, 200, { ok: true, scopeId, text });
+    return;
+  }
+
+  if (req.method === "PUT") {
+    let text: string;
+    try {
+      const rawBody = await readRequestBody(req);
+      const parsed = JSON.parse(rawBody) as { text?: unknown };
+      if (typeof parsed.text !== "string") {
+        sendJson(res, 400, { ok: false, error: "Field 'text' (string) is required." });
+        return;
+      }
+      text = parsed.text;
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        sendJson(res, 400, { ok: false, error: "Invalid JSON body." });
+        return;
+      }
+      sendJson(res, 400, { ok: false, error: (err as Error).message || "Invalid body." });
+      return;
+    }
+
+    // Mutate in place: lazy-init the map, write the entry, persist.
+    const nextState: AppState = { ...state };
+    const nextMap: Record<string, string> = { ...(nextState.linearNotesByScope ?? {}) };
+    nextMap[scopeId] = text;
+    nextState.linearNotesByScope = nextMap;
+
+    const nextModel = RapidMvpModel.fromJSON(nextState);
+    const errors = nextModel.validate();
+    if (errors.length > 0) {
+      sendJson(res, 400, { ok: false, error: `Invalid model before save: ${errors.join(" | ")}` });
+      return;
+    }
+    nextModel.saveToSqlite(SQLITE_DB_PATH, docId);
+    const savedAt = new Date().toISOString();
+    const sourceTabId = (req.headers["x-m3e-tab-id"] as string) || null;
+    incrementDocVersion();
+    broadcastDocUpdate(docId, savedAt, sourceTabId);
+    sendJson(res, 200, { ok: true, scopeId, savedAt });
+    return;
+  }
+
+  if (req.method === "DELETE") {
+    const nextState: AppState = { ...state };
+    const currentMap = nextState.linearNotesByScope ?? {};
+    if (!(scopeId in currentMap)) {
+      // Idempotent: still report ok with savedAt of now but note unchanged.
+      sendJson(res, 200, { ok: true, scopeId, savedAt: new Date().toISOString(), removed: false });
+      return;
+    }
+    const nextMap: Record<string, string> = { ...currentMap };
+    delete nextMap[scopeId];
+    nextState.linearNotesByScope = nextMap;
+
+    const nextModel = RapidMvpModel.fromJSON(nextState);
+    const errors = nextModel.validate();
+    if (errors.length > 0) {
+      sendJson(res, 400, { ok: false, error: `Invalid model before save: ${errors.join(" | ")}` });
+      return;
+    }
+    nextModel.saveToSqlite(SQLITE_DB_PATH, docId);
+    const savedAt = new Date().toISOString();
+    const sourceTabId = (req.headers["x-m3e-tab-id"] as string) || null;
+    incrementDocVersion();
+    broadcastDocUpdate(docId, savedAt, sourceTabId);
+    sendJson(res, 200, { ok: true, scopeId, savedAt, removed: true });
+    return;
+  }
+
+  sendJson(res, 405, { ok: false, error: "Method not allowed." });
+}
+
 function isLinearTransformRoute(urlPath: string): boolean {
   const pathname = new URL(urlPath, "http://localhost").pathname;
   return pathname === "/api/linear-transform/status" || pathname === "/api/linear-transform/convert";
@@ -1451,6 +1573,12 @@ export function createAppServer(): http.Server {
       }
       const list = getPresenceList(presenceDocId);
       sendJson(res, 200, { ok: true, documentId: presenceDocId, count: list.length, users: list });
+      return;
+    }
+
+    const linearNoteRoute = parseLinearNoteRoute(req.url ?? "/");
+    if (linearNoteRoute) {
+      await handleLinearNoteApi(req, res, linearNoteRoute);
       return;
     }
 

--- a/beta/tests/unit/linear_notes_api.test.js
+++ b/beta/tests/unit/linear_notes_api.test.js
@@ -1,0 +1,174 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-linear-api-data-"));
+process.env.M3E_DATA_DIR = tempDataDir;
+
+const { createAppServer } = require("../../dist/node/start_viewer.js");
+const { RapidMvpModel } = require("../../dist/node/rapid_mvp.js");
+
+let server;
+let baseUrl;
+
+async function requestJson(url, init) {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => ({}));
+  return { response, payload };
+}
+
+function seedDoc(docId) {
+  // Build a minimal valid state and POST it via the whole-doc API so the
+  // document row exists in SQLite.
+  const model = new RapidMvpModel("Root");
+  const childId = model.addNode(model.state.rootId, "Child A");
+  return { state: model.toJSON(), rootId: model.state.rootId, childId };
+}
+
+beforeAll(async () => {
+  server = createAppServer();
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+  fs.rmSync(tempDataDir, { recursive: true, force: true });
+});
+
+async function ensureDoc(docId) {
+  const seeded = seedDoc(docId);
+  const post = await requestJson(`${baseUrl}/api/docs/${docId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: seeded.state }),
+  });
+  expect(post.response.status).toBe(200);
+  return seeded;
+}
+
+test("GET returns empty text when linearNotesByScope is unset", async () => {
+  const docId = "linear-get-empty";
+  const seeded = await ensureDoc(docId);
+  const res = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.rootId)}`,
+  );
+  expect(res.response.status).toBe(200);
+  expect(res.payload.ok).toBe(true);
+  expect(res.payload.scopeId).toBe(seeded.rootId);
+  expect(res.payload.text).toBe("");
+});
+
+test("PUT then GET round-trips the text", async () => {
+  const docId = "linear-put-get";
+  const seeded = await ensureDoc(docId);
+  const body = { text: "problem: X\nthought: try Y" };
+  const put = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(body),
+    },
+  );
+  expect(put.response.status).toBe(200);
+  expect(put.payload.ok).toBe(true);
+  expect(put.payload.scopeId).toBe(seeded.childId);
+  expect(typeof put.payload.savedAt).toBe("string");
+
+  const get = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+  );
+  expect(get.response.status).toBe(200);
+  expect(get.payload.text).toBe(body.text);
+
+  // Full-replace semantics — PUT with shorter text replaces, not appends.
+  const put2 = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ text: "replaced" }),
+    },
+  );
+  expect(put2.response.status).toBe(200);
+  const get2 = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+  );
+  expect(get2.payload.text).toBe("replaced");
+});
+
+test("DELETE clears the entry", async () => {
+  const docId = "linear-delete";
+  const seeded = await ensureDoc(docId);
+  await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ text: "to be deleted" }),
+    },
+  );
+  const del = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+    { method: "DELETE" },
+  );
+  expect(del.response.status).toBe(200);
+  expect(del.payload.ok).toBe(true);
+  expect(del.payload.removed).toBe(true);
+
+  const get = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.childId)}`,
+  );
+  expect(get.payload.text).toBe("");
+
+  // Verify the key was removed (not just set to "") by inspecting the doc state.
+  const docGet = await requestJson(`${baseUrl}/api/docs/${docId}`);
+  const map = docGet.payload.state.linearNotesByScope ?? {};
+  expect(Object.prototype.hasOwnProperty.call(map, seeded.childId)).toBe(false);
+});
+
+test("returns 404 when scopeId is not an existing nodeId", async () => {
+  const docId = "linear-bad-scope";
+  await ensureDoc(docId);
+  const res = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/nonexistent-node-id`,
+  );
+  expect(res.response.status).toBe(404);
+  expect(res.payload.ok).toBe(false);
+
+  const put = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/nonexistent-node-id`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ text: "x" }),
+    },
+  );
+  expect(put.response.status).toBe(404);
+});
+
+test("PUT rejects body without text field", async () => {
+  const docId = "linear-bad-body";
+  const seeded = await ensureDoc(docId);
+  const res = await requestJson(
+    `${baseUrl}/api/docs/${docId}/linear/${encodeURIComponent(seeded.rootId)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ notText: 123 }),
+    },
+  );
+  expect(res.response.status).toBe(400);
+});

--- a/dev-docs/03_Spec/REST_API.md
+++ b/dev-docs/03_Spec/REST_API.md
@@ -34,6 +34,9 @@ M3E_ROOT=C:\Users\chiec\dev\M3E
 | `DELETE` | `/api/docs/{docId}` | 物理削除（archived のみ） | 本文書 |
 | `GET` | `/api/docs/{docId}` | ドキュメント読み込み | 本文書 |
 | `POST` | `/api/docs/{docId}` | ドキュメント保存 | 本文書 |
+| `GET` | `/api/docs/{docId}/linear/{scopeId}` | リニアノート取得 | 本文書 |
+| `PUT` | `/api/docs/{docId}/linear/{scopeId}` | リニアノート保存 | 本文書 |
+| `DELETE` | `/api/docs/{docId}/linear/{scopeId}` | リニアノート削除 | 本文書 |
 | `GET` | `/api/sync/status/{docId}` | クラウド同期ステータス | 本文書 |
 | `POST` | `/api/sync/push/{docId}` | クラウドへ push | 本文書 |
 | `POST` | `/api/sync/pull/{docId}` | クラウドから pull | 本文書 |
@@ -294,6 +297,67 @@ Body:
 - Link の `direction` / `style` の値域
 - ツリーの循環検出（DFS）
 - 孤立ノードの検出
+
+---
+
+## Linear Notes API
+
+リニアテキストボックス（スコープ単位の自由記述エリア）を全体ドキュメントの POST ラウンドトリップ無しで編集するための API。
+`AppState.linearNotesByScope: Record<string, string>` を scopeId（= nodeId）単位で読み書きする。
+
+書き込みは in-place で反映され、他のミューテーションと同様に `docVersion` をインクリメントし、
+`/api/docs/{docId}/watch` SSE サブスクライバーに `doc_updated` を通知する。
+
+### `GET /api/docs/{docId}/linear/{scopeId}`
+
+指定スコープのリニアテキストを取得する。未設定なら空文字を返す。
+
+#### 成功レスポンス (200)
+
+```json
+{ "ok": true, "scopeId": "n_xxx", "text": "problem: ..." }
+```
+
+#### エラーレスポンス
+
+| status | 条件 |
+|--------|------|
+| 404 | ドキュメント不在 / scopeId がノードとして存在しない |
+
+### `PUT /api/docs/{docId}/linear/{scopeId}`
+
+指定スコープのリニアテキストを**完全置換**で保存する（追記は client 側の責務）。
+
+#### リクエスト Body
+
+```json
+{ "text": "任意の UTF-8 文字列" }
+```
+
+#### 成功レスポンス (200)
+
+```json
+{ "ok": true, "scopeId": "n_xxx", "savedAt": "2026-04-14T10:00:00.000Z" }
+```
+
+#### エラーレスポンス
+
+| status | 条件 |
+|--------|------|
+| 400 | JSON パース失敗 / `text` が文字列でない / validate エラー |
+| 404 | ドキュメント不在 / scopeId がノードとして存在しない |
+
+### `DELETE /api/docs/{docId}/linear/{scopeId}`
+
+指定スコープのエントリをマップから削除する（キーごと除去）。存在しなかった場合も 200 で返す（冪等）。
+
+#### 成功レスポンス (200)
+
+```json
+{ "ok": true, "scopeId": "n_xxx", "savedAt": "...", "removed": true }
+```
+
+`removed` は実際にキーが存在して削除された場合のみ `true`。
 
 ---
 


### PR DESCRIPTION
## Summary

Targeted REST endpoints for editing `AppState.linearNotesByScope` without a full-doc POST round-trip — backing store for the per-scope linear text box used as the natural-language input channel that agents later materialize as `reviews/<Task>/Qn` children on the map.

- `GET    /api/docs/:docId/linear/:scopeId` → `{ok, scopeId, text}` (empty string if unset)
- `PUT    /api/docs/:docId/linear/:scopeId` body `{text}` → `{ok, scopeId, savedAt}` (full replace)
- `DELETE /api/docs/:docId/linear/:scopeId` → `{ok, scopeId, savedAt, removed}` (idempotent)

Mutations persist in place via `RapidMvpModel.saveToSqlite`, run `validate()` before write, bump `docVersion`, and broadcast `doc_updated` to `/api/docs/:docId/watch` SSE subscribers. `scopeId` is validated as an existing `nodes[scopeId]` (404 otherwise). `linearNotesByScope` is lazy-initialized — no schema change, V1-compatible.

## Pooled ambiguity (tentative defaults applied)

Recorded in `backlog/linear-api-qs-260414.md` for later promotion to `ROOT/SYSTEM/DEV/reviews/Linear API/Qn`:

- **Q1 PUT semantics**: full replace (append is a client concern).
- **Q2 Debounce**: client-side only; server accepts every PUT.
- **Q3 DELETE of missing key**: 200 idempotent with `removed:false`.
- **Q4 Empty string vs DELETE**: distinct — PUT "" preserves the key; DELETE removes it.

## Test plan

- [x] `npx tsc -p tsconfig.node.json` clean
- [x] `npx vitest run tests/unit/linear_notes_api.test.js` — 5/5 pass (GET empty, PUT/GET round-trip + full-replace, DELETE removes key, 404 on bad scopeId, 400 on missing text)
- [x] Full suite: only 3 pre-existing failures on `origin/dev-beta` (persistence_db_behavior ×2, backup ×1, flash_ingest ×1); unchanged by this PR.
- [ ] Manual: browser linear-text editor can switch from full-doc POST to this API (follow-up, browser scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)