### PR TITLE
Persist node deletions immediately

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -11679,6 +11679,17 @@ function deleteSelectedGraphLink(): boolean {
   return true;
 }
 
+function deleteGraphLinksForNode(nodeId: string): void {
+  if (!map?.state.links) {
+    return;
+  }
+  Object.entries(map.state.links).forEach(([linkId, link]) => {
+    if (link.sourceNodeId === nodeId || link.targetNodeId === nodeId) {
+      delete map!.state.links![linkId];
+    }
+  });
+}
+
 function cycleSelectedGraphLinkPort(endpoint: "source" | "target"): boolean {
   if (!map || !viewState.selectedLinkId) {
     return false;
@@ -12058,6 +12069,7 @@ function deleteSelected(): void {
       if (!isAliasNode(current)) {
         markAliasesBrokenInViewer(currentId, uiLabel(current));
       }
+      deleteGraphLinksForNode(currentId);
       stack.push(...(current.children || []));
       viewState.reparentSourceIds.delete(currentId);
       delete map!.state.nodes[currentId];

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -393,7 +393,15 @@ interface BcStateMessage {
   savedAt: string;
 }
 
+interface ClipboardSyncRecord {
+  type: "M3E_CLIPBOARD_UPDATE";
+  fromTabId: string;
+  encoded: string;
+  writtenAt: number;
+}
+
 let bc: BroadcastChannel | null = null;
+let clipboardBc: BroadcastChannel | null = null;
 let lastServerSavedAt: string | null = null;
 let lastServerBaseState: AppState | null = null;
 
@@ -640,6 +648,8 @@ const SCATTER_MIN_RADIUS = 18;
 const SCATTER_DEPTH_SCALE = 2 / 3;
 const SCATTER_MIN_SCALE = 0.52;
 const STRUCTURED_CLIPBOARD_PREFIX = "M3E_CLIPBOARD_V1\n";
+const STRUCTURED_CLIPBOARD_STORAGE_KEY = "m3e:subtree-clipboard:v1";
+const STRUCTURED_CLIPBOARD_MAX_AGE_MS = 10 * 60 * 1000;
 let scatterAnimationEnabled = false;
 let scatterAnimationFrame: number | null = null;
 let scatterRepulsion = SCATTER_REPULSION_DEFAULT;
@@ -13938,6 +13948,114 @@ function parseStructuredClipboardPayload(text: string): SubtreeClipboardPayload 
   }
 }
 
+function normalizeClipboardSyncRecord(raw: unknown): ClipboardSyncRecord | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const record = raw as Partial<ClipboardSyncRecord>;
+  if (
+    record.type !== "M3E_CLIPBOARD_UPDATE" ||
+    typeof record.fromTabId !== "string" ||
+    typeof record.encoded !== "string" ||
+    typeof record.writtenAt !== "number"
+  ) {
+    return null;
+  }
+  if (!record.encoded.startsWith(STRUCTURED_CLIPBOARD_PREFIX)) {
+    return null;
+  }
+  if (Date.now() - record.writtenAt > STRUCTURED_CLIPBOARD_MAX_AGE_MS) {
+    return null;
+  }
+  return {
+    type: "M3E_CLIPBOARD_UPDATE",
+    fromTabId: record.fromTabId,
+    encoded: record.encoded,
+    writtenAt: record.writtenAt,
+  };
+}
+
+function applyStructuredClipboardPayload(payload: SubtreeClipboardPayload): void {
+  viewState.clipboardState = {
+    type: "copy",
+    snapshots: payload.roots,
+    links: payload.links,
+  };
+  scheduleRender();
+}
+
+function applyStructuredClipboardText(encoded: string): boolean {
+  const payload = parseStructuredClipboardPayload(encoded);
+  if (!payload) {
+    return false;
+  }
+  applyStructuredClipboardPayload(payload);
+  return true;
+}
+
+function writeStructuredClipboardFallback(encoded: string): boolean {
+  const record: ClipboardSyncRecord = {
+    type: "M3E_CLIPBOARD_UPDATE",
+    fromTabId: TAB_ID,
+    encoded,
+    writtenAt: Date.now(),
+  };
+  let stored = false;
+  try {
+    window.localStorage.setItem(STRUCTURED_CLIPBOARD_STORAGE_KEY, JSON.stringify(record));
+    stored = true;
+  } catch {
+    stored = false;
+  }
+  try {
+    clipboardBc?.postMessage(record);
+  } catch {
+    // localStorage is the durable same-origin fallback; BroadcastChannel is best-effort.
+  }
+  return stored || Boolean(clipboardBc);
+}
+
+function readStructuredClipboardFallback(): SubtreeClipboardPayload | null {
+  try {
+    const record = normalizeClipboardSyncRecord(JSON.parse(window.localStorage.getItem(STRUCTURED_CLIPBOARD_STORAGE_KEY) || "null"));
+    return record ? parseStructuredClipboardPayload(record.encoded) : null;
+  } catch {
+    return null;
+  }
+}
+
+function initClipboardSync(): void {
+  if (typeof BroadcastChannel !== "undefined") {
+    try {
+      clipboardBc = new BroadcastChannel("m3e-subtree-clipboard");
+      clipboardBc.onmessage = (ev: MessageEvent<ClipboardSyncRecord>) => {
+        const record = normalizeClipboardSyncRecord(ev.data);
+        if (!record || record.fromTabId === TAB_ID) {
+          return;
+        }
+        applyStructuredClipboardText(record.encoded);
+      };
+    } catch {
+      clipboardBc = null;
+    }
+  }
+  window.addEventListener("storage", (ev: StorageEvent) => {
+    if (ev.key !== STRUCTURED_CLIPBOARD_STORAGE_KEY || !ev.newValue) {
+      return;
+    }
+    try {
+      const record = normalizeClipboardSyncRecord(JSON.parse(ev.newValue));
+      if (!record || record.fromTabId === TAB_ID) {
+        return;
+      }
+      applyStructuredClipboardText(record.encoded);
+    } catch {
+      // Ignore malformed same-origin clipboard fallback records.
+    }
+  });
+  window.addEventListener("beforeunload", () => clipboardBc?.close());
+}
+
 async function copyTextViaLocalClipboardApi(text: string): Promise<boolean> {
   if (!text || typeof fetch !== "function" || !/^https?:$/.test(window.location.protocol)) {
     return false;
@@ -14038,22 +14156,32 @@ async function copyScopeId(): Promise<void> {
   setStatus("Failed to copy scope ID to system clipboard.", true);
 }
 
-function copySelected(): void {
+async function copySelected(): Promise<void> {
   const roots = getSelectionRoots();
   if (roots.length === 0) {
     return;
   }
   const snapshots = roots.map((rootId) => toSubtreeSnapshot(rootId));
   const links = collectInternalLinksForRoots(roots);
+  const payload = buildStructuredClipboardPayload(snapshots, links);
+  const encoded = encodeStructuredClipboardPayload(payload);
   viewState.clipboardState = {
     type: "copy",
     snapshots,
     links,
   };
-  const payload = buildStructuredClipboardPayload(snapshots, links);
-  void copyTextToSystemClipboard(encodeStructuredClipboardPayload(payload));
+  const copiedToM3eTabs = writeStructuredClipboardFallback(encoded);
   scheduleRender();
-  setStatus(`Copied ${roots.length} node(s)${links.length ? ` and ${links.length} link(s)` : ""}.`);
+  const message = `Copied ${roots.length} node(s)${links.length ? ` and ${links.length} link(s)` : ""}`;
+  if (await copyTextToSystemClipboard(encoded)) {
+    setStatus(`${message}.`);
+    return;
+  }
+  if (copiedToM3eTabs) {
+    setStatus(`${message} for M3E tabs. System clipboard unavailable.`);
+    return;
+  }
+  setStatus("Failed to copy nodes.", true);
 }
 
 function cutSelected(): void {
@@ -14076,7 +14204,7 @@ async function pasteClipboard(): Promise<void> {
   }
   if (!viewState.clipboardState) {
     const clipboardText = await readTextFromSystemClipboard();
-    const payload = clipboardText ? parseStructuredClipboardPayload(clipboardText) : null;
+    const payload = (clipboardText ? parseStructuredClipboardPayload(clipboardText) : null) || readStructuredClipboardFallback();
     if (!payload) {
       setStatus("Clipboard is empty.", true);
       return;
@@ -15515,7 +15643,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "c") {
     event.preventDefault();
-    copySelected();
+    void copySelected();
     return;
   }
 
@@ -16039,6 +16167,7 @@ void initializeDocument().then(() => {
   if (fatalLoadError || !map) {
     return;
   }
+  initClipboardSync();
   if (!LOCAL_FS_VIEW_MODE) {
     initBroadcastSync();
     initVisibilityManagedLiveStreams();

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -11674,6 +11674,7 @@ function deleteSelectedGraphLink(): boolean {
   viewState.selectedLinkId = "";
   selectedGraphLinkId = null;
   touchDocument();
+  flushAutosaveNow();
   setStatus(`Deleted link: ${source ? uiLabel(source) : link.sourceNodeId} -> ${target ? uiLabel(target) : link.targetNodeId}.`);
   return true;
 }
@@ -12076,6 +12077,7 @@ function deleteSelected(): void {
     viewState.currentScopeRootId = viewState.currentScopeId;
   }
   touchDocument();
+  flushAutosaveNow();
 }
 
 function toggleCollapse(): void {
@@ -12453,6 +12455,21 @@ function scheduleAutosave(): void {
     autosaveTimer = null;
     void saveDocToLocalDb(false);
   }, AUTOSAVE_DELAY_MS);
+}
+
+function flushAutosaveNow(): void {
+  if (!map || isReadOnlyLink()) {
+    return;
+  }
+  if (autosaveTimer !== null) {
+    clearTimeout(autosaveTimer);
+    autosaveTimer = null;
+  }
+  void saveDocToLocalDb(false).then((ok) => {
+    if (!ok) {
+      setStatus("Local save failed after delete.", true);
+    }
+  });
 }
 
 function isValidAppState(s: unknown): s is AppState {

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -18,6 +18,8 @@
  * Total: 7 nodes
  */
 const { test, expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
 const { spawnSync } = require("child_process");
 const {
   launchViewer,
@@ -31,6 +33,21 @@ const {
   expectMetaContains,
   expectStatusContains,
 } = require("../helpers/viewer_test_utils");
+
+const FIXTURE_PATH = path.resolve(__dirname, "..", "fixtures", "shortcut_test.json");
+
+function shortcutFixtureWithGraphLink() {
+  const payload = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf-8"));
+  payload.state.links = {
+    "link-child-b": {
+      id: "link-child-b",
+      sourceNodeId: "child-b",
+      targetNodeId: "grandchild-a1",
+      relationType: "related",
+    },
+  };
+  return payload;
+}
 
 function readMacClipboard() {
   if (process.platform !== "darwin") return null;
@@ -305,6 +322,24 @@ test.describe("Delete and Backspace: remove node", () => {
 
     const afterCount = await getNodeCount(page);
     expect(afterCount).toBe(initialCount - 1);
+  });
+
+  test("Delete removes graph links connected to the deleted node", async ({ page }) => {
+    await launchViewer(page, shortcutFixtureWithGraphLink());
+    await focusBoard(page);
+
+    const initialCount = await getNodeCount(page);
+    expect(await getLinkCount(page)).toBe(1);
+
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    await pressKey(page, "Delete");
+    await waitForRender(page);
+
+    expect(await getNodeCount(page)).toBe(initialCount - 1);
+    expect(await getLinkCount(page)).toBe(0);
   });
 });
 

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -495,6 +495,61 @@ test.describe("Copy and Paste", () => {
     }
   });
 
+  test("Ctrl+C in one tab then Ctrl+V in another tab works without system clipboard", async ({ page, context }) => {
+    const disableSystemClipboard = async (targetPage) => {
+      await targetPage.addInitScript(() => {
+        Object.defineProperty(navigator, "clipboard", {
+          value: undefined,
+          configurable: true,
+        });
+      });
+      await targetPage.route("**/api/system-clipboard/**", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ ok: false, error: "clipboard disabled for test" }),
+        });
+      });
+    };
+    const sourceMap = JSON.parse(JSON.stringify(require("../fixtures/shortcut_test.json")));
+    sourceMap.state.links = {
+      "internal-link": {
+        id: "internal-link",
+        sourceNodeId: "grandchild-a1",
+        targetNodeId: "grandchild-a2",
+        direction: "forward",
+        style: "default",
+      },
+    };
+    const targetPage = await context.newPage();
+    try {
+      await disableSystemClipboard(page);
+      await disableSystemClipboard(targetPage);
+
+      await launchViewer(page, sourceMap);
+      await focusBoard(page);
+      await pressKey(page, "ArrowRight");
+      await expectMetaContains(page, "selected: Child A");
+      await pressKey(page, "Control+c");
+      await waitForRender(page);
+      expect(await getStatusText(page)).toContain("for M3E tabs");
+
+      await launchViewer(targetPage);
+      await focusBoard(targetPage);
+      expect(await getNodeCount(targetPage)).toBe(7);
+      expect(await getLinkCount(targetPage)).toBe(0);
+
+      await pressKey(targetPage, "Control+v");
+      await waitForRender(targetPage);
+
+      expect(await getNodeCount(targetPage)).toBe(10);
+      expect(await getLinkCount(targetPage)).toBe(1);
+      expect(await getStatusText(targetPage)).toContain("and 1 link(s)");
+    } finally {
+      await targetPage.close();
+    }
+  });
+
   test("Ctrl+Alt+C copies selected node path", async ({ page }) => {
     await launchViewer(page);
     await focusBoard(page);
@@ -506,8 +561,8 @@ test.describe("Copy and Paste", () => {
     await pressKey(page, "Control+Alt+c");
     await waitForRender(page);
 
-    expect(await getStatusText(page)).toContain("Path copied: Test Root / Child A / Grandchild A1");
-    expect(readMacClipboard()).toBe("Test Root / Child A / Grandchild A1");
+    expect(await getStatusText(page)).toContain("Path copied: M:(開発)> Child A > Grandchild A1");
+    expect(readMacClipboard()).toBe("M:(開発)> Child A > Grandchild A1");
   });
 
   test("Ctrl+Alt+I copies current scope ID", async ({ page }) => {


### PR DESCRIPTION
## Summary
- flush pending autosave and save immediately after node deletion
- apply the same immediate persistence to graph-link deletion
- remove GraphLinks connected to deleted node subtrees so server validation accepts the saved map

## Verification
- npm --prefix beta run build:browser
- npm --prefix beta run test:shortcuts -- --grep "Delete and Backspace"
- manual in-app browser check on the real 4173 URL: deleted n_1780500950727_5ubrrz, reloaded after 100ms, node stayed deleted
- API check after reload: hasTarget=false, hasBadLink=false, nodes=344

## Runtime note
- localhost:4173 is currently running this branch via launchctl label m3e-beta-4173-delete-node-persist against the live workspace DB.