### PR TITLE
Add LangGraph study prototype

### DIFF
--- a/beta/prototypes/langgraph-study/app.js
+++ b/beta/prototypes/langgraph-study/app.js
@@ -1,0 +1,209 @@
+const snippets = {
+  modern: `from typing_extensions import TypedDict
+from langgraph.graph import START, END, StateGraph
+
+class State(TypedDict):
+    user_input: str
+    answer: str
+
+def answer_once(state: State) -> dict[str, str]:
+    return {"answer": f"received: {state['user_input']}"}
+
+builder = StateGraph(State)
+builder.add_node("answer_once", answer_once)
+builder.add_edge(START, "answer_once")
+builder.add_edge("answer_once", END)
+
+graph = builder.compile()
+print(graph.invoke({"user_input": "hello"}))`,
+
+  task: `from typing import Literal
+from typing_extensions import TypedDict
+from langgraph.graph import START, END, StateGraph
+
+class TaskState(TypedDict):
+    raw_input: str
+    tasks: list[str]
+    prioritized: list[dict]
+    summary: str
+
+def parse_tasks(state: TaskState):
+    return {"tasks": ["レポートを書く", "洗濯する"]}
+
+def add_priority(state: TaskState):
+    return {"prioritized": [{"task": t, "priority": "中"} for t in state["tasks"]]}
+
+def route_after_priority(state: TaskState) -> Literal["deadline", "summary"]:
+    return "deadline" if "今日" in state["raw_input"] else "summary"
+
+def deadline_estimate(state: TaskState):
+    return {"prioritized": [{**x, "due": "今日"} for x in state["prioritized"]]}
+
+def summarize(state: TaskState):
+    return {"summary": "期限が近いものから処理する。"}
+
+builder = StateGraph(TaskState)
+builder.add_node("parse", parse_tasks)
+builder.add_node("priority", add_priority)
+builder.add_node("deadline", deadline_estimate)
+builder.add_node("summary", summarize)
+builder.add_edge(START, "parse")
+builder.add_edge("parse", "priority")
+builder.add_conditional_edges("priority", route_after_priority, {
+    "deadline": "deadline",
+    "summary": "summary",
+})
+builder.add_edge("deadline", "summary")
+builder.add_edge("summary", END)
+graph = builder.compile()`,
+
+  tools: `from typing_extensions import TypedDict, Annotated
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langgraph.graph import START, END, StateGraph
+from langgraph.graph.message import add_messages
+
+class ChatState(TypedDict):
+    messages: Annotated[list, add_messages]
+
+@tool
+def multiply(x: int, y: int) -> int:
+    return x * y
+
+tools_by_name = {"multiply": multiply}
+
+def chatbot(state: ChatState):
+    response = llm_with_tools.invoke(state["messages"])
+    return {"messages": [response]}
+
+def tool_node(state: ChatState):
+    outputs = []
+    for call in state["messages"][-1].tool_calls:
+        result = tools_by_name[call["name"]].invoke(call["args"])
+        outputs.append(ToolMessage(content=str(result), tool_call_id=call["id"]))
+    return {"messages": outputs}
+
+def route_tools(state: ChatState):
+    last = state["messages"][-1]
+    return "tools" if getattr(last, "tool_calls", None) else END
+
+builder = StateGraph(ChatState)
+builder.add_node("chatbot", chatbot)
+builder.add_node("tools", tool_node)
+builder.add_edge(START, "chatbot")
+builder.add_conditional_edges("chatbot", route_tools, {"tools": "tools", END: END})
+builder.add_edge("tools", "chatbot")
+graph = builder.compile()`,
+};
+
+const traces = {
+  deadline: [
+    ["START", "入力 State を graph に渡す"],
+    ["parse", "自然文から作業単位を抽出する"],
+    ["priority", "各 task に優先度を付ける"],
+    ["deadline", "期限語を見て due を補完し、今日・明日なら高優先度へ寄せる"],
+    ["summary", "取り組み順の一文を作る"],
+    ["END", "最終 State を返す"],
+  ],
+  plain: [
+    ["START", "入力 State を graph に渡す"],
+    ["parse", "自然文から作業単位を抽出する"],
+    ["priority", "各 task に優先度を付ける"],
+    ["summary", "期限推定を飛ばしてまとめる"],
+    ["END", "最終 State を返す"],
+  ],
+  tool: [
+    ["START", "user message を State.messages に入れる"],
+    ["chatbot", "LLM が回答または tool call を返す"],
+    ["tools", "tool call を実行し ToolMessage を追加する"],
+    ["chatbot", "tool result を読んで最終回答を生成する"],
+    ["END", "会話 State を返す"],
+  ],
+};
+
+const diagrams = {
+  deadline: `flowchart LR
+  Start((START)) --> Parse["parse_tasks"]
+  Parse --> Priority["add_priority"]
+  Priority -->|"期限語あり"| Deadline["deadline_estimate"]
+  Priority -.->|"期限語なし"| Summary["summarize"]
+  Deadline --> Summary
+  Summary --> End((END))`,
+  plain: `flowchart LR
+  Start((START)) --> Parse["parse_tasks"]
+  Parse --> Priority["add_priority"]
+  Priority -.->|"期限語あり"| Deadline["deadline_estimate"]
+  Priority -->|"期限語なし"| Summary["summarize"]
+  Deadline -.-> Summary
+  Summary --> End((END))`,
+  tool: `flowchart LR
+  Start((START)) --> Chatbot["chatbot"]
+  Chatbot -->|"tool_calls"| Tools["tool_node"]
+  Tools --> Chatbot
+  Chatbot -->|"no tool_calls"| End((END))`,
+};
+
+const codeBlock = document.getElementById("codeBlock");
+const tabs = Array.from(document.querySelectorAll(".tab"));
+const scenarioSelect = document.getElementById("scenarioSelect");
+const traceList = document.getElementById("traceList");
+const flowDiagram = document.getElementById("flowDiagram");
+const progressText = document.getElementById("progressText");
+const progressBar = document.getElementById("progressBar");
+const checklist = document.getElementById("checklist");
+const navLinks = Array.from(document.querySelectorAll(".rail-nav a"));
+
+function renderCode(name) {
+  codeBlock.textContent = snippets[name];
+  tabs.forEach((tab) => tab.classList.toggle("is-active", tab.dataset.tab === name));
+}
+
+async function renderScenario(name) {
+  flowDiagram.textContent = diagrams[name];
+  traceList.innerHTML = traces[name]
+    .map((item, index) => {
+      const [label, detail] = item;
+      return `<article class="trace-item"><span>${index + 1}</span><div><strong>${label}</strong><p>${detail}</p></div></article>`;
+    })
+    .join("");
+
+  if (window.mermaid) {
+    flowDiagram.removeAttribute("data-processed");
+    await window.mermaid.run({ nodes: [flowDiagram] });
+  }
+}
+
+function updateProgress() {
+  const checks = Array.from(checklist.querySelectorAll("input"));
+  const done = checks.filter((input) => input.checked).length;
+  progressText.textContent = `${done} / ${checks.length}`;
+  progressBar.style.width = `${(done / checks.length) * 100}%`;
+}
+
+function updateActiveNav() {
+  const current = navLinks
+    .map((link) => {
+      const target = document.querySelector(link.getAttribute("href"));
+      return { link, top: target.getBoundingClientRect().top };
+    })
+    .filter((item) => item.top < 180)
+    .pop();
+
+  navLinks.forEach((link) => link.removeAttribute("aria-current"));
+  (current?.link ?? navLinks[0]).setAttribute("aria-current", "page");
+}
+
+tabs.forEach((tab) => tab.addEventListener("click", () => renderCode(tab.dataset.tab)));
+scenarioSelect.addEventListener("change", () => renderScenario(scenarioSelect.value));
+checklist.addEventListener("change", updateProgress);
+document.addEventListener("scroll", updateActiveNav, { passive: true });
+
+window.addEventListener("load", async () => {
+  if (window.mermaid) {
+    window.mermaid.initialize({ startOnLoad: false, theme: "base" });
+  }
+  renderCode("modern");
+  await renderScenario("deadline");
+  updateProgress();
+  updateActiveNav();
+});

--- a/beta/prototypes/langgraph-study/index.html
+++ b/beta/prototypes/langgraph-study/index.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LangGraph Study Board</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      window.mermaid = mermaid;
+    </script>
+  </head>
+  <body>
+    <main class="study-shell">
+      <aside class="rail" aria-label="LangGraph study navigation">
+        <div class="brand-block">
+          <p class="eyebrow">Study Board</p>
+          <h1>LangGraph</h1>
+          <p>StateGraph を中心に、node / edge / state / route / tool calling を一枚で復習する。</p>
+        </div>
+
+        <nav class="rail-nav" aria-label="Sections">
+          <a href="#overview" aria-current="page">Overview</a>
+          <a href="#flow">Flow</a>
+          <a href="#code">Code</a>
+          <a href="#drill">Drill</a>
+          <a href="#sources">Sources</a>
+        </nav>
+
+        <section class="progress-panel" aria-label="Learning progress">
+          <div class="progress-head">
+            <span>Progress</span>
+            <strong id="progressText">0 / 6</strong>
+          </div>
+          <div class="meter"><span id="progressBar"></span></div>
+        </section>
+      </aside>
+
+      <section class="content">
+        <header class="topline">
+          <div>
+            <p class="eyebrow">VSCode workspace</p>
+            <h2>最小エージェントから M3E Runtime までつなぐ</h2>
+          </div>
+          <div class="source-chip">Python / LangGraph</div>
+        </header>
+
+        <section id="overview" class="band overview-band" aria-labelledby="overview-title">
+          <div class="section-head">
+            <p class="eyebrow">Overview</p>
+            <h2 id="overview-title">まず掴む4語</h2>
+          </div>
+          <div class="concept-grid">
+            <article class="concept" data-accent="state">
+              <span>01</span>
+              <h3>State</h3>
+              <p>全 node が読み書きする共有状態。返り値は通常、State の部分更新。</p>
+            </article>
+            <article class="concept" data-accent="node">
+              <span>02</span>
+              <h3>Node</h3>
+              <p>Python 関数または runnable。LLM 呼び出し、tool 実行、整形、判定を分ける。</p>
+            </article>
+            <article class="concept" data-accent="edge">
+              <span>03</span>
+              <h3>Edge</h3>
+              <p>次に実行する node を決める線。固定遷移と条件付き遷移を使い分ける。</p>
+            </article>
+            <article class="concept" data-accent="thread">
+              <span>04</span>
+              <h3>Thread</h3>
+              <p>checkpoint を辿れる一連の実行。M3E の Runtime Board と対応させやすい。</p>
+            </article>
+          </div>
+        </section>
+
+        <section id="flow" class="band flow-band" aria-labelledby="flow-title">
+          <div class="section-head">
+            <p class="eyebrow">Interactive Flow</p>
+            <h2 id="flow-title">タスク管理AIの流れ</h2>
+          </div>
+          <div class="flow-layout">
+            <div class="diagram-panel">
+              <pre class="mermaid" id="flowDiagram">
+flowchart LR
+  Start((START)) --> Parse["parse_tasks"]
+  Parse --> Priority["add_priority"]
+  Priority -->|"期限語あり"| Deadline["deadline_estimate"]
+  Priority -->|"期限語なし"| Summary["summarize"]
+  Deadline --> Summary
+  Summary --> End((END))
+              </pre>
+            </div>
+            <div class="sim-panel">
+              <label for="scenarioSelect">Scenario</label>
+              <select id="scenarioSelect">
+                <option value="deadline">期限語あり</option>
+                <option value="plain">期限語なし</option>
+                <option value="tool">tool calling へ拡張</option>
+              </select>
+              <div id="traceList" class="trace-list" aria-live="polite"></div>
+            </div>
+          </div>
+        </section>
+
+        <section id="code" class="band code-band" aria-labelledby="code-title">
+          <div class="section-head">
+            <p class="eyebrow">VSCode Notes</p>
+            <h2 id="code-title">最小実装の骨格</h2>
+          </div>
+          <div class="code-tabs" role="tablist" aria-label="Code examples">
+            <button class="tab is-active" type="button" data-tab="modern">modern</button>
+            <button class="tab" type="button" data-tab="task">task agent</button>
+            <button class="tab" type="button" data-tab="tools">tools</button>
+          </div>
+          <pre class="code-block"><code id="codeBlock"></code></pre>
+        </section>
+
+        <section id="drill" class="band drill-band" aria-labelledby="drill-title">
+          <div class="section-head">
+            <p class="eyebrow">Drill</p>
+            <h2 id="drill-title">理解チェック</h2>
+          </div>
+          <div class="checklist" id="checklist">
+            <label><input type="checkbox" /> State を TypedDict または Pydantic model で定義できる</label>
+            <label><input type="checkbox" /> node は State を受け取り、部分更新を返すと説明できる</label>
+            <label><input type="checkbox" /> START / END と set_entry_point / set_finish_point の対応が分かる</label>
+            <label><input type="checkbox" /> add_conditional_edges の routing function を書ける</label>
+            <label><input type="checkbox" /> tool calling で ToolMessage を State に戻す理由が分かる</label>
+            <label><input type="checkbox" /> M3E では GraphSpec と Runtime Board に分けて考えられる</label>
+          </div>
+        </section>
+
+        <section id="sources" class="band sources-band" aria-labelledby="sources-title">
+          <div class="section-head">
+            <p class="eyebrow">Sources</p>
+            <h2 id="sources-title">参照元</h2>
+          </div>
+          <div class="source-list">
+            <a href="https://www.skygroup.jp/tech-blog/article/2320/" target="_blank" rel="noreferrer">Ｓｋｙ Tech Blog: タスク管理AIの最小構成</a>
+            <a href="https://qiita.com/sakuraia/items/27db3f118e0ee41c54c1" target="_blank" rel="noreferrer">Qiita: 初心者向け LangGraph 基本操作</a>
+            <a href="https://docs.langchain.com/oss/python/langgraph/graph-api" target="_blank" rel="noreferrer">LangGraph official docs: Graph API</a>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/beta/prototypes/langgraph-study/langgraph-implementation-examples.md
+++ b/beta/prototypes/langgraph-study/langgraph-implementation-examples.md
@@ -1,0 +1,104 @@
+# LangGraph Implementation Examples
+
+| No. | Example | URL |
+|---:|---|---|
+| 1 | Agentic RAG notebook | https://github.com/langchain-ai/langgraph/blob/main/examples/rag/langgraph_agentic_rag.ipynb |
+| 2 | LangGraph Cloud example agent | https://github.com/langchain-ai/langgraph-example |
+| 3 | ReAct agent template | https://github.com/langchain-ai/react-agent |
+| 4 | Agent chat UI for LangGraph agents | https://github.com/langchain-ai/agent-chat-ui |
+| 5 | Large-tool LangGraph agent | https://github.com/langchain-ai/langgraph-bigtool |
+| 6 | CodeAct LangGraph agent | https://github.com/langchain-ai/langgraph-codeact |
+| 7 | Supervisor multi-agent library/example | https://github.com/langchain-ai/langgraph-supervisor-py |
+| 8 | Swarm multi-agent library/example | https://github.com/langchain-ai/langgraph-swarm-py |
+| 9 | LangGraph 101 notebooks | https://github.com/langchain-ai/langgraph-101 |
+| 10 | LangGraph.js generative UI agents | https://github.com/langchain-ai/langgraphjs-gen-ui-examples |
+| 11 | Gemini full-stack LangGraph quickstart | https://github.com/google-gemini/gemini-fullstack-langgraph-quickstart |
+| 12 | AWS Bedrock LangGraph agents | https://github.com/aws-samples/langgraph-agents-with-amazon-bedrock |
+| 13 | AWS multi-agent data-analysis workflow | https://github.com/aws-samples/langgraph-multi-agent |
+| 14 | FastAPI LangGraph production template | https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template |
+| 15 | Agent service toolkit | https://github.com/JoshuaC215/agent-service-toolkit |
+| 16 | Agentic RAG for Dummies | https://github.com/GiovanniPasq/agentic-rag-for-dummies |
+| 17 | Controllable RAG Agent | https://github.com/NirDiamant/Controllable-RAG-Agent |
+| 18 | GenAI Agents examples | https://github.com/NirDiamant/GenAI_Agents |
+| 19 | Agents toward production examples | https://github.com/NirDiamant/agents-towards-production |
+| 20 | AI PDF chatbot with LangChain/LangGraph | https://github.com/mayooear/ai-pdf-chatbot-langchain |
+| 21 | Company research agent | https://github.com/guy-hartstein/company-research-agent |
+| 22 | Multi-agent report writer | https://github.com/botextractai/ai-langgraph-multi-agent |
+| 23 | DATAGEN research assistant | https://github.com/starpig1129/DATAGEN |
+| 24 | LangGraph Java examples/runtime | https://github.com/langgraph4j/langgraph4j |
+| 25 | LangGraph.js framework examples | https://github.com/langchain-ai/langgraphjs |
+| 26 | LangGraph TypeScript agents from scratch | https://github.com/langchain-ai/agents-from-scratch-ts |
+| 27 | Multi-agent course examples | https://github.com/emarco177/langgraph-course |
+| 28 | LangChain course with LangGraph agents | https://github.com/emarco177/langchain-course |
+| 29 | LangChain OpenTutorial LangGraph examples | https://github.com/LangChain-OpenTutorial/LangChain-OpenTutorial |
+| 30 | LangGraph freeCodeCamp course code | https://github.com/iamvaibhavmehra/LangGraph-Course-freeCodeCamp |
+| 31 | LangGraph Practice workflow examples | https://github.com/0x-Professor/LangGraph-Practice |
+| 32 | Master LangGraph workflows: 20 projects | https://github.com/hereandnowai/master-langgraph-workflows-in-python-20-real-world-agent-projects-by-hereandnow-ai |
+| 33 | Dive into LangGraph tutorial | https://github.com/luochang212/dive-into-langgraph |
+| 34 | BrandPeng LangChain/LangGraph learning repo | https://github.com/BrandPeng/Langchain1.0-Langgraph1.0-Learning |
+| 35 | LangGraph chatbot with memory | https://github.com/NanGePlus/LangGraphChatBot |
+| 36 | Web search agent | https://github.com/john-adeojo/graph_websearch_agent |
+| 37 | Stock insights AI agent | https://github.com/vinay-gatech/stocks-insights-ai-agent |
+| 38 | Options analytics agent | https://github.com/nuglifeleoji/Options-Analytics-Agent |
+| 39 | YT Navigator video-search agent | https://github.com/wassim249/YT-Navigator |
+| 40 | OpenChatBI text-to-SQL agent | https://github.com/zhongyu09/openchatbi |
+| 41 | SnowChat text-to-SQL agent | https://github.com/kaarthik108/snowChat |
+| 42 | Legal-tech contract chat agent | https://github.com/tomasonjo-labs/legal-tech-chat |
+| 43 | Medical multi-agent assistant | https://github.com/souvikmajumder26/Multi-Agent-Medical-Assistant |
+| 44 | Aurora SRE incident agent | https://github.com/Arvo-AI/aurora |
+| 45 | WhatsApp LangGraph agent | https://github.com/lucasboscatti/Whatsapp-Langgraph-Agent-Integration |
+| 46 | LangGraph voice-call agent | https://github.com/ahmad2b/langgraph-voice-call-agent |
+| 47 | LangGraph voice-call web UI | https://github.com/ahmad2b/langgraph-voice-call-agent-web |
+| 48 | Human-in-the-loop FastAPI demo | https://github.com/esurovtsev/langgraph-hitl-fastapi-demo |
+| 49 | FastAPI meets LangGraph REST demo | https://github.com/naghost-dev/Fastapi-meets-Langgraph |
+| 50 | LangGraph streaming WebSocket API | https://github.com/sheikhhanif/LangGraph_Streaming |
+| 51 | BentoML LangGraph serving demo | https://github.com/bentoml/BentoLangGraph |
+| 52 | LangGraph AWS deployment template | https://github.com/al-mz/langgraph-aws-deployment |
+| 53 | Azure adaptive RAG workbench | https://github.com/Azure-Samples/adaptive-rag-workbench |
+| 54 | Azure App Service LangGraph Foundry Python | https://github.com/Azure-Samples/app-service-agentic-langgraph-foundry-python |
+| 55 | Azure App Service LangGraph Foundry Node | https://github.com/Azure-Samples/app-service-agentic-langgraph-foundry-node |
+| 56 | LangGraph MCP agent template | https://github.com/prsdm/langgraph-mcp |
+| 57 | LangGraph MCP solution template | https://github.com/esxr/langgraph-mcp |
+| 58 | MCP LangGraph tutorial | https://github.com/hirokiyn/mcp-langgraph |
+| 59 | LangGraph MCP agents Streamlit app | https://github.com/braincrew-lab/langgraph-mcp-agents |
+| 60 | MCP multi-server LangGraph A2A system | https://github.com/junfanz1/MCP-MultiServer-Interoperable-Agent2Agent-LangGraph-AI-System |
+| 61 | A2A server for LangGraph agents | https://github.com/5enxia/langgraph-a2a-server |
+| 62 | LangGraph agent OpenWebUI demo | https://github.com/casedone/langgraph-agent-openwebui-demo |
+| 63 | LangGraph agents template | https://github.com/panaversity/langgraph-agents-template |
+| 64 | Production multi-agent system | https://github.com/shamspias/langgraph-agents |
+| 65 | LangGraph agent system for LangGraph Platform | https://github.com/shamspias/langgraph-agent-system |
+| 66 | Clean architecture LangGraph agent | https://github.com/eng-mostafa-alrahal/langgraph-agent-clean-architecture |
+| 67 | LangGraph agent toolkit | https://github.com/kryvokhyzha/langgraph-agent-toolkit |
+| 68 | LangGraph agent skill tutorial | https://github.com/SpillwaveSolutions/mastering-langgraph-agent-skill |
+| 69 | Agent contracts for LangGraph | https://github.com/yatarousan0227/agent-contracts |
+| 70 | Think-tool LangGraph agent | https://github.com/emanueleielo/langgraph-think-tool |
+| 71 | LangGraph Compass follow-up question agent | https://github.com/sardanaaman/langgraph-compass |
+| 72 | Recursive LangGraph.js agent | https://github.com/maunappl8/recursive-langgraph-agent |
+| 73 | LangGraph StateGraph runtime example | https://github.com/zkzkGamal/zkzkAgent |
+| 74 | Agentic vision RAG | https://github.com/MaazzAlii/langchain-agentic-vision-rag |
+| 75 | Deep research StateGraph agent | https://github.com/surpradhan/cartograph |
+| 76 | Sales-development HITL agent | https://github.com/prithvikar/constrox-sdr-agent |
+| 77 | Multi-agent supervisor demo | https://github.com/dasda34user/langgraph-multi-agent-supervisor |
+| 78 | Medical clinical decision support pipeline | https://github.com/PranavViswanathan/CaduceusAI |
+| 79 | Grafana inspection agent | https://github.com/gengjie/grafana-inspection-agent |
+| 80 | Supervisor research orchestrator | https://github.com/HarveyAGH/Supervisor-Research-Orchestrator-with-Langgraph |
+| 81 | Chinook music SQL agent benchmark | https://github.com/finding-archit/Chinook-Music-Agent |
+| 82 | NPS analysis StateGraph agent | https://github.com/edsonirvana/ml-nps-analysis |
+| 83 | Sales training Agentic RAG | https://github.com/xt765/UMU-Sales-Trainer |
+| 84 | Multi-tool PDF/calculator chatbot | https://github.com/Saurav-kumar077/LangGraph-Chatbot |
+| 85 | Advanced LangGraph agents lab | https://github.com/sujitchan431/av-advanced-langgraph-agents |
+| 86 | Referral-letter urgency agent | https://github.com/gbhorne/langgraph-referral-letter-agent |
+| 87 | Stateful market intelligence agent | https://github.com/ruthuraraj-ml/stateful-market-intelligence-agent |
+| 88 | Casino host multi-agent system | https://github.com/Oded-Ben-Yair/hey-seven |
+| 89 | Security reconnaissance ReAct agent | https://github.com/grinsteindavid/atlas-security-react-agent |
+| 90 | Patent hunter agent | https://github.com/katsuyukishimbo/patent-hunter |
+| 91 | Prompt-injection firewall StateGraph | https://github.com/yashgunjal95/ai-based-secure-prompt-injection-detection |
+| 92 | MemOS RAG/memory Streamlit agent | https://github.com/dev-k99/MemOS |
+| 93 | Loan eligibility chatbot | https://github.com/Laxmikant-Baviskar/LoanSense-AI |
+| 94 | Medical scheduling agent | https://github.com/debalina-chowdhury/langgraph-medical-agent |
+| 95 | Multi-Agent Dev Squad | https://github.com/MinhHieu13-cmc/Multi-Agent_Dev_Squad |
+| 96 | Governed LangGraph HITL policy agent | https://github.com/MacFall7/governed-langgraph |
+| 97 | Corrective RAG Streamlit app | https://github.com/Yashajmeri/LLM_Based_Agentic_RAG |
+| 98 | Multi-agent research system | https://github.com/riddhi-more/Multi-Agent-Research-System |
+| 99 | AI blog writer with Send/reducer graph | https://github.com/rajgupta19/ai-blog-writer |
+| 100 | Automated data-analysis agent with tools/HITL | https://github.com/huchunbo666/ai-agent-assistant |

--- a/beta/prototypes/langgraph-study/styles.css
+++ b/beta/prototypes/langgraph-study/styles.css
@@ -1,0 +1,457 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --panel: #ffffff;
+  --panel-strong: #eef1f5;
+  --ink: #171a1f;
+  --muted: #647083;
+  --line: #d9dee7;
+  --blue: #1f6feb;
+  --teal: #0f766e;
+  --red: #b42318;
+  --amber: #a16207;
+  --violet: #6d28d9;
+  --shadow: 0 18px 50px rgba(16, 24, 40, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 1120px;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, "Segoe UI", system-ui, sans-serif;
+}
+
+button,
+select {
+  font: inherit;
+}
+
+button,
+select,
+a,
+input {
+  min-height: 36px;
+}
+
+.study-shell {
+  display: grid;
+  grid-template-columns: 292px minmax(0, 1fr);
+  gap: 18px;
+  min-height: 100vh;
+  padding: 18px;
+}
+
+.rail {
+  position: sticky;
+  top: 18px;
+  align-self: start;
+  display: grid;
+  gap: 18px;
+  height: calc(100vh - 36px);
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.brand-block {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 34px;
+  line-height: 1.05;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+h3 {
+  margin-bottom: 8px;
+  font-size: 17px;
+  line-height: 1.25;
+}
+
+p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.rail-nav {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+
+.rail-nav a,
+.source-list a {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fff;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.rail-nav a {
+  padding: 0 12px;
+}
+
+.rail-nav a[aria-current="page"] {
+  border-color: var(--blue);
+  background: #edf4ff;
+  color: #0f4fb7;
+}
+
+.progress-panel {
+  align-self: end;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-strong);
+}
+
+.progress-head {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.meter {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #d9dee7;
+}
+
+.meter span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--teal);
+  transition: width 180ms ease;
+}
+
+.content {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.topline,
+.band {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 86px;
+  padding: 18px 20px;
+}
+
+.topline > div,
+.section-head > div,
+.band,
+.concept {
+  min-width: 0;
+}
+
+.source-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid #b8c6d9;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #334155;
+  font-size: 13px;
+  font-weight: 800;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.band {
+  padding: 20px;
+}
+
+.section-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+
+.concept-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.concept {
+  min-height: 172px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-top: 4px solid var(--blue);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.concept[data-accent="node"] {
+  border-top-color: var(--teal);
+}
+
+.concept[data-accent="edge"] {
+  border-top-color: var(--amber);
+}
+
+.concept[data-accent="thread"] {
+  border-top-color: var(--violet);
+}
+
+.concept span {
+  display: block;
+  margin-bottom: 16px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.flow-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 330px;
+  gap: 14px;
+}
+
+.diagram-panel,
+.sim-panel,
+.code-block,
+.checklist,
+.source-list {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.diagram-panel {
+  min-height: 350px;
+  padding: 16px;
+  overflow: auto;
+}
+
+.diagram-panel .mermaid {
+  max-width: 100%;
+  overflow: auto;
+}
+
+.diagram-panel .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.sim-panel {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  padding: 14px;
+}
+
+.sim-panel label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fff;
+  color: var(--ink);
+  padding: 0 10px;
+}
+
+.trace-list {
+  display: grid;
+  gap: 8px;
+}
+
+.trace-item {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 10px;
+  border: 1px solid #e1e6ef;
+  border-radius: 7px;
+  background: #f8fafc;
+}
+
+.trace-item span {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: #111827;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.trace-item strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 14px;
+}
+
+.trace-item p {
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.code-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tab {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fff;
+  color: var(--ink);
+  padding: 0 14px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.tab.is-active {
+  border-color: #111827;
+  background: #111827;
+  color: #fff;
+}
+
+.code-block {
+  min-height: 344px;
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  color: #d6deeb;
+  background: #101827;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.checklist {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 12px;
+}
+
+.checklist label {
+  display: grid;
+  grid-template-columns: 20px 1fr;
+  gap: 10px;
+  align-items: start;
+  min-height: 48px;
+  padding: 12px;
+  border: 1px solid #e1e6ef;
+  border-radius: 7px;
+  background: #f8fafc;
+  color: #273142;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.checklist input {
+  min-height: 18px;
+  margin-top: 2px;
+  accent-color: var(--teal);
+}
+
+.source-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.source-list a {
+  padding: 10px 12px;
+}
+
+@media (max-width: 900px) {
+  body {
+    min-width: 0;
+  }
+
+  .study-shell,
+  .flow-layout,
+  .concept-grid,
+  .checklist {
+    grid-template-columns: 1fr;
+  }
+
+  .rail {
+    position: static;
+    height: auto;
+  }
+
+  .topline,
+  .section-head {
+    align-items: start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a static LangGraph study page under beta/prototypes/langgraph-study
- Cover StateGraph basics, task-agent routing, tool-calling notes, source links, and an interactive progress checklist
- Use Mermaid from CDN for graph visualization

## Verification
- node --check beta/prototypes/langgraph-study/app.js
- git diff --check
- Browser verification at http://localhost:5179/: page load, Mermaid render, scenario switch, tools tab, checklist progress
- Responsive check: 1280px desktop and 390px mobile without horizontal overflow

## Residual risk
- Mermaid rendering depends on the CDN being reachable; the source links are external references.