### PR TITLE
Refactor viewer layout options and PN controls

### DIFF
--- a/beta/src/browser/viewer.globals.d.ts
+++ b/beta/src/browser/viewer.globals.d.ts
@@ -19,6 +19,10 @@ type SurfaceKind = "tree" | "system" | "scatter" | "mindmap" | "logic-chart" | "
 type SurfaceLayout = "tree" | "flow-lr" | "scatter" | "mindmap" | "logic-chart" | "timeline";
 type SurfaceLayoutDensity = "compact" | "balanced" | "spacious";
 type SurfaceBranchDirection = "both" | "right" | "left";
+type SurfaceLayoutDirection = "right" | "left" | "down" | "up";
+type SurfaceDepthAlign = "aligned" | "packed";
+type SurfaceEdgeRoute = "elbow" | "bezier" | "straight";
+type SurfaceLinkRoute = "simple-bezier" | "orthogonal" | "straight";
 
 interface TreeNode {
   id: string;
@@ -335,6 +339,10 @@ interface ViewState {
   surfaceViewMode: SurfaceViewMode;
   surfaceLayoutDensity: SurfaceLayoutDensity;
   surfaceBranchDirection: SurfaceBranchDirection;
+  surfaceLayoutDirection: SurfaceLayoutDirection;
+  surfaceDepthAlign: SurfaceDepthAlign;
+  surfaceEdgeRoute: SurfaceEdgeRoute;
+  surfaceLinkRoute: SurfaceLinkRoute;
   zoom: number;
   cameraX: number;
   cameraY: number;
@@ -352,6 +360,34 @@ interface ViewState {
 
 type CameraMovePreset = "off" | "minimal" | "follow-selection" | "cinematic" | "locked";
 type CameraMoveTrigger = "scope" | "selection" | "layout" | "continuous" | "command";
+
+interface Window {
+  m3eLayout?: (
+    graph: {
+      nodeIds: string[];
+      childrenOf: (id: string) => string[];
+      graphLinks: GraphLink[];
+    },
+    boxSizes: Record<string, { w: number; h: number; labelLines?: string[]; fontSize?: number }>,
+    mode: SurfaceKind,
+    options?: {
+      spacing?: { nodeGap?: number; levelGap?: number; padding?: number };
+      direction?: SurfaceLayoutDirection;
+      depthAlign?: SurfaceDepthAlign;
+      edge?: { route?: SurfaceEdgeRoute };
+      link?: { route?: SurfaceLinkRoute };
+      displayRootId?: string;
+      structuredMode?: "tree" | "mindmap" | "logic-chart" | "timeline";
+      density?: SurfaceLayoutDensity;
+      branchDirection?: SurfaceBranchDirection;
+    },
+  ) => {
+    pos: Record<string, NodePosition>;
+    order: string[];
+    totalWidth: number;
+    totalHeight: number;
+  };
+}
 
 interface CameraMoveState {
   preset: CameraMovePreset;

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -669,6 +669,10 @@ let viewState: ViewState = {
   surfaceViewMode: "tree",
   surfaceLayoutDensity: "balanced",
   surfaceBranchDirection: "right",
+  surfaceLayoutDirection: "right",
+  surfaceDepthAlign: "packed",
+  surfaceEdgeRoute: "elbow",
+  surfaceLinkRoute: "simple-bezier",
   zoom: 1,
   cameraX: VIEWER_TUNING.pan.initialCameraX,
   cameraY: VIEWER_TUNING.pan.initialCameraY,
@@ -770,6 +774,31 @@ function sanitizeSurfaceBranchDirection(value: unknown): SurfaceBranchDirection 
   return "right";
 }
 
+function sanitizeSurfaceLayoutDirection(value: unknown): SurfaceLayoutDirection {
+  if (value === "right" || value === "left" || value === "down" || value === "up") {
+    return value;
+  }
+  return "right";
+}
+
+function sanitizeSurfaceDepthAlign(value: unknown): SurfaceDepthAlign {
+  return value === "aligned" ? "aligned" : "packed";
+}
+
+function sanitizeSurfaceEdgeRoute(value: unknown): SurfaceEdgeRoute {
+  if (value === "elbow" || value === "bezier" || value === "straight") {
+    return value;
+  }
+  return "elbow";
+}
+
+function sanitizeSurfaceLinkRoute(value: unknown): SurfaceLinkRoute {
+  if (value === "simple-bezier" || value === "orthogonal" || value === "straight") {
+    return value;
+  }
+  return "simple-bezier";
+}
+
 function inferSurfaceLayoutDensityForScope(scopeId: string, mode: SurfaceViewMode): SurfaceLayoutDensity {
   if (!map || !map.state.nodes[scopeId]) {
     return "balanced";
@@ -796,6 +825,10 @@ function syncThinkingModeUi(): void {
   const mode = viewState.thinkingMode;
   const surfaceMode = structuredSurfaceMode();
   document.body.classList.toggle("scatter-surface-active", viewState.surfaceViewMode === "scatter");
+  document.documentElement.dataset.surfaceLayoutDirection = viewState.surfaceLayoutDirection;
+  document.documentElement.dataset.surfaceDepthAlign = viewState.surfaceDepthAlign;
+  document.documentElement.dataset.surfaceEdgeRoute = viewState.surfaceEdgeRoute;
+  document.documentElement.dataset.surfaceLinkRoute = viewState.surfaceLinkRoute;
   const layoutSuffix = surfaceMode
     ? ` / ${surfaceLayoutDensityLabel(viewState.surfaceLayoutDensity)} / ${surfaceBranchDirectionLabel(viewState.surfaceBranchDirection)}`
     : "";
@@ -902,6 +935,34 @@ function setSurfaceBranchDirection(direction: SurfaceBranchDirection): void {
     fitDocument();
   });
   setStatus(`Depth: ${surfaceBranchDirectionLabel(direction)}`);
+}
+
+function setPublicLayoutOptions(options: Partial<PublicLayoutOptions>): void {
+  if (options.direction) {
+    viewState.surfaceLayoutDirection = sanitizeSurfaceLayoutDirection(options.direction);
+  }
+  if (options.depthAlign) {
+    viewState.surfaceDepthAlign = sanitizeSurfaceDepthAlign(options.depthAlign);
+  }
+  if (options.edge?.route) {
+    viewState.surfaceEdgeRoute = sanitizeSurfaceEdgeRoute(options.edge.route);
+  }
+  if (options.link?.route) {
+    viewState.surfaceLinkRoute = sanitizeSurfaceLinkRoute(options.link.route);
+  }
+  _linearPanelLayoutDirty = true;
+  syncThinkingModeUi();
+  render();
+  fitDocument();
+  window.dispatchEvent(new CustomEvent("m3e:layout-options-changed", {
+    detail: {
+      direction: viewState.surfaceLayoutDirection,
+      depthAlign: viewState.surfaceDepthAlign,
+      edgeRoute: viewState.surfaceEdgeRoute,
+      linkRoute: viewState.surfaceLinkRoute,
+    },
+  }));
+  setStatus("Layout options updated.");
 }
 
 function syncScatterToolbarUi(): void {
@@ -6511,6 +6572,33 @@ interface LayoutNodeMetric {
   fontSize?: number;
 }
 
+type PublicLayoutOptions = {
+  spacing?: { nodeGap?: number; levelGap?: number; padding?: number };
+  direction?: SurfaceLayoutDirection;
+  depthAlign?: SurfaceDepthAlign;
+  edge?: { route?: SurfaceEdgeRoute };
+  link?: { route?: SurfaceLinkRoute };
+  scatter?: { seed?: number; strength?: number; repulsion?: number };
+};
+
+type InternalLayoutOptions = {
+  displayRootId?: string;
+  structuredMode?: StructuredSurfaceMode;
+  density?: SurfaceLayoutDensity;
+  branchDirection?: SurfaceBranchDirection;
+  surfaceNodeViews?: Record<string, SurfaceNodeView>;
+  flowCells?: Record<string, { col: number; row: number; isReference: boolean }>;
+  scatterCollapsedGroups?: Record<string, boolean>;
+};
+
+type LayoutOptions = PublicLayoutOptions & InternalLayoutOptions;
+
+type VisibleLayoutGraph = {
+  nodeIds: string[];
+  childrenOf: (id: string) => string[];
+  graphLinks: GraphLink[];
+};
+
 interface MeasuredTreeContext {
   displayRootId: string;
   metrics: Record<string, LayoutNodeMetric>;
@@ -6518,6 +6606,7 @@ interface MeasuredTreeContext {
   depthMaxWidth: Record<number, number>;
   maxDepth: number;
   config: StructuredLayoutConfig;
+  depthAlign: SurfaceDepthAlign;
 }
 
 function structuredSurfaceMode(): StructuredSurfaceMode | null {
@@ -6532,9 +6621,11 @@ function structuredSurfaceMode(): StructuredSurfaceMode | null {
   return null;
 }
 
-function structuredLayoutConfig(mode: StructuredSurfaceMode): StructuredLayoutConfig {
-  const density = viewState.surfaceLayoutDensity;
-  const branchDirection = viewState.surfaceBranchDirection;
+function structuredLayoutConfig(
+  mode: StructuredSurfaceMode,
+  density = viewState.surfaceLayoutDensity,
+  branchDirection = viewState.surfaceBranchDirection,
+): StructuredLayoutConfig {
   const compact = density === "compact";
   const spacious = density === "spacious";
   const mapLike = mode === "mindmap";
@@ -6600,30 +6691,36 @@ function compactNodeMinHeight(config: StructuredLayoutConfig): number {
   return config.density === "compact" ? 22 : VIEWER_TUNING.layout.leafHeight;
 }
 
-function buildMeasuredTreeContext(state: AppState, displayRootId: string, mode: StructuredSurfaceMode): MeasuredTreeContext {
-  const config = structuredLayoutConfig(mode);
+function buildMeasuredTreeContext(
+  displayRootId: string,
+  mode: StructuredSurfaceMode,
+  graph: VisibleLayoutGraph,
+  boxSizes: Record<string, LayoutNodeMetric>,
+  options: LayoutOptions = {},
+): MeasuredTreeContext {
+  const config = structuredLayoutConfig(mode, options.density, options.branchDirection);
   const metrics: Record<string, LayoutNodeMetric> = {};
   const depthOf: Record<string, number> = {};
   const depthMaxWidth: Record<number, number> = {};
   let maxDepth = 0;
 
   function visit(nodeId: string, depth: number): void {
-    const node = state.nodes[nodeId];
-    if (!node) return;
+    const metric = boxSizes[nodeId];
+    if (!metric) return;
     maxDepth = Math.max(maxDepth, depth);
     depthOf[nodeId] = depth;
-    metrics[nodeId] = measureLayoutNode(state, nodeId, displayRootId, config);
+    metrics[nodeId] = metric;
     depthMaxWidth[depth] = Math.max(depthMaxWidth[depth] ?? 0, metrics[nodeId]!.w);
-    visibleChildren(node).forEach((childId) => visit(childId, depth + 1));
+    graph.childrenOf(nodeId).forEach((childId) => visit(childId, depth + 1));
   }
 
   visit(displayRootId, 0);
-  return { displayRootId, metrics, depthOf, depthMaxWidth, maxDepth, config };
+  return { displayRootId, metrics, depthOf, depthMaxWidth, maxDepth, config, depthAlign: options.depthAlign || "packed" };
 }
 
 function subtreeSpanForLayout(
-  state: AppState,
   nodeId: string,
+  childrenOf: (id: string) => string[],
   metrics: Record<string, LayoutNodeMetric>,
   cache: Record<string, number>,
   siblingGap = VIEWER_TUNING.layout.siblingGap,
@@ -6631,11 +6728,10 @@ function subtreeSpanForLayout(
   if (cache[nodeId] !== undefined) {
     return cache[nodeId]!;
   }
-  const node = state.nodes[nodeId];
-  if (!node) {
+  if (!metrics[nodeId]) {
     return VIEWER_TUNING.layout.leafHeight;
   }
-  const children = visibleChildren(node);
+  const children = childrenOf(nodeId);
   if (children.length === 0) {
     const leafSpan = Math.max(VIEWER_TUNING.layout.leafHeight, metrics[nodeId]!.h + siblingGap);
     cache[nodeId] = leafSpan;
@@ -6643,7 +6739,7 @@ function subtreeSpanForLayout(
   }
   let sum = 0;
   children.forEach((childId, i) => {
-    sum += subtreeSpanForLayout(state, childId, metrics, cache, siblingGap);
+    sum += subtreeSpanForLayout(childId, childrenOf, metrics, cache, siblingGap);
     if (i < children.length - 1) {
       sum += siblingGap;
     }
@@ -6669,8 +6765,42 @@ function finalizeLayoutBounds(pos: Record<string, NodePosition>, order: string[]
   };
 }
 
-function buildRightTreeLayout(state: AppState, ctx: MeasuredTreeContext): LayoutResult {
-  const { displayRootId, metrics, depthOf, depthMaxWidth, maxDepth, config } = ctx;
+function orientLayoutResult(result: LayoutResult, direction: SurfaceLayoutDirection | undefined): LayoutResult {
+  if (!direction || direction === "right") {
+    return result;
+  }
+  const order = result.order.filter((nodeId) => result.pos[nodeId]);
+  if (order.length === 0) {
+    return result;
+  }
+  const positions = order.map((nodeId) => result.pos[nodeId]!);
+  const minX = Math.min(...positions.map((p) => p.x));
+  const maxX = Math.max(...positions.map((p) => p.x + p.w));
+  const minY = Math.min(...positions.map((p) => p.y - p.h / 2));
+  const maxY = Math.max(...positions.map((p) => p.y + p.h / 2));
+  const oriented: Record<string, NodePosition> = {};
+  order.forEach((nodeId) => {
+    const p = result.pos[nodeId]!;
+    if (direction === "left") {
+      oriented[nodeId] = { ...p, x: minX + maxX - (p.x + p.w) };
+      return;
+    }
+    if (direction === "down") {
+      oriented[nodeId] = { ...p, x: minY + (p.y - p.h / 2), y: minX + (p.x - minX) + p.w / 2 };
+      return;
+    }
+    oriented[nodeId] = { ...p, x: minY + (maxY - (p.y + p.h / 2)), y: minX + (p.x - minX) + p.w / 2 };
+  });
+  const bounds = finalizeLayoutBounds(oriented, order);
+  return { ...result, pos: oriented, totalHeight: bounds.totalHeight, totalWidth: bounds.totalWidth };
+}
+
+function applyDepthAlignOptions(result: LayoutResult, options: LayoutOptions): LayoutResult {
+  return orientLayoutResult(result, options.direction);
+}
+
+function buildRightTreeLayout(graph: VisibleLayoutGraph, ctx: MeasuredTreeContext): LayoutResult {
+  const { displayRootId, metrics, depthOf, depthMaxWidth, maxDepth, config, depthAlign } = ctx;
   const xByDepth: Record<number, number> = {};
   let cursorX = VIEWER_TUNING.layout.leftPad;
   for (let d = 0; d <= maxDepth; d += 1) {
@@ -6681,15 +6811,14 @@ function buildRightTreeLayout(state: AppState, ctx: MeasuredTreeContext): Layout
   const subtreeHeightCache: Record<string, number> = {};
   const pos: Record<string, NodePosition> = {};
   const order: string[] = [];
-  const depthOffsetFactor = VIEWER_TUNING.layout.depthOffsetFactor;
+  const depthOffsetFactor = depthAlign === "aligned" ? 0 : VIEWER_TUNING.layout.depthOffsetFactor;
 
   function place(nodeId: string, topY: number, parentX: number | null, parentW: number | null): number {
-    const node = state.nodes[nodeId];
-    if (!node) return VIEWER_TUNING.layout.leafHeight;
+    if (!metrics[nodeId]) return VIEWER_TUNING.layout.leafHeight;
     const depth = depthOf[nodeId] ?? 0;
     const h = subtreeSpanForLayout(
-      state,
       nodeId,
+      graph.childrenOf,
       metrics,
       subtreeHeightCache,
       config.mode === "tree" ? VIEWER_TUNING.layout.siblingGap : config.siblingGap,
@@ -6704,7 +6833,7 @@ function buildRightTreeLayout(state: AppState, ctx: MeasuredTreeContext): Layout
     pos[nodeId] = { x: nodeX, y: centerY, depth, w: metrics[nodeId]!.w, h: metrics[nodeId]!.h, fontSize: metrics[nodeId]!.fontSize, labelLines: metrics[nodeId]!.labelLines };
     order.push(nodeId);
     let placeCursorY = topY;
-    visibleChildren(node).forEach((childId, i, arr) => {
+    graph.childrenOf(nodeId).forEach((childId, i, arr) => {
       const childH = place(childId, placeCursorY, nodeX, metrics[nodeId]!.w);
       placeCursorY += childH;
       if (i < arr.length - 1) placeCursorY += config.mode === "tree" ? VIEWER_TUNING.layout.siblingGap : config.siblingGap;
@@ -6725,9 +6854,8 @@ function buildRightTreeLayout(state: AppState, ctx: MeasuredTreeContext): Layout
   return { pos, order, totalHeight: bounds.totalHeight, totalWidth: bounds.totalWidth };
 }
 
-function splitMindmapBranches(state: AppState, rootId: string, direction: SurfaceBranchDirection): { left: string[]; right: string[] } {
-  const root = state.nodes[rootId];
-  const children = root ? visibleChildren(root) : [];
+function splitMindmapBranches(graph: VisibleLayoutGraph, rootId: string, direction: SurfaceBranchDirection): { left: string[]; right: string[] } {
+  const children = graph.childrenOf(rootId);
   const left: string[] = [];
   const right: string[] = [];
   if (direction === "right") {
@@ -6742,7 +6870,7 @@ function splitMindmapBranches(state: AppState, rootId: string, direction: Surfac
   return { left, right };
 }
 
-function buildMindmapLayout(state: AppState, ctx: MeasuredTreeContext): LayoutResult {
+function buildMindmapLayout(graph: VisibleLayoutGraph, ctx: MeasuredTreeContext): LayoutResult {
   const { displayRootId, metrics, depthOf, depthMaxWidth, maxDepth, config } = ctx;
   const rootMetric = metrics[displayRootId] || { w: 280, h: VIEWER_TUNING.layout.rootHeight };
   const branchWidth = (fromDepth = 1): number => {
@@ -6767,10 +6895,10 @@ function buildMindmapLayout(state: AppState, ctx: MeasuredTreeContext): LayoutRe
     leftXByDepth[d] = leftXByDepth[d - 1]! - config.columnGap - (depthMaxWidth[d] ?? 120);
   }
   const spanCache: Record<string, number> = {};
-  const { left, right } = splitMindmapBranches(state, displayRootId, config.branchDirection);
+  const { left, right } = splitMindmapBranches(graph, displayRootId, config.branchDirection);
   const sideGap = config.sideGap;
   const sideSpan = (ids: string[]) => ids.reduce((sum, id, index) => (
-    sum + subtreeSpanForLayout(state, id, metrics, spanCache, config.siblingGap) + (index > 0 ? sideGap : 0)
+    sum + subtreeSpanForLayout(id, graph.childrenOf, metrics, spanCache, config.siblingGap) + (index > 0 ? sideGap : 0)
   ), 0);
   const totalSpan = Math.max(rootMetric.h + 60, sideSpan(left), sideSpan(right), VIEWER_TUNING.layout.rootHeight + 80);
   const rootY = VIEWER_TUNING.layout.topPad + totalSpan / 2;
@@ -6780,10 +6908,9 @@ function buildMindmapLayout(state: AppState, ctx: MeasuredTreeContext): LayoutRe
   const order: string[] = [displayRootId];
 
   function placeSide(nodeId: string, topY: number, direction: -1 | 1): number {
-    const node = state.nodes[nodeId];
-    if (!node) return VIEWER_TUNING.layout.leafHeight;
+    if (!metrics[nodeId]) return VIEWER_TUNING.layout.leafHeight;
     const depth = Math.max(1, depthOf[nodeId] ?? 1);
-    const span = subtreeSpanForLayout(state, nodeId, metrics, spanCache, config.siblingGap);
+    const span = subtreeSpanForLayout(nodeId, graph.childrenOf, metrics, spanCache, config.siblingGap);
     const metric = metrics[nodeId]!;
     const centerY = topY + span / 2;
     const depthWidth = depthMaxWidth[depth] ?? metric.w;
@@ -6793,7 +6920,7 @@ function buildMindmapLayout(state: AppState, ctx: MeasuredTreeContext): LayoutRe
     pos[nodeId] = { x, y: centerY, depth, w: metric.w, h: metric.h, fontSize: metric.fontSize, labelLines: metric.labelLines };
     order.push(nodeId);
     let cursorY = topY;
-    visibleChildren(node).forEach((childId, i, arr) => {
+    graph.childrenOf(nodeId).forEach((childId, i, arr) => {
       const childSpan = placeSide(childId, cursorY, direction);
       cursorY += childSpan;
       if (i < arr.length - 1) cursorY += config.siblingGap;
@@ -6815,7 +6942,7 @@ function buildMindmapLayout(state: AppState, ctx: MeasuredTreeContext): LayoutRe
   return { pos, order, totalHeight: bounds.totalHeight, totalWidth: bounds.totalWidth };
 }
 
-function buildTimelineLayout(state: AppState, ctx: MeasuredTreeContext): LayoutResult {
+function buildTimelineLayout(graph: VisibleLayoutGraph, ctx: MeasuredTreeContext): LayoutResult {
   const { displayRootId, metrics, depthOf, config } = ctx;
   const rootMetric = metrics[displayRootId] || { w: 280, h: VIEWER_TUNING.layout.rootHeight };
   const rootX = VIEWER_TUNING.layout.leftPad;
@@ -6824,14 +6951,11 @@ function buildTimelineLayout(state: AppState, ctx: MeasuredTreeContext): LayoutR
     [displayRootId]: { x: rootX, y: axisY, depth: 0, w: rootMetric.w, h: rootMetric.h, fontSize: rootMetric.fontSize, labelLines: rootMetric.labelLines },
   };
   const order: string[] = [displayRootId];
-  const root = state.nodes[displayRootId];
-  const rootChildren = root ? visibleChildren(root) : [];
+  const rootChildren = graph.childrenOf(displayRootId);
   const stepX = Math.max(config.density === "compact" ? 190 : 260, config.columnGap + 120);
 
   function placeDescendants(nodeId: string, baseX: number, baseY: number, sign: -1 | 1): void {
-    const node = state.nodes[nodeId];
-    if (!node) return;
-    visibleChildren(node).forEach((childId, index) => {
+    graph.childrenOf(nodeId).forEach((childId, index) => {
       const metric = metrics[childId]!;
       const x = baseX + 54;
       const y = baseY + sign * (92 + index * 72);
@@ -6855,28 +6979,38 @@ function buildTimelineLayout(state: AppState, ctx: MeasuredTreeContext): LayoutR
   return { pos, order, totalHeight: bounds.totalHeight, totalWidth: bounds.totalWidth };
 }
 
-function buildLayout(state: AppState): LayoutResult {
-  const displayRootId = currentScopeRootId();
-  const displayRootNode = state.nodes[displayRootId];
-  const flowSurface = currentSurfaceIsFlowMode();
-  const scatterSurface = currentSurfaceIsScatterMode();
-  const metrics: Record<string, { w: number; h: number }> = {};
-  const depthOf: Record<string, number> = {};
+function layout(
+  visibleGraph: VisibleLayoutGraph,
+  boxSizes: Record<string, LayoutNodeMetric>,
+  mode: SurfaceKind,
+  options: LayoutOptions,
+): LayoutResult {
+  const displayRootId = options.displayRootId || visibleGraph.nodeIds[0] || "";
+  const displayRootExists = Boolean(displayRootId && boxSizes[displayRootId]);
 
-  if (scatterSurface && displayRootNode) {
-    const surface = currentMapSurface();
-    const { ids: descendants, depthOf: scatterDepthOf } = collectScatterNodes(state, displayRootId);
-    const seededByNode = scatterSeedPositions(state, displayRootId, descendants, scatterDepthOf);
+  if (mode === "scatter" && visibleGraph.nodeIds.length > 0) {
+    const descendants = visibleGraph.nodeIds;
+    const scatterDepthOf: Record<string, number> = {};
+    const visitDepth = (nodeId: string, depth: number): void => {
+      scatterDepthOf[nodeId] = depth;
+      visibleGraph.childrenOf(nodeId).forEach((childId) => visitDepth(childId, depth + 1));
+    };
+    descendants.forEach((nodeId) => {
+      if (scatterDepthOf[nodeId] === undefined) {
+        visitDepth(nodeId, 0);
+      }
+    });
+    const seededByNode = scatterSeedPositionsFromGraph(displayRootId, descendants, scatterDepthOf, visibleGraph.childrenOf);
     const pos: Record<string, NodePosition> = {};
     let maxRight = VIEWER_TUNING.layout.minCanvasWidth;
     let maxBottom = VIEWER_TUNING.layout.minCanvasHeight;
     descendants.forEach((nodeId) => {
-      const node = state.nodes[nodeId];
-      if (!node) return;
+      const metric = boxSizes[nodeId];
+      if (!metric) return;
       const depth = scatterDepthOf[nodeId] ?? 0;
-      const radius = scatterRadiusFor(nodeId, depth, descendants.length);
+      const radius = metric.w / 2;
       const diameter = radius * 2;
-      const saved = surface?.nodeViews?.[nodeId];
+      const saved = options.surfaceNodeViews?.[nodeId];
       const seeded = seededByNode[nodeId] || scatterSeedCenter();
       const seededX = seeded.x - radius;
       const seededY = seeded.y;
@@ -6889,7 +7023,7 @@ function buildLayout(state: AppState): LayoutResult {
         w: diameter,
         h: diameter,
         fontSize: scatterFontSizeFor(radius),
-        scatterCollapsedGroup: scatterNodeIsCollapsedGroup(state, nodeId),
+        scatterCollapsedGroup: Boolean(options.scatterCollapsedGroups?.[nodeId]),
       };
       maxRight = Math.max(maxRight, x + diameter + VIEWER_TUNING.layout.canvasRightPad);
       maxBottom = Math.max(maxBottom, y + radius + VIEWER_TUNING.layout.canvasBottomPad);
@@ -6903,41 +7037,30 @@ function buildLayout(state: AppState): LayoutResult {
     };
   }
 
-  if (flowSurface && displayRootNode) {
-    const surfaceNodes = visibleChildren(displayRootNode);
-    const primarySurfaceNodes = surfaceNodes.filter((nodeId) => !isReferenceNode(state.nodes[nodeId]));
-    const referenceSurfaceNodes = surfaceNodes.filter((nodeId) => isReferenceNode(state.nodes[nodeId]));
+  if (mode === "system" && displayRootExists) {
+    const surfaceNodes = visibleGraph.childrenOf(displayRootId);
+    const flowCells = options.flowCells || {};
+    const primarySurfaceNodes = surfaceNodes.filter((nodeId) => !flowCells[nodeId]?.isReference);
+    const referenceSurfaceNodes = surfaceNodes.filter((nodeId) => flowCells[nodeId]?.isReference);
     const pos: Record<string, NodePosition> = {};
     const order: string[] = [];
     const colMaxWidth: Record<number, number> = {};
     const rowMaxHeight: Record<number, number> = {};
+    const depthOf: Record<string, number> = {};
     const surfaceCells: Record<string, { col: number; row: number }> = {};
     const occupiedRowsByCol: Record<number, Set<number>> = {};
     let maxCol = 0;
     let maxRow = 0;
 
     surfaceNodes.forEach((nodeId, index) => {
-      const node = state.nodes[nodeId];
-      if (!node) return;
-      const nodeStyles = effectiveNodeStyleAttrs(node);
-      const label = diagramLabel(node, nodeStyles);
-      const baseMetric = isLatexNode(node)
-        ? measureLatex(node.text)
-        : measureNodeLabel(label, VIEWER_TUNING.typography.nodeFont);
-      const previewLayout = buildFlowPreviewLayout(node);
-      const metric = previewLayout
-        ? {
-            w: Math.max(baseMetric.w + 28, previewLayout.totalWidth),
-            h: Math.max(VIEWER_TUNING.layout.leafHeight + 18, previewLayout.totalHeight),
-          }
-        : baseMetric;
-      metrics[nodeId] = metric;
-      if (isReferenceNode(node)) {
+      const metric = boxSizes[nodeId];
+      if (!metric) return;
+      if (flowCells[nodeId]?.isReference) {
         return;
       }
-      const col = flowColOf(node, index);
+      const col = flowCells[nodeId]?.col ?? index;
       const occupiedRows = occupiedRowsByCol[col] || new Set<number>();
-      let row = flowRowOf(node, 0);
+      let row = flowCells[nodeId]?.row ?? 0;
       while (occupiedRows.has(row)) {
         row += 1;
       }
@@ -6967,11 +7090,9 @@ function buildLayout(state: AppState): LayoutResult {
     }
 
     primarySurfaceNodes.forEach((nodeId, index) => {
-      const node = state.nodes[nodeId];
-      if (!node) return;
-      const resolvedCell = surfaceCells[nodeId] || { col: flowColOf(node, index), row: flowRowOf(node, 0) };
+      const resolvedCell = surfaceCells[nodeId] || { col: flowCells[nodeId]?.col ?? index, row: flowCells[nodeId]?.row ?? 0 };
       const { col, row } = resolvedCell;
-      const metric = metrics[nodeId]!;
+      const metric = boxSizes[nodeId]!;
       pos[nodeId] = {
         x: xByCol[col]!,
         y: yByRow[row]!,
@@ -6986,7 +7107,7 @@ function buildLayout(state: AppState): LayoutResult {
       const referenceTop = cursorY + 26;
       let referenceCursorX = VIEWER_TUNING.layout.leftPad;
       referenceSurfaceNodes.forEach((nodeId) => {
-        const metric = metrics[nodeId]!;
+        const metric = boxSizes[nodeId]!;
         pos[nodeId] = {
           x: referenceCursorX,
           y: referenceTop + metric.h / 2,
@@ -6997,7 +7118,7 @@ function buildLayout(state: AppState): LayoutResult {
         order.push(nodeId);
         referenceCursorX += metric.w + VIEWER_TUNING.layout.columnGap;
       });
-      cursorY = referenceTop + Math.max(...referenceSurfaceNodes.map((nodeId) => metrics[nodeId]!.h)) + FLOW_SURFACE_ROW_GAP;
+      cursorY = referenceTop + Math.max(...referenceSurfaceNodes.map((nodeId) => boxSizes[nodeId]!.h)) + FLOW_SURFACE_ROW_GAP;
       cursorX = Math.max(cursorX, referenceCursorX);
     }
 
@@ -7009,18 +7130,193 @@ function buildLayout(state: AppState): LayoutResult {
     };
   }
 
-  const structuredMode = structuredSurfaceMode() || "tree";
-  const measuredContext = buildMeasuredTreeContext(state, displayRootId, structuredMode);
+  const structuredMode = options.structuredMode || (mode === "mindmap" || mode === "logic-chart" || mode === "timeline" ? mode : "tree");
+  const measuredContext = buildMeasuredTreeContext(displayRootId, structuredMode, visibleGraph, boxSizes, options);
   if (structuredMode === "mindmap") {
-    return buildMindmapLayout(state, measuredContext);
+    return applyDepthAlignOptions(buildMindmapLayout(visibleGraph, measuredContext), options);
   }
   if (structuredMode === "logic-chart" && measuredContext.config.branchDirection === "both") {
-    return buildMindmapLayout(state, measuredContext);
+    return applyDepthAlignOptions(buildMindmapLayout(visibleGraph, measuredContext), options);
   }
   if (structuredMode === "timeline") {
-    return buildTimelineLayout(state, measuredContext);
+    return applyDepthAlignOptions(buildTimelineLayout(visibleGraph, measuredContext), options);
   }
-  return buildRightTreeLayout(state, measuredContext);
+  return applyDepthAlignOptions(buildRightTreeLayout(visibleGraph, measuredContext), options);
+}
+
+function scatterSeedPositionsFromGraph(
+  rootId: string,
+  ids: string[],
+  depthOf: Record<string, number>,
+  childrenOf: (id: string) => string[] = () => [],
+): Record<string, { x: number; y: number }> {
+  const center = scatterSeedCenter();
+  const idSet = new Set(ids);
+  const visibleChildrenForSeed = (nodeId: string): string[] =>
+    childrenOf(nodeId).filter((childId) => idSet.has(childId));
+  const childLeafCount = new Map<string, number>();
+  const leafCount = (nodeId: string): number => {
+    const cached = childLeafCount.get(nodeId);
+    if (cached != null) return cached;
+    const children = visibleChildrenForSeed(nodeId);
+    const count = children.length ? children.reduce((sum, childId) => sum + leafCount(childId), 0) : 1;
+    childLeafCount.set(nodeId, count);
+    return count;
+  };
+
+  const yByNode: Record<string, number> = {};
+  const assignBreadth = (nodeId: string, top: number): number => {
+    const children = visibleChildrenForSeed(nodeId);
+    if (!children.length) {
+      yByNode[nodeId] = top;
+      return top + scatterEdgeLength * 0.76;
+    }
+    let cursor = top;
+    children.forEach((childId) => {
+      cursor = assignBreadth(childId, cursor);
+    });
+    yByNode[nodeId] = (yByNode[children[0]!]! + yByNode[children[children.length - 1]!]!) / 2;
+    return cursor;
+  };
+  const totalBreadth = leafCount(rootId) * scatterEdgeLength * 0.76;
+  assignBreadth(rootId, center.y - totalBreadth / 2);
+
+  const rankPeers: Record<number, string[]> = {};
+  ids.forEach((nodeId) => {
+    const depth = depthOf[nodeId] ?? 0;
+    if (!rankPeers[depth]) rankPeers[depth] = [];
+    rankPeers[depth]!.push(nodeId);
+  });
+
+  const seeded: Record<string, { x: number; y: number }> = {};
+  ids.forEach((nodeId, index) => {
+    const depth = depthOf[nodeId] ?? 0;
+    const peers = rankPeers[depth] || [];
+    const peerIndex = Math.max(0, peers.indexOf(nodeId));
+    const siblingNudge = ((peerIndex % 3) - 1) * 12;
+    seeded[nodeId] = {
+      x: center.x + (depth - 1) * scatterEdgeLength * 1.26,
+      y: (yByNode[nodeId] ?? center.y) + siblingNudge,
+    };
+  });
+  if (ids.includes(rootId)) {
+    seeded[rootId] = {
+      x: center.x - scatterEdgeLength * 1.18,
+      y: yByNode[rootId] ?? center.y,
+    };
+  }
+  return seeded;
+}
+
+window.m3eLayout = (
+  graph: VisibleLayoutGraph,
+  boxSizes: Record<string, LayoutNodeMetric>,
+  mode: SurfaceKind,
+  options: LayoutOptions = {},
+): LayoutResult => layout(graph, boxSizes, mode, options);
+
+function buildLayout(state: AppState): LayoutResult {
+  const displayRootId = currentScopeRootId();
+  const displayRootNode = state.nodes[displayRootId];
+  const mode = surfaceKindForViewMode(viewState.surfaceViewMode);
+  const structuredMode = structuredSurfaceMode() || "tree";
+  const graphLinks = Object.values(state.links || {}).map((rawLink) => normalizeGraphLink(rawLink));
+  const childrenOf = (nodeId: string): string[] => {
+    const node = state.nodes[nodeId];
+    return node ? visibleChildren(node) : [];
+  };
+  const visibleNodeIds = new Set<string>();
+  const collectVisible = (nodeId: string): void => {
+    if (visibleNodeIds.has(nodeId) || !state.nodes[nodeId]) return;
+    visibleNodeIds.add(nodeId);
+    childrenOf(nodeId).forEach(collectVisible);
+  };
+  collectVisible(displayRootId);
+  const boxSizes: Record<string, LayoutNodeMetric> = {};
+  Array.from(visibleNodeIds).forEach((nodeId) => {
+    boxSizes[nodeId] = measureLayoutNode(state, nodeId, displayRootId, structuredLayoutConfig(structuredMode));
+  });
+
+  const publicOptions: PublicLayoutOptions = {
+    direction: viewState.surfaceLayoutDirection,
+    depthAlign: viewState.surfaceDepthAlign,
+    edge: { route: viewState.surfaceEdgeRoute },
+    link: { route: viewState.surfaceLinkRoute },
+  };
+  const options: LayoutOptions = {
+    ...publicOptions,
+    displayRootId,
+    structuredMode,
+    density: viewState.surfaceLayoutDensity,
+    branchDirection: viewState.surfaceBranchDirection,
+  };
+
+  if (mode === "scatter" && displayRootNode) {
+    const surface = currentMapSurface();
+    const { ids: descendants, depthOf: scatterDepthOf } = collectScatterNodes(state, displayRootId);
+    visibleNodeIds.clear();
+    descendants.forEach((nodeId) => visibleNodeIds.add(nodeId));
+    descendants.forEach((nodeId) => {
+      const depth = scatterDepthOf[nodeId] ?? 0;
+      const radius = scatterRadiusFor(nodeId, depth, descendants.length);
+      boxSizes[nodeId] = { w: radius * 2, h: radius * 2 };
+    });
+    options.surfaceNodeViews = surface?.nodeViews || {};
+    options.scatterCollapsedGroups = Object.fromEntries(descendants.map((nodeId) => [nodeId, scatterNodeIsCollapsedGroup(state, nodeId)]));
+    // Scatter layout reads persisted per-node view coordinates; scatter simulation writes them elsewhere.
+    return layout(
+      {
+        nodeIds: descendants,
+        childrenOf: (nodeId) => {
+          const node = state.nodes[nodeId];
+          return node && (nodeId === displayRootId || !viewState.collapsedIds.has(nodeId))
+            ? (node.children || []).filter((childId) => descendants.includes(childId))
+            : [];
+        },
+        graphLinks,
+      },
+      boxSizes,
+      mode,
+      options,
+    );
+  }
+
+  if (mode === "system" && displayRootNode) {
+    const surfaceNodes = visibleChildren(displayRootNode);
+    const flowCells: Record<string, { col: number; row: number; isReference: boolean }> = {};
+    visibleNodeIds.clear();
+    visibleNodeIds.add(displayRootId);
+    surfaceNodes.forEach((nodeId) => {
+      const node = state.nodes[nodeId];
+      if (!node) return;
+      visibleNodeIds.add(nodeId);
+      const nodeStyles = effectiveNodeStyleAttrs(node);
+      const label = diagramLabel(node, nodeStyles);
+      const baseMetric = isLatexNode(node)
+        ? measureLatex(node.text)
+        : measureNodeLabel(label, VIEWER_TUNING.typography.nodeFont);
+      const previewLayout = buildFlowPreviewLayout(node);
+      boxSizes[nodeId] = previewLayout
+        ? {
+            w: Math.max(baseMetric.w + 28, previewLayout.totalWidth),
+            h: Math.max(VIEWER_TUNING.layout.leafHeight + 18, previewLayout.totalHeight),
+          }
+        : baseMetric;
+      flowCells[nodeId] = { col: flowColOf(node, surfaceNodes.indexOf(nodeId)), row: flowRowOf(node, 0), isReference: isReferenceNode(node) };
+    });
+    options.flowCells = flowCells;
+  }
+
+  return layout(
+    {
+      nodeIds: Array.from(visibleNodeIds),
+      childrenOf,
+      graphLinks,
+    },
+    boxSizes,
+    mode,
+    options,
+  );
 }
 
 function updateMapTitle(): void {
@@ -7064,10 +7360,30 @@ function layoutEdgePath(
   mode: StructuredSurfaceMode,
   parent: NodePosition,
   child: NodePosition,
+  route: SurfaceEdgeRoute = viewState.surfaceEdgeRoute,
 ): { d: string; labelX: number; labelY: number; sourceSide: EdgeAnchorSide; targetSide: EdgeAnchorSide } {
   const { source, target } = mode === "tree"
     ? treeRightEdgeEndsBetween(parent, child)
     : legacyEdgeEndsBetween(parent, child);
+  if (route === "straight") {
+    return {
+      d: `M ${source.x} ${source.y} L ${target.x} ${target.y}`,
+      labelX: (source.x + target.x) / 2,
+      labelY: (source.y + target.y) / 2 - 8,
+      sourceSide: source.side,
+      targetSide: target.side,
+    };
+  }
+  if (route === "elbow") {
+    const midX = source.x + (target.x - source.x) * 0.5;
+    return {
+      d: `M ${source.x} ${source.y} H ${midX} V ${target.y} H ${target.x}`,
+      labelX: midX,
+      labelY: (source.y + target.y) / 2 - 8,
+      sourceSide: source.side,
+      targetSide: target.side,
+    };
+  }
   if (mode === "mindmap") {
     const rightward = target.x >= source.x;
     const dir = rightward ? 1 : -1;
@@ -7117,6 +7433,34 @@ function layoutEdgePath(
     sourceSide: source.side,
     targetSide: target.side,
   };
+}
+
+function graphLinkPathForRoute(
+  source: EdgeConnectionPoint,
+  target: EdgeConnectionPoint,
+  route: SurfaceLinkRoute,
+  waveOffset = 0,
+): string {
+  if (route === "straight") {
+    return `M ${source.x} ${source.y} L ${target.x} ${target.y}`;
+  }
+  if (route === "orthogonal") {
+    const midX = source.x + (target.x - source.x) * 0.5;
+    return roundedOrthogonalPath(source.x, source.y, target.x, target.y, { radius: 9, midX });
+  }
+  return graphLinkPathWithPorts(source, target, waveOffset);
+}
+
+function graphLinkLabelPointForRoute(
+  source: EdgeConnectionPoint,
+  target: EdgeConnectionPoint,
+  route: SurfaceLinkRoute,
+  waveOffset = 0,
+): { x: number; y: number } {
+  if (route === "straight" || route === "orthogonal") {
+    return { x: (source.x + target.x) / 2, y: (source.y + target.y) / 2 };
+  }
+  return graphLinkLabelPointWithPorts(source, target, waveOffset);
 }
 
 function render(): void {
@@ -7394,8 +7738,8 @@ function render(): void {
       controlX = (sxArch + txArch) / 2;
       controlY = useTop ? apexY - 10 : apexY + 16;
     } else {
-      graphLinkPathD = graphLinkPathWithPorts(sourceEnd, targetEnd, pairWaveOffset);
-      const labelPoint = graphLinkLabelPointWithPorts(sourceEnd, targetEnd, pairWaveOffset);
+      graphLinkPathD = graphLinkPathForRoute(sourceEnd, targetEnd, viewState.surfaceLinkRoute, pairWaveOffset);
+      const labelPoint = graphLinkLabelPointForRoute(sourceEnd, targetEnd, viewState.surfaceLinkRoute, pairWaveOffset);
       controlX = labelPoint.x;
       controlY = labelPoint.y - 12 - Math.abs(pairWaveOffset) * 0.35;
     }
@@ -13055,10 +13399,17 @@ function renderRoutingScopeSurface(selectedNodeId: string | null): string {
   const state = routingScopeState(routingScopeTargets);
   const rootId = state.rootId;
   const activeScopeId = selectedRoutingScopeTarget()?.id;
-  const layout = withVisibleChildrenOverride(
-    (node) => node.children || [],
-    () => buildRightTreeLayout(state, buildMeasuredTreeContext(state, rootId, "tree")),
-  );
+  const routingGraph: VisibleLayoutGraph = {
+    nodeIds: Object.keys(state.nodes),
+    childrenOf: (nodeId) => state.nodes[nodeId]?.children || [],
+    graphLinks: [],
+  };
+  const routingConfig = structuredLayoutConfig("tree");
+  const routingBoxSizes: Record<string, LayoutNodeMetric> = {};
+  Object.keys(state.nodes).forEach((nodeId) => {
+    routingBoxSizes[nodeId] = measureLayoutNode(state, nodeId, rootId, routingConfig);
+  });
+  const layout = buildRightTreeLayout(routingGraph, buildMeasuredTreeContext(rootId, "tree", routingGraph, routingBoxSizes));
   let edges = "";
   let nodes = "";
   layout.order.forEach((nodeId) => {
@@ -13906,6 +14257,21 @@ window.addEventListener("m3e:set-surface-layout", (event: Event) => {
   if (detail.direction) {
     setSurfaceBranchDirection(sanitizeSurfaceBranchDirection(detail.direction));
   }
+});
+
+window.addEventListener("m3e:set-layout-options", (event: Event) => {
+  const detail = (event as CustomEvent<{
+    direction?: SurfaceLayoutDirection;
+    depthAlign?: SurfaceDepthAlign;
+    edgeRoute?: SurfaceEdgeRoute;
+    linkRoute?: SurfaceLinkRoute;
+  }>).detail || {};
+  setPublicLayoutOptions({
+    direction: detail.direction,
+    depthAlign: detail.depthAlign,
+    edge: detail.edgeRoute ? { route: detail.edgeRoute } : undefined,
+    link: detail.linkRoute ? { route: detail.linkRoute } : undefined,
+  });
 });
 
 scatterNormalBtn?.addEventListener("click", () => setScatterToolMode("normal"));

--- a/beta/src/browser/workbench-ui.css
+++ b/beta/src/browser/workbench-ui.css
@@ -526,7 +526,9 @@
   gap: 14px;
   width: 486px;
   height: 420px;
+  max-width: calc(100vw - 96px);
   opacity: 0;
+  overflow: visible;
   pointer-events: none;
   transition: opacity 90ms ease;
 }
@@ -567,6 +569,7 @@
   width: 486px;
   height: 420px;
   margin-left: 56px;
+  overflow: visible;
 }
 
 .wb-progressive-column {
@@ -574,7 +577,7 @@
   flex-direction: column;
   gap: 6px;
   position: absolute;
-  min-width: 172px;
+  width: 172px;
   z-index: 2;
 }
 
@@ -602,6 +605,8 @@
 }
 
 .wb-progressive-node {
+  box-sizing: border-box;
+  width: 172px;
   min-height: 44px;
   display: flex;
   align-items: center;
@@ -613,6 +618,10 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
+}
+
+.wb-progressive-node > svg {
+  flex: 0 0 auto;
 }
 
 .wb-progressive-node span:first-child {

--- a/beta/src/browser/workbench-ui.tsx
+++ b/beta/src/browser/workbench-ui.tsx
@@ -38,6 +38,10 @@ type ToolId = "select" | "mindmap" | "pen" | "highlighter" | "date" | "eraser" |
 type ModalId = "menu" | "settings" | "share" | "help" | "ai" | null;
 type ProgressiveSurfaceMode = "tree" | "system" | "scatter" | "mindmap" | "logic-chart" | "timeline";
 type ProgressiveBranchDirection = "both" | "right" | "left";
+type ProgressiveLayoutDirection = "right" | "left" | "down" | "up";
+type ProgressiveDepthAlign = "aligned" | "packed";
+type ProgressiveEdgeRoute = "elbow" | "bezier" | "straight";
+type ProgressiveLinkRoute = "simple-bezier" | "orthogonal" | "straight";
 type ProgressiveMode = "gui" | "active-node";
 type RapidGenerateAction = "detail" | "examples" | "classify" | "related";
 type ViewerTheme = "light" | "dark";
@@ -75,6 +79,23 @@ type ProgressiveNodeId =
   | "mindmap"
   | "annotation"
   | "panel"
+  | "layout"
+  | "layout-direction"
+  | "layout-direction-right"
+  | "layout-direction-left"
+  | "layout-direction-down"
+  | "layout-direction-up"
+  | "layout-depth-align"
+  | "layout-depth-aligned"
+  | "layout-depth-packed"
+  | "layout-edge-route"
+  | "layout-edge-elbow"
+  | "layout-edge-bezier"
+  | "layout-edge-straight"
+  | "layout-link-route"
+  | "layout-link-simple-bezier"
+  | "layout-link-orthogonal"
+  | "layout-link-straight"
   | "import"
   | "export-json"
   | "export-mm"
@@ -124,6 +145,7 @@ type ProgressiveNode = {
   hint: string;
   parentId?: ProgressiveNodeId;
   action?: () => void;
+  active?: () => boolean;
 };
 
 type ProgressiveEdge = {
@@ -170,6 +192,31 @@ function setSurfaceLayout(
   direction?: ProgressiveBranchDirection,
 ): void {
   window.dispatchEvent(new CustomEvent("m3e:set-surface-layout", { detail: { mode, density, direction } }));
+}
+
+function setLayoutOptions(detail: {
+  direction?: ProgressiveLayoutDirection;
+  depthAlign?: ProgressiveDepthAlign;
+  edgeRoute?: ProgressiveEdgeRoute;
+  linkRoute?: ProgressiveLinkRoute;
+}): void {
+  window.dispatchEvent(new CustomEvent("m3e:set-layout-options", { detail }));
+}
+
+function currentLayoutDirection(): ProgressiveLayoutDirection {
+  return document.documentElement.dataset.surfaceLayoutDirection as ProgressiveLayoutDirection || "right";
+}
+
+function currentDepthAlign(): ProgressiveDepthAlign {
+  return document.documentElement.dataset.surfaceDepthAlign as ProgressiveDepthAlign || "packed";
+}
+
+function currentEdgeRoute(): ProgressiveEdgeRoute {
+  return document.documentElement.dataset.surfaceEdgeRoute as ProgressiveEdgeRoute || "elbow";
+}
+
+function currentLinkRoute(): ProgressiveLinkRoute {
+  return document.documentElement.dataset.surfaceLinkRoute as ProgressiveLinkRoute || "simple-bezier";
 }
 
 function sendKey(key: string, options: KeyboardEventInit = {}): void {
@@ -819,6 +866,23 @@ function makeProgressiveNodes(openModal: (id: ModalId) => void): ProgressiveNode
     { id: "timeline-spacious", label: "Timeline spacious", hint: "wide axis spacing", parentId: "timeline-surface", action: () => setSurfaceLayout("timeline", "spacious") },
     { id: "system", label: "System surface", hint: "diagram canvas", parentId: "view", action: () => clickLegacy("view-system") },
     { id: "scatter-surface", label: "Scatter surface", hint: "spatial graph canvas", parentId: "view", action: () => clickLegacy("view-scatter") },
+    { id: "layout", label: "Layout", hint: "surface layout options", parentId: "view" },
+    { id: "layout-direction", label: "Direction", hint: "layout growth axis", parentId: "layout" },
+    { id: "layout-direction-right", label: "Right", hint: "grow right", parentId: "layout-direction", action: () => setLayoutOptions({ direction: "right" }), active: () => currentLayoutDirection() === "right" },
+    { id: "layout-direction-left", label: "Left", hint: "grow left", parentId: "layout-direction", action: () => setLayoutOptions({ direction: "left" }), active: () => currentLayoutDirection() === "left" },
+    { id: "layout-direction-down", label: "Down", hint: "grow down", parentId: "layout-direction", action: () => setLayoutOptions({ direction: "down" }), active: () => currentLayoutDirection() === "down" },
+    { id: "layout-direction-up", label: "Up", hint: "grow up", parentId: "layout-direction", action: () => setLayoutOptions({ direction: "up" }), active: () => currentLayoutDirection() === "up" },
+    { id: "layout-depth-align", label: "Depth Align", hint: "rank alignment", parentId: "layout" },
+    { id: "layout-depth-aligned", label: "Aligned", hint: "align depth ranks", parentId: "layout-depth-align", action: () => setLayoutOptions({ depthAlign: "aligned" }), active: () => currentDepthAlign() === "aligned" },
+    { id: "layout-depth-packed", label: "Packed", hint: "pack subtrees", parentId: "layout-depth-align", action: () => setLayoutOptions({ depthAlign: "packed" }), active: () => currentDepthAlign() === "packed" },
+    { id: "layout-edge-route", label: "Edge Route", hint: "parent-child lines", parentId: "layout" },
+    { id: "layout-edge-elbow", label: "Elbow", hint: "orthogonal tree edge", parentId: "layout-edge-route", action: () => setLayoutOptions({ edgeRoute: "elbow" }), active: () => currentEdgeRoute() === "elbow" },
+    { id: "layout-edge-bezier", label: "Bezier", hint: "curved tree edge", parentId: "layout-edge-route", action: () => setLayoutOptions({ edgeRoute: "bezier" }), active: () => currentEdgeRoute() === "bezier" },
+    { id: "layout-edge-straight", label: "Straight", hint: "direct tree edge", parentId: "layout-edge-route", action: () => setLayoutOptions({ edgeRoute: "straight" }), active: () => currentEdgeRoute() === "straight" },
+    { id: "layout-link-route", label: "Link Route", hint: "GraphLink lines", parentId: "layout" },
+    { id: "layout-link-simple-bezier", label: "Simple Bezier", hint: "curved GraphLink", parentId: "layout-link-route", action: () => setLayoutOptions({ linkRoute: "simple-bezier" }), active: () => currentLinkRoute() === "simple-bezier" },
+    { id: "layout-link-orthogonal", label: "Orthogonal", hint: "right-angle GraphLink", parentId: "layout-link-route", action: () => setLayoutOptions({ linkRoute: "orthogonal" }), active: () => currentLinkRoute() === "orthogonal" },
+    { id: "layout-link-straight", label: "Straight", hint: "direct GraphLink", parentId: "layout-link-route", action: () => setLayoutOptions({ linkRoute: "straight" }), active: () => currentLinkRoute() === "straight" },
     { id: "scatter-normal", label: "Normal", hint: "select scatter objects", parentId: "scatter", action: () => clickLegacy("scatter-normal") },
     { id: "scatter-add-node", label: "Add node", hint: "create scatter node", parentId: "scatter", action: () => clickLegacy("scatter-add-node") },
     { id: "scatter-add-edge", label: "Add edge", hint: "connect scatter nodes", parentId: "scatter", action: () => clickLegacy("scatter-add-edge") },
@@ -941,24 +1005,37 @@ function ProgressiveNavigation({
     return ids;
   }, [activeId, nodeById]);
   const columns = useMemo(() => path.map((id) => childrenByParent.get(id) || []), [childrenByParent, path]);
-  const rootChildren = columns[0] || [];
-  const activeRootIndex = Math.max(0, rootChildren.findIndex((node) => node.id === path[1]));
-  const activeChildren = columns[1] || [];
+  const [, setLayoutRevision] = useState(0);
   const [navRootCenterY, setNavRootCenterY] = useState(156);
   const nodeCenterOffsetY = 23.5;
   const nodeStepY = 53;
   const columnStepX = 194;
+  const columnWidth = 172;
+  const navColumnOffsetX = 56;
+  const navPaddingRight = 28;
+  const navWidth = navColumnOffsetX + Math.max(1, columns.length - 1) * columnStepX + columnWidth + navPaddingRight;
+  const navHeight = 560;
   const groupHeight = (count: number) => (count > 0 ? 47 + (count - 1) * nodeStepY : 0);
-  const groupTop = (count: number, parentCenterY: number) => parentCenterY - groupHeight(count) / 2;
-  const rootColumnTop = groupTop(rootChildren.length, navRootCenterY);
-  const nodeCenterY = (columnTop: number, index: number) => columnTop + nodeCenterOffsetY + index * nodeStepY;
-  const activeRootCenterY = nodeCenterY(rootColumnTop, activeRootIndex);
-  const childColumnTop = groupTop(activeChildren.length, activeRootCenterY);
-  const columnTop = (index: number, count: number) => {
-    if (index === 0) return rootColumnTop;
-    if (index === 1) return childColumnTop;
-    return groupTop(count, activeRootCenterY);
+  const groupTop = (count: number, parentCenterY: number) => {
+    const height = groupHeight(count);
+    if (!height) return parentCenterY;
+    return clampPlacement(parentCenterY - height / 2, 0, Math.max(0, navHeight - height));
   };
+  const nodeCenterY = (top: number, index: number) => top + nodeCenterOffsetY + index * nodeStepY;
+  const columnTops = useMemo(() => {
+    const tops: number[] = [];
+    const parentCenters: number[] = [navRootCenterY];
+    columns.forEach((column, index) => {
+      const top = groupTop(column.length, parentCenters[index] ?? navRootCenterY);
+      tops[index] = top;
+      const selectedChildId = path[index + 1];
+      const selectedChildIndex = selectedChildId ? column.findIndex((node) => node.id === selectedChildId) : -1;
+      if (selectedChildIndex >= 0) {
+        parentCenters[index + 1] = nodeCenterY(top, selectedChildIndex);
+      }
+    });
+    return tops;
+  }, [columns, navRootCenterY, path]);
   const navRef = useRef<HTMLDivElement | null>(null);
   const [edges, setEdges] = useState<ProgressiveEdge[]>([]);
   const [edgeSize, setEdgeSize] = useState({ width: 486, height: 420 });
@@ -984,22 +1061,22 @@ function ProgressiveNavigation({
     const measuredRootCenterY = rootRect.y + rootRect.h / 2;
     setNavRootCenterY((current) => (Math.abs(current - measuredRootCenterY) > 0.5 ? measuredRootCenterY : current));
     const nextEdges: ProgressiveEdge[] = [];
-    rootChildren.forEach((node) => {
-      const el = nav.querySelector(`[data-pn-node="${node.id}"]`);
-      if (!el) return;
-      nextEdges.push({ id: `${rootId}-${node.id}`, d: edgePathBetweenRects(rootRect, toRect(el), 0), active: false });
-    });
-    const activeParentId = path[1];
-    const activeParentEl = activeParentId ? nav.querySelector(`[data-pn-node="${activeParentId}"]`) : null;
-    if (activeParentEl) {
-      const fromRect = toRect(activeParentEl);
-      activeChildren.forEach((node) => {
+    columns.forEach((column, index) => {
+      const parentId = path[index];
+      const parentRect = index === 0
+        ? rootRect
+        : (() => {
+          const parentEl = nav.querySelector(`[data-pn-node="${parentId}"]`);
+          return parentEl ? toRect(parentEl) : null;
+        })();
+      if (!parentRect) return;
+      column.forEach((node) => {
         const el = nav.querySelector(`[data-pn-node="${node.id}"]`);
         if (!el) return;
-        nextEdges.push({ id: `${activeParentId}-${node.id}`, d: edgePathBetweenRects(fromRect, toRect(el), 0), active: true });
+        nextEdges.push({ id: `${parentId}-${node.id}`, d: edgePathBetweenRects(parentRect, toRect(el), 0), active: index > 0 });
       });
-    }
-    setEdgeSize({ width: Math.ceil(navRect.width), height: Math.ceil(navRect.height) });
+    });
+    setEdgeSize({ width: Math.max(Math.ceil(navRect.width), navWidth), height: Math.max(Math.ceil(navRect.height), navHeight) });
     setEdges(nextEdges);
   };
 
@@ -1007,11 +1084,19 @@ function ProgressiveNavigation({
     measureEdges();
     window.addEventListener("resize", measureEdges);
     window.addEventListener("m3e:viewport-changed", measureEdges);
+    window.addEventListener("m3e:layout-options-changed", measureEdges);
     return () => {
       window.removeEventListener("resize", measureEdges);
       window.removeEventListener("m3e:viewport-changed", measureEdges);
+      window.removeEventListener("m3e:layout-options-changed", measureEdges);
     };
-  }, [activeId, rootChildren.length, activeChildren.length, navRootCenterY, mode, placement.left, placement.top]);
+  }, [activeId, columns, navRootCenterY, mode, navHeight, navWidth, path, placement.left, placement.top]);
+
+  useEffect(() => {
+    const refreshLayout = () => setLayoutRevision((value) => value + 1);
+    window.addEventListener("m3e:layout-options-changed", refreshLayout);
+    return () => window.removeEventListener("m3e:layout-options-changed", refreshLayout);
+  }, []);
 
   useEffect(() => {
     setActiveId(rootId);
@@ -1030,8 +1115,13 @@ function ProgressiveNavigation({
       className={`wb-progressive-nav${open ? " is-open" : ""}${mode === "active-node" ? " is-active-node" : ""}`}
       data-testid="progressive-navigation"
       data-pn-mode={mode}
+      data-active-pn-node={activeId}
       ref={navRef}
-      style={mode === "active-node" ? { left: `${placement.left}px`, top: `${placement.top}px` } : undefined}
+      style={{
+        width: `${navWidth}px`,
+        height: `${navHeight}px`,
+        ...(mode === "active-node" ? { left: `${placement.left}px`, top: `${placement.top}px` } : {}),
+      }}
       onMouseLeave={() => setActiveId(rootId)}
     >
       <svg className="wb-progressive-edges" viewBox={`0 0 ${edgeSize.width} ${edgeSize.height}`} aria-hidden="true">
@@ -1039,15 +1129,15 @@ function ProgressiveNavigation({
           <path className={edge.active ? "is-active-edge" : undefined} key={edge.id} d={edge.d} />
         ))}
       </svg>
-      <div className="wb-progressive-columns">
+      <div className="wb-progressive-columns" style={{ width: `${navWidth - navColumnOffsetX}px`, height: `${navHeight}px` }}>
         {columns.map((column, index) => (
           <div
             className="wb-progressive-column"
             key={`${path[index]}-${index}`}
-            style={{ left: `${index * columnStepX}px`, top: `${columnTop(index, column.length)}px` }}
+            style={{ left: `${index * columnStepX}px`, top: `${columnTops[index] ?? 0}px` }}
           >
             {column.map((node) => {
-              const selected = path.includes(node.id) || activeId === node.id;
+              const selected = path.includes(node.id) || activeId === node.id || Boolean(node.active?.());
               const hasChildren = Boolean(childrenByParent.get(node.id)?.length);
               return (
                 <button

--- a/beta/tests/visual/workbench_progressive_nav.spec.js
+++ b/beta/tests/visual/workbench_progressive_nav.spec.js
@@ -168,6 +168,43 @@ test.describe("Workbench progressive navigation", () => {
     expect(geometry.endpoints.ty).toBeCloseTo(geometry.toRect.cy, 1);
   });
 
+  test("View exposes Layout group with edge and GraphLink route options", async ({ page }) => {
+    const mapId = "pn-view-layout-options";
+    await routeRapidFixture(page, mapId);
+    await page.goto(`/viewer.html?localMapId=${mapId}&cloudMapId=${mapId}`);
+
+    await page.locator('[aria-label="[GUI] navigation root"]').evaluate((element) => {
+      const nav = document.querySelector('[data-testid="progressive-navigation"]');
+      if (!nav?.classList.contains("is-open")) {
+        element.click();
+      }
+    });
+    await page.locator('[data-pn-node="view"]').hover();
+    await expect(page.locator('[data-pn-node="layout"]')).toContainText("Layout");
+
+    await page.locator('[data-pn-node="layout"]').hover();
+    await page.locator('[data-pn-node="layout"]').evaluate((element) => element.click());
+    await expect(page.locator('[data-testid="progressive-navigation"]')).toHaveAttribute("data-active-pn-node", "layout");
+    await expect(page.locator('[data-pn-node="layout-direction"]')).toContainText("Direction");
+    await expect(page.locator('[data-pn-node="layout-depth-align"]')).toContainText("Depth Align");
+    await expect(page.locator('[data-pn-node="layout-edge-route"]')).toContainText("Edge Route");
+    await expect(page.locator('[data-pn-node="layout-link-route"]')).toContainText("Link Route");
+
+    await page.locator('[data-pn-node="layout-edge-route"]').hover();
+    await page.locator('[data-pn-node="layout-edge-route"]').evaluate((element) => element.click());
+    await expect(page.locator('[data-testid="progressive-navigation"]')).toHaveAttribute("data-active-pn-node", "layout-edge-route");
+    await expect(page.locator('[data-pn-node="layout-edge-elbow"]')).toContainText("Elbow");
+    await expect(page.locator('[data-pn-node="layout-edge-bezier"]')).toContainText("Bezier");
+    await expect(page.locator('[data-pn-node="layout-edge-straight"]')).toContainText("Straight");
+
+    await page.locator('[data-pn-node="layout-link-route"]').hover();
+    await page.locator('[data-pn-node="layout-link-route"]').evaluate((element) => element.click());
+    await expect(page.locator('[data-testid="progressive-navigation"]')).toHaveAttribute("data-active-pn-node", "layout-link-route");
+    await expect(page.locator('[data-pn-node="layout-link-simple-bezier"]')).toContainText("Simple Bezier");
+    await expect(page.locator('[data-pn-node="layout-link-orthogonal"]')).toContainText("Orthogonal");
+    await expect(page.locator('[data-pn-node="layout-link-straight"]')).toContainText("Straight");
+  });
+
   test("Space opens active-node expand actions directly and N3-N6 generate", async ({ page }) => {
     const mapId = `pn-active-node-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
     const doc = rapidFixture();


### PR DESCRIPTION
## Summary
- Split public/internal layout options and expose pure `layout(...)` through the viewer bridge.
- Add PN `View > Layout` controls for direction, depth alignment, tree edge route, and GraphLink route.
- Fix Progressive Navigation arbitrary-depth column placement so the new third/fourth-level Layout branches do not collapse.

## Verification
- `npm --prefix beta run build:browser`
- `npm --prefix beta run build:test`
- `npx playwright test tests/visual/workbench_progressive_nav.spec.js -g "View exposes Layout group"`
- In-app browser against worktree-local server `http://127.0.0.1:14175/viewer.html`: opened `[GUI] > View > Layout`; confirmed Layout group geometry uses fixed 172px controls in a 644x560 panel with no detected overlaps.

## Notes
- Existing daily beta server on `localhost:4173` was running from `/Users/nisimoriyuuya/dev/M3E/beta`, so visual verification used a separate worktree-local test server on port 14175.
- Phase D, placing PN itself with `layout()`, remains reverted/deferred.