### PR TITLE
visual: add table view mode for sibling comparison

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -2767,6 +2767,62 @@ function render(): void {
   });
   defs += "</defs>";
 
+  /**
+   * Render children of a node as an HTML table via foreignObject.
+   * Columns are auto-derived from the union of all children's attribute keys
+   * (excluding m3e: internal attributes). First column is always the node text.
+   */
+  function renderTableView(parentId: string, parentPos: { x: number; y: number; w: number; h: number }): string {
+    const parent = state.nodes[parentId];
+    if (!parent || parent.children.length === 0) return "";
+
+    const childNodes = parent.children
+      .map((cid) => state.nodes[cid])
+      .filter((n): n is TreeNode => !!n);
+
+    // Collect column keys from all children's attributes (exclude m3e: internals)
+    const colSet = new Set<string>();
+    for (const child of childNodes) {
+      for (const key of Object.keys(child.attributes || {})) {
+        if (!key.startsWith("m3e:")) colSet.add(key);
+      }
+      if (child.details) colSet.add("_details");
+    }
+    const columns = Array.from(colSet).sort();
+
+    // Build HTML table
+    const esc = (s: string) => escapeXml(s);
+
+    let html = `<table class="m3e-table-view"><thead><tr><th>Name</th>`;
+    for (const col of columns) {
+      html += `<th>${esc(col === "_details" ? "Details" : col)}</th>`;
+    }
+    html += `</tr></thead><tbody>`;
+
+    for (const child of childNodes) {
+      const statusClass = child.attributes?.["m3e:status"] ? ` class="status-${esc(child.attributes["m3e:status"])}"` : "";
+      html += `<tr data-node-id="${esc(child.id)}"${statusClass}>`;
+      html += `<td class="m3e-table-name">${esc(child.text || "(empty)")}</td>`;
+      for (const col of columns) {
+        if (col === "_details") {
+          html += `<td>${esc(child.details || "")}</td>`;
+        } else {
+          html += `<td>${esc(child.attributes?.[col] || "")}</td>`;
+        }
+      }
+      html += `</tr>`;
+    }
+    html += `</tbody></table>`;
+
+    // Size: estimate based on columns and rows
+    const tableW = Math.max(columns.length * 150 + 200, 600);
+    const tableH = Math.min((childNodes.length + 1) * 32 + 16, 800);
+    const foX = parentPos.x - 20;
+    const foY = parentPos.y + parentPos.h / 2 + 20;
+
+    return `<foreignObject x="${foX}" y="${foY}" width="${tableW}" height="${tableH}"><div xmlns="http://www.w3.org/1999/xhtml" class="m3e-table-container">${html}</div></foreignObject>`;
+  }
+
   function drawNode(nodeId: string): void {
     const node = state.nodes[nodeId];
     const p = pos[nodeId];
@@ -2947,7 +3003,14 @@ function render(): void {
       nodes += `<text class="collapsed-badge-count" data-collapse-node-id="${nodeId}" x="${indicatorX}" y="${p.y}" text-anchor="middle" dominant-baseline="middle">${escapeXml(badgeLabel)}</text>`;
     }
 
-    children.forEach((cid) => drawNode(cid));
+    // Table view mode: render children as table instead of tree
+    const viewType = node.attributes?.["m3e:view-type"];
+    if (viewType === "table" && children.length > 0 && nodeId !== displayRootId) {
+      // Skip recursive tree rendering for children — they'll be shown as table
+      nodes += renderTableView(nodeId, p);
+    } else {
+      children.forEach((cid) => drawNode(cid));
+    }
   }
 
   drawNode(displayRootId);

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -2231,3 +2231,55 @@
       .viewer-logo:hover {
         background: var(--accent-soft);
       }
+
+      /* ── m3e: table view ── */
+      .m3e-table-container {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        font-size: 13px;
+        overflow: auto;
+        max-height: 780px;
+        background: #fff;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+      }
+      .m3e-table-view {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      .m3e-table-view th {
+        background: #f5f5f7;
+        border-bottom: 2px solid #ddd;
+        padding: 6px 10px;
+        text-align: left;
+        font-weight: 600;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #555;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+      .m3e-table-view td {
+        padding: 5px 10px;
+        border-bottom: 1px solid #eee;
+        color: #333;
+        max-width: 300px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .m3e-table-view tr:hover {
+        background: rgba(106, 53, 255, 0.04);
+      }
+      .m3e-table-view .m3e-table-name {
+        font-weight: 500;
+        color: #232323;
+      }
+      .m3e-table-view tr.status-placeholder td { opacity: 0.5; }
+      .m3e-table-view tr.status-confirmed td:first-child { border-left: 3px solid #2d8c4e; }
+      .m3e-table-view tr.status-contested td:first-child { border-left: 3px solid #d94040; }
+      .m3e-table-view tr.status-frozen td { opacity: 0.7; }
+      .m3e-table-view tr.status-active td:first-child { border-left: 3px solid #e89b1a; }
+      .m3e-table-view tr.status-review td:first-child { border-left: 3px solid #9b59b6; }


### PR DESCRIPTION
## Summary
- Adds `renderTableView()` function in `viewer.ts` that renders child nodes as an HTML table via `foreignObject` when parent has `m3e:view-type="table"` attribute
- Columns are auto-derived from the union of all children's attribute keys (excluding `m3e:` internals); first column is always the node name
- Includes status-aware row styling (confirmed/contested/frozen/active/review) and CSS for sticky headers, hover highlight, and overflow scroll

## Test plan
- [ ] Set `m3e:view-type` to `"table"` on a parent node with multiple children that share attributes
- [ ] Verify table renders with correct columns derived from children's attributes
- [ ] Verify children with `m3e:status` attributes show correct left-border colors
- [ ] Verify table does not appear when `m3e:view-type` is absent or has a different value
- [ ] Verify the display root node itself is excluded from table rendering (tree always shown at root level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)