### PR TITLE
feat(beta): node-draw seam — nodeDraw pure renderer (node_draw_svg)

### DIFF
--- a/beta/dependency-cruiser.config.cjs
+++ b/beta/dependency-cruiser.config.cjs
@@ -30,6 +30,28 @@ module.exports = {
       to: { path: "^src/browser/" },
     },
     {
+      name: "node-lab-must-not-import-browser-implementation",
+      severity: "error",
+      from: { path: "^src/labs/node/" },
+      to: { path: "^src/browser/" },
+    },
+    {
+      name: "node-lab-uses-node-draw-only",
+      severity: "error",
+      from: { path: "^src/labs/node/" },
+      to: {
+        path: "^src/shared/(?!node_draw_port\\.ts$|node_draw_svg\\.ts$|layout_port\\.ts$)",
+      },
+    },
+    {
+      name: "node-draw-svg-must-not-import-viewer-markdown-edge-or-labs",
+      severity: "error",
+      from: { path: "^src/shared/node_draw_svg\\.ts$" },
+      to: {
+        path: "^src/(browser|labs/)|^src/shared/(edge_|parent_child_edge|graph_)",
+      },
+    },
+    {
       name: "parent-child-edge-must-not-import-graphlink-endpoint-edit",
       severity: "error",
       from: { path: "^src/shared/parent_child_edge_adapter\\.ts$" },

--- a/beta/jscpd.config.json
+++ b/beta/jscpd.config.json
@@ -3,7 +3,7 @@
   "minLines": 20,
   "minTokens": 120,
   "reporters": ["console"],
-  "path": ["src/shared/layout_port.ts", "src/shared/edge_port.ts", "src/shared/edge_route.ts", "src/shared/parent_child_edge_adapter.ts", "src/labs/layout", "src/labs/edge-port", "src/browser/viewer.ts", "src/browser/edge_adapters"],
+  "path": ["src/shared/layout_port.ts", "src/shared/edge_port.ts", "src/shared/edge_route.ts", "src/shared/parent_child_edge_adapter.ts", "src/shared/node_draw_port.ts", "src/shared/node_draw_svg.ts", "src/labs/layout", "src/labs/edge-port", "src/labs/node", "src/browser/viewer.ts", "src/browser/edge_adapters"],
   "pattern": "**/*.ts*",
   "ignore": ["dist/**", "node_modules/**", "tests/fixtures/**"]
 }

--- a/beta/package.json
+++ b/beta/package.json
@@ -13,6 +13,8 @@
     "test:edge-port": "npm run build:test && npx vitest run tests/unit/edge_port_*.test.*",
     "edge-port:capture": "npm run build:node && node dist/node/edge_port_capture.js",
     "lab:edge-port": "vite --host 127.0.0.1 --config vite.config.mjs",
+    "lab:node": "vite --host 127.0.0.1 --port 14274 --config vite.config.mjs",
+    "test:node": "npm run build:test && npx vitest run tests/unit/node_draw_*.test.* && playwright test --config playwright.node-lab.config.js",
     "test:layout": "npm run build:test && npx vitest run tests/unit/layout_*.test.*",
     "layout:capture": "npm run build:node && node dist/node/layout_capture.js",
     "weekly:review": "npm run build:node && node dist/node/weekly_review_loop.js",

--- a/beta/playwright.node-lab.config.js
+++ b/beta/playwright.node-lab.config.js
@@ -1,0 +1,39 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+const PORT = process.env.M3E_NODE_LAB_PORT || "14274";
+if (PORT === "4173" && process.env.M3E_ALLOW_VISUAL_TEST_ON_4173 !== "1") {
+  throw new Error("Refusing to run node-lab tests on beta port 4173. Use a dedicated test port.");
+}
+
+module.exports = defineConfig({
+  testDir: "./tests/visual",
+  testMatch: /node_lab\.spec\.js/,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      animations: "disabled",
+      caret: "hide",
+    },
+  },
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    viewport: { width: 1400, height: 900 },
+  },
+  webServer: {
+    command: `npx vite --host 127.0.0.1 --port ${PORT} --config vite.config.mjs`,
+    url: `http://127.0.0.1:${PORT}/src/labs/node/node-lab.html`,
+    reuseExistingServer: false,
+    cwd: __dirname,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
+    },
+  ],
+});

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -9,6 +9,16 @@ import {
   type StructuredLayoutMode,
   type VisibleLayoutGraph,
 } from "../shared/layout_port";
+import {
+  canonicalSurfaceViewName,
+  normalizeNodeDrawStyle,
+  type AliasDrawState,
+  type NodeDrawInput,
+  type NodeDrawStyle,
+  type NodeDrawSurface,
+  type ScopeLockDrawState,
+} from "../shared/node_draw_port";
+import { renderNode as renderNodeSvg } from "../shared/node_draw_svg";
 import { routeParentChildEdge, type ParentChildSurfaceMode } from "../shared/parent_child_edge_adapter";
 import type { EdgeRouteStyle } from "../shared/edge_route";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
@@ -3102,35 +3112,25 @@ function deriveFillFromUrgencyImportance(urgency: number, importance: number): s
 }
 
 function readNodeStyleAttrs(attrs: Record<string, string>): NodeStyleAttrs {
-  // V1-compatible JSON decoration layer (Miro-style). Takes priority over
-  // legacy m3e:bg/m3e:border/m3e:color if present.
-  const style = readNodeStyleJson(attrs);
-  const jsonFill = typeof style.fill === "string" ? sanitizeColor(style.fill) : null;
-  const jsonBorder = typeof style.border === "string" ? sanitizeColor(style.border) : null;
-  const jsonText = typeof style.text === "string" ? sanitizeColor(style.text) : null;
-  const urgency = typeof style.urgency === "number" ? style.urgency : NaN;
-  const importance = typeof style.importance === "number" ? style.importance : NaN;
-  // Derived fill only applies when explicit fill is absent (both legacy and JSON).
-  const legacyBg = sanitizeColor(attrs["m3e:bg"]);
-  let effectiveBg = jsonFill ?? legacyBg;
-  if (!effectiveBg && (Number.isFinite(urgency) || Number.isFinite(importance))) {
-    effectiveBg = deriveFillFromUrgencyImportance(urgency, importance);
-  }
+  const nodeDrawStyle = normalizeNodeDrawStyle({
+    styleJson: attrs["m3e:style"],
+    legacy: attrs,
+  });
   return {
-    bg: effectiveBg,
-    color: jsonText ?? sanitizeColor(attrs["m3e:color"]),
-    border: jsonBorder ?? sanitizeColor(attrs["m3e:border"]),
-    borderStyle: sanitizeBorderStyle(attrs["m3e:border-style"]),
-    borderWidth: sanitizeNumeric(attrs["m3e:border-width"], 0, 8),
-    shape: sanitizeShape(attrs["m3e:shape"]),
-    icon: sanitizeIcon(attrs["m3e:icon"]),
+    bg: nodeDrawStyle.fill ?? null,
+    color: nodeDrawStyle.text ?? null,
+    border: nodeDrawStyle.border ?? null,
+    borderStyle: nodeDrawStyle.borderStyle ?? null,
+    borderWidth: nodeDrawStyle.borderWidth ?? null,
+    shape: nodeDrawStyle.shape ?? null,
+    icon: nodeDrawStyle.icon ?? null,
     edgeColor: sanitizeColor(attrs["m3e:edge-color"]),
     edgeStyle: sanitizeBorderStyle(attrs["m3e:edge-style"]),
     edgeWidth: sanitizeNumeric(attrs["m3e:edge-width"], 1, 10),
     edgeLabel: (attrs["m3e:edge-label"] || "").trim() || null,
-    band: sanitizeBand(attrs["m3e:band"]),
-    confidence: sanitizeNumeric(attrs["m3e:confidence"], 0, 1),
-    status: sanitizeStatus(style.status) ?? sanitizeStatus(attrs["m3e:status"]),
+    band: nodeDrawStyle.band ?? null,
+    confidence: nodeDrawStyle.confidence ?? null,
+    status: nodeDrawStyle.status ?? null,
   };
 }
 
@@ -7251,6 +7251,185 @@ function render(): void {
     return `<foreignObject data-node-id="${escapeXmlAttr(parentId)}" data-component-kind="tabular" x="${foX}" y="${foY}" width="${tableW}" height="${tableH}"><div xmlns="http://www.w3.org/1999/xhtml" class="m3e-component m3e-component--tabular ${densityClass} ${maxHeightClass}">${html}</div></foreignObject>`;
   }
 
+  function nodeDrawStyleFromAttrs(attrs: NodeStyleAttrs): NodeDrawStyle {
+    return {
+      fill: attrs.bg ?? undefined,
+      text: attrs.color ?? undefined,
+      border: attrs.border ?? undefined,
+      borderStyle: attrs.borderStyle as NodeDrawStyle["borderStyle"] | undefined,
+      borderWidth: attrs.borderWidth ?? undefined,
+      shape: attrs.shape as NodeDrawStyle["shape"] | undefined,
+      icon: attrs.icon ?? undefined,
+      status: attrs.status as NodeDrawStyle["status"] | undefined,
+      confidence: attrs.confidence ?? undefined,
+      band: attrs.band as NodeDrawStyle["band"] | undefined,
+    };
+  }
+
+  function nodeDrawAliasState(node: TreeNode): AliasDrawState {
+    if (!isAliasNode(node)) return "none";
+    if (isBrokenAlias(node)) return "broken";
+    return aliasAccess(node) === "write" ? "write" : "read";
+  }
+
+  function nodeDrawLockState(nodeId: string): ScopeLockDrawState {
+    const nodeLock = scopeLockMap.get(nodeId);
+    if (!nodeLock) return "none";
+    return nodeLock.entityId === collabEntityId ? "self" : "other";
+  }
+
+  function nodeDrawSurface(): NodeDrawSurface {
+    return {
+      view: canonicalSurfaceViewName(scatterSurface ? "scatter" : structuredMode),
+      structuredMode: canonicalSurfaceViewName(structuredMode),
+      displayRootId,
+      rootless: rootlessSurface,
+    };
+  }
+
+  function renderLatexHtml(text: string): { html: string; displayMode: boolean } {
+    let htmlStr = latexHtmlCache.get(text);
+    const { latex, displayMode } = latexSource(text);
+    if (!htmlStr) {
+      try {
+        htmlStr = katex.renderToString(latex, { displayMode, throwOnError: false });
+      } catch {
+        htmlStr = escapeXml(text);
+      }
+      latexHtmlCache.set(text, htmlStr);
+    }
+    return { html: htmlStr, displayMode };
+  }
+
+  function toNodeDrawInput(node: TreeNode, p: NodePosition, nodeStyles: NodeStyleAttrs): NodeDrawInput {
+    const treatAsRoot = node.id === displayRootId && !rootlessSurface;
+    const label = diagramLabel(node, nodeStyles);
+    const aliasState = nodeDrawAliasState(node);
+    const fontSize = p.fontSize ?? (treatAsRoot ? VIEWER_TUNING.typography.rootFont : VIEWER_TUNING.typography.nodeFont);
+    const content = isLatexNode(node)
+      ? { kind: "latexHtml" as const, ...renderLatexHtml(node.text) }
+      : {
+          kind: "plainLabel" as const,
+          labelLines: p.labelLines || splitLabelLines(treatAsRoot ? (uiLabel(node) || "(empty)") : label),
+          fontSize,
+          textAnchor: structuredMode === "mindmap" || treatAsRoot ? "middle" as const : "start" as const,
+        };
+    return {
+      node: {
+        id: node.id,
+        type: (isAliasNode(node) ? "alias" : isFolderNode(node) ? "folder" : node.nodeType || "text") as NodeDrawInput["node"]["type"],
+        kind: treatAsRoot ? "root" : isLatexNode(node) ? "latex" : nodeStyles.status ? "status" : isFolderNode(node) ? "folder" : "plain",
+        label: uiLabel(node),
+        text: node.text,
+        alias: aliasState,
+        aliasLabel: node.aliasLabel,
+        targetLabel: resolveAliasTarget(node)?.text,
+        snapshotLabel: node.targetSnapshotLabel,
+        isFolder: isFolderNode(node),
+        isScopePortal: isScopePortalNode(node),
+        isRoot: treatAsRoot,
+        isLatex: isLatexNode(node),
+        isScatterGroup: Boolean(p.scatterCollapsedGroup),
+        scatterRole: rawAttr(node, "m3e:scatter-role") as NodeDrawInput["node"]["scatterRole"],
+        badge: nodeBadge(node) || undefined,
+      },
+      position: p,
+      style: nodeDrawStyleFromAttrs(nodeStyles),
+      view: {
+        selected: viewState.selectedNodeIds.has(node.id),
+        primarySelected: node.id === viewState.selectedNodeId,
+        multiSelected: viewState.selectedNodeIds.has(node.id),
+        linkSource: viewState.linkSourceNodeId === node.id,
+        cutPending: viewState.clipboardState?.type === "cut" && viewState.clipboardState.sourceIds.has(node.id),
+        reparentSource: viewState.reparentSourceIds.has(node.id),
+        dragSource: Boolean(viewState.dragState && node.id === viewState.dragState.sourceNodeId),
+        dropTarget: viewState.dragState?.proposal?.kind === "reparent" && node.id === viewState.dragState.proposal.parentId,
+        collapsedCount: viewState.collapsedIds.has(node.id) && (node.children || []).length > 0
+          ? Math.max(1, countHiddenDescendants(node.id))
+          : undefined,
+        lockedBy: nodeDrawLockState(node.id),
+      },
+      surface: nodeDrawSurface(),
+      content,
+    };
+  }
+
+  function renderParentChildEdges(nodeId: string, nodeStyles: NodeStyleAttrs, p: NodePosition, childIds: string[]): string {
+    let result = "";
+    childIds.forEach((childId, i) => {
+      const child = pos[childId];
+      if (!child) return;
+      const defaultStroke = VIEWER_TUNING.palette.edgeColors[(p.depth + i) % VIEWER_TUNING.palette.edgeColors.length];
+      const stroke = nodeStyles.edgeColor || defaultStroke;
+      const edgeInline = buildEdgeStyle(nodeStyles);
+      const edgePath = layoutEdgePath(structuredMode, p, child);
+      result += `<path class="edge edge-${structuredMode}" data-source-node-id="${nodeId}" data-target-node-id="${childId}" data-source-port-side="${edgePath.sourceSide}" data-target-port-side="${edgePath.targetSide}" stroke="${stroke}" d="${edgePath.d}"${edgeInline ? ` style="${edgeInline}"` : ""} />`;
+
+      const childNode = state.nodes[childId];
+      const childStyles = readNodeStyleAttrs(childNode?.attributes || {});
+      const edgeLabel = childStyles.edgeLabel || parentChildLinkLabels.get(parentChildEdgeKey(nodeId, childId));
+      if (edgeLabel) {
+        result += `<text class="edge-label" data-node-id="${childId}" x="${edgePath.labelX}" y="${edgePath.labelY}" text-anchor="middle">${escapeXml(edgeLabel)}</text>`;
+      }
+    });
+    return result;
+  }
+
+  function renderFolderPreview(node: TreeNode, nodeStyles: NodeStyleAttrs, p: NodePosition): string {
+    const previewLayout = buildFlowPreviewLayout(node);
+    if (!previewLayout) return "";
+    const frameInsetY = structuredMode === "mindmap" ? 0 : 12;
+    const framePadX = structuredMode === "mindmap" ? 0 : 14;
+    const frameH = Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h) - frameInsetY;
+    const folderFrameX = p.x - framePadX;
+    const folderFrameY = p.y - frameH / 2;
+    let result = "";
+    const previewIds = new Set(previewLayout.childIds);
+    Object.values(state.links || {}).forEach((rawLink) => {
+      const link = normalizeGraphLink(rawLink);
+      const sourceNode = state.nodes[link.sourceNodeId];
+      const targetNode = state.nodes[link.targetNodeId];
+      if (!sourceNode || !targetNode || isParentChildPair(sourceNode, targetNode)) return;
+      if (!previewIds.has(link.sourceNodeId) || !previewIds.has(link.targetNodeId)) return;
+      const sourcePreview = previewLayout.positions[link.sourceNodeId];
+      const targetPreview = previewLayout.positions[link.targetNodeId];
+      if (!sourcePreview || !targetPreview) return;
+      const sourceRect = {
+        x: folderFrameX + sourcePreview.x,
+        y: folderFrameY + sourcePreview.y,
+        w: sourcePreview.w,
+        h: sourcePreview.h,
+      };
+      const targetRect = {
+        x: folderFrameX + targetPreview.x,
+        y: folderFrameY + targetPreview.y,
+        w: targetPreview.w,
+        h: targetPreview.h,
+      };
+      const { source: sourceEnd, target: targetEnd } = edgePortPairBetweenRects(sourceRect, targetRect);
+      const previewEdgePath = smoothGraphLinkPath(sourceEnd.x, sourceEnd.y, targetEnd.x, targetEnd.y);
+      result += `<path class="flow-preview-edge" d="${previewEdgePath}" />`;
+      const edgeLabel = (link.label || link.relationType || "").trim();
+      if (edgeLabel) {
+        result += `<text class="flow-preview-edge-label" x="${(sourceEnd.x + targetEnd.x) / 2}" y="${(sourceEnd.y + targetEnd.y) / 2 - 6}" text-anchor="middle">${escapeXml(edgeLabel)}</text>`;
+      }
+    });
+
+    previewLayout.childIds.forEach((previewChildId) => {
+      const previewChild = state.nodes[previewChildId];
+      const previewPos = previewLayout.positions[previewChildId];
+      if (!previewChild || !previewPos) return;
+      const previewStyles = readNodeStyleAttrs(previewChild.attributes || {});
+      const previewLabel = escapeXml(diagramLabel(previewChild, previewStyles));
+      const previewX = folderFrameX + previewPos.x;
+      const previewY = folderFrameY + previewPos.y;
+      const previewClass = isFolderNode(previewChild) ? "flow-preview-node flow-preview-node-scope" : "flow-preview-node";
+      result += `<rect class="${previewClass}" x="${previewX}" y="${previewY}" width="${previewPos.w}" height="${previewPos.h}" rx="8" />`;
+      result += `<text class="flow-preview-node-label" x="${previewX + 10}" y="${previewY + previewPos.h / 2}" dominant-baseline="middle" text-anchor="start">${previewLabel}</text>`;
+    });
+    return result;
+  }
+
   function drawNode(nodeId: string): void {
     const node = state.nodes[nodeId];
     const p = pos[nodeId];
@@ -7264,385 +7443,17 @@ function render(): void {
     const children = scatterSurface ? [] : visibleChildren(node);
     const nodeComponent = scatterSurface ? null : parseNodeComponent(node);
     const nodeStyles = effectiveNodeStyleAttrs(node);
-    const previewLayout = buildFlowPreviewLayout(node);
-    if (scatterSurface) {
-      const { cx, cy, r } = scatterCircleGeometry(p);
-      const circleClasses = ["node-hit", "scatter-node-circle"];
-      if (nodeId === displayRootId) {
-        circleClasses.push("scatter-root");
-      }
-      if (p.scatterCollapsedGroup) {
-        circleClasses.push("scatter-group");
-      } else {
-        circleClasses.push("scatter-branch");
-      }
-      const scatterRole = rawAttr(node, "m3e:scatter-role");
-      if (scatterRole === "downstream") {
-        circleClasses.push("scatter-role-downstream");
-      } else if (scatterRole === "sample") {
-        circleClasses.push("scatter-role-sample");
-      } else if (scatterRole === "upstream") {
-        circleClasses.push("scatter-role-upstream");
-      }
-      if (viewState.selectedNodeIds.has(nodeId)) {
-        circleClasses.push("selected");
-        circleClasses.push("multi-selected");
-      }
-      if (nodeId === viewState.selectedNodeId) {
-        circleClasses.push("primary-selected");
-      }
-      if (isAliasNode(node)) {
-        circleClasses.push("alias");
-        circleClasses.push(isBrokenAlias(node) ? "alias-broken" : (aliasAccess(node) === "write" ? "alias-write" : "alias-read"));
-      }
-      if (viewState.linkSourceNodeId === nodeId) {
-        circleClasses.push("link-source");
-      }
-      if (viewState.dragState && nodeId === viewState.dragState.sourceNodeId) {
-        circleClasses.push("drag-source");
-      }
-      const circleStyle: string[] = [];
-      if (nodeStyles.bg) circleStyle.push(`fill:${nodeStyles.bg}`);
-      if (nodeStyles.border) circleStyle.push(`stroke:${nodeStyles.border}`);
-      if (nodeStyles.borderWidth != null) circleStyle.push(`stroke-width:${nodeStyles.borderWidth}px`);
-      if (nodeStyles.borderStyle === "dashed") circleStyle.push("stroke-dasharray:8 5");
-      if (nodeStyles.borderStyle === "dotted") circleStyle.push("stroke-dasharray:3 3");
-      if (nodeStyles.borderStyle === "none") circleStyle.push("stroke:none");
-      const inline = circleStyle.length ? ` style="${circleStyle.join(";")}"` : "";
-      nodes += `<circle class="${circleClasses.join(" ")}" data-node-id="${nodeId}" cx="${cx}" cy="${cy}" r="${r}"${inline} />`;
-      const labelClass = nodeId === displayRootId ? "label-root scatter-label" : "label-node scatter-label";
-      const labelStyles = [`font-size:${p.fontSize ?? scatterFontSizeFor(r)}px`];
-      const labelInline = buildLabelStyle(nodeStyles);
-      if (labelInline) labelStyles.push(labelInline);
-      const label = scatterDisplayLabel(node);
-      const fontSize = p.fontSize ?? scatterFontSizeFor(r);
-      const labelMeasure = measureNodeLabel(label || node.id, fontSize);
-      const labelX = cx + r + 7;
-      const labelY = cy;
-      maxX = Math.max(maxX, labelX + labelMeasure.w + VIEWER_TUNING.layout.nodeRightPad);
-      maxY = Math.max(maxY, labelY + Math.max(r, labelMeasure.h / 2) + VIEWER_TUNING.layout.nodeBottomPad);
-      nodes += `<text class="${labelClass}" data-node-id="${nodeId}" x="${labelX}" y="${labelY}" text-anchor="start" dominant-baseline="middle" style="${labelStyles.join(";")}">${escapeXml(label)}</text>`;
-      return;
-    }
-    if (!nodeComponent) children.forEach((childId, i) => {
-      const child = pos[childId];
-      if (!child) {
-        return;
-      }
-
-      const defaultStroke =
-        VIEWER_TUNING.palette.edgeColors[(p.depth + i) % VIEWER_TUNING.palette.edgeColors.length];
-      const stroke = nodeStyles.edgeColor || defaultStroke;
-      const edgeInline = buildEdgeStyle(nodeStyles);
-      const edgePath = layoutEdgePath(structuredMode, p, child);
-      edges += `<path class="edge edge-${structuredMode}" data-source-node-id="${nodeId}" data-target-node-id="${childId}" data-source-port-side="${edgePath.sourceSide}" data-target-port-side="${edgePath.targetSide}" stroke="${stroke}" d="${edgePath.d}"${edgeInline ? ` style="${edgeInline}"` : ""} />`;
-
-      // Edge label — stored on the child node (parent is unique per child)
-      const childNode = state.nodes[childId];
-      const childStyles = readNodeStyleAttrs(childNode?.attributes || {});
-      const edgeLabel = childStyles.edgeLabel || parentChildLinkLabels.get(parentChildEdgeKey(nodeId, childId));
-      if (edgeLabel) {
-        edges += `<text class="edge-label" data-node-id="${childId}" x="${edgePath.labelX}" y="${edgePath.labelY}" text-anchor="middle">${escapeXml(edgeLabel)}</text>`;
-      }
-    });
-
-    const classNames = ["node-hit"];
-    if (scatterSurface) {
-      classNames.push("scatter-node");
-    }
-    if (viewState.selectedNodeIds.has(nodeId)) {
-      classNames.push("selected");
-      classNames.push("multi-selected");
-    }
-    if (nodeId === viewState.selectedNodeId) {
-      classNames.push("primary-selected");
-    }
-    if (isAliasNode(node)) {
-      classNames.push("alias");
-      classNames.push(isBrokenAlias(node) ? "alias-broken" : (aliasAccess(node) === "write" ? "alias-write" : "alias-read"));
-    }
-    if (nodeStyles.status) {
-      classNames.push(`status-${nodeStyles.status}`);
-    }
-    if (viewState.reparentSourceIds.has(nodeId)) {
-      classNames.push("reparent-source");
-    }
-    if (viewState.linkSourceNodeId === nodeId) {
-      classNames.push("link-source");
-    }
-    if (viewState.clipboardState?.type === "cut" && viewState.clipboardState.sourceIds.has(nodeId)) {
-      classNames.push("cut-pending");
-    }
-    if (viewState.dragState?.proposal?.kind === "reparent" && nodeId === viewState.dragState.proposal.parentId) {
-      classNames.push("drop-target");
-    }
-    if (viewState.dragState && nodeId === viewState.dragState.sourceNodeId) {
-      classNames.push("drag-source");
-    }
-    // Scope lock visual indicator
-    const nodeLock = scopeLockMap.get(nodeId);
-    if (nodeLock) {
-      classNames.push("scope-locked");
-      if (nodeLock.entityId !== collabEntityId) {
-        classNames.push("scope-locked-by-other");
-      }
-    }
-    const treatAsRoot = nodeId === displayRootId && !rootlessSurface;
-    const hitX = treatAsRoot ? p.x : p.x - 8;
-    const hitH = Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h);
-    const hitY = p.y - hitH / 2;
-    const hitW = treatAsRoot ? p.w : p.w + 36;
-    const hitRx = shapeRx(nodeStyles.shape, treatAsRoot);
-    nodes += `<rect class="${classNames.join(" ")}" data-node-id="${nodeId}" x="${hitX}" y="${hitY}" width="${hitW}" height="${hitH}" rx="${hitRx}" />`;
-    const visualClasses = ["node-visual-box"];
-    if (structuredMode === "mindmap") {
-      visualClasses.push("mindmap-box");
-    }
-    if (viewState.selectedNodeIds.has(nodeId)) {
-      visualClasses.push("selected");
-      visualClasses.push("multi-selected");
-    }
-    if (nodeId === viewState.selectedNodeId) {
-      visualClasses.push("primary-selected");
-    }
-    if (isAliasNode(node)) {
-      visualClasses.push("alias");
-      visualClasses.push(isBrokenAlias(node) ? "alias-broken" : (aliasAccess(node) === "write" ? "alias-write" : "alias-read"));
-    }
-    if (nodeStyles.status) {
-      visualClasses.push(`status-${nodeStyles.status}`);
-    }
-    if (viewState.reparentSourceIds.has(nodeId)) {
-      visualClasses.push("reparent-source");
-    }
-    if (viewState.linkSourceNodeId === nodeId) {
-      visualClasses.push("link-source");
-    }
-    if (viewState.dragState?.proposal?.kind === "reparent" && nodeId === viewState.dragState.proposal.parentId) {
-      visualClasses.push("drop-target");
-    }
-    if (viewState.dragState && nodeId === viewState.dragState.sourceNodeId) {
-      visualClasses.push("drag-source");
-    }
-    if (viewState.clipboardState?.type === "cut" && viewState.clipboardState.sourceIds.has(nodeId)) {
-      visualClasses.push("cut-pending");
-    }
-    if (nodeLock) {
-      visualClasses.push("scope-locked");
-      if (nodeLock.entityId !== collabEntityId) {
-        visualClasses.push("scope-locked-by-other");
-      }
+    if (!nodeComponent) {
+      edges += renderParentChildEdges(nodeId, nodeStyles, p, children);
     }
 
-    if (treatAsRoot) {
-      const rootLabelLines = p.labelLines || splitLabelLines(uiLabel(node) || "(empty)");
-      const rootFont = p.fontSize ?? VIEWER_TUNING.typography.rootFont;
-      const rootLineHeight = lineHeightForFont(rootFont);
-      const rootStartY = multilineTextStartY(p.y, rootLabelLines.length, rootFont, rootLineHeight);
-      const rootTspans = multilineTspans(rootLabelLines, p.x + p.w / 2, rootLineHeight);
-      const w = p.w;
-      const h = p.h;
-      const rx = structuredMode === "mindmap" ? Math.min(28, h / 2) : shapeRx(nodeStyles.shape, true);
-      const x = p.x;
-      const y = p.y - h / 2;
-      const rootBoxStyle = buildNodeVisualStyle(nodeStyles);
-      const rootBoxInline = rootBoxStyle ? ` style="${rootBoxStyle}"` : "";
-      nodes += `<rect class="root-box ${visualClasses.join(" ")}" data-node-id="${nodeId}" x="${x}" y="${y}" width="${w}" height="${h}" rx="${rx}"${rootBoxInline} />`;
-      const rootLabelInline = buildLabelStyle(nodeStyles);
-      const rootLabelStyle = [`font-size:${rootFont}px`];
-      if (rootLabelInline) rootLabelStyle.push(rootLabelInline);
-      nodes += `<text class="label-root" data-node-id="${nodeId}" x="${x + w / 2}" y="${rootStartY}" text-anchor="middle" style="${rootLabelStyle.join(";")}">${rootTspans}</text>`;
-    } else {
-      const rawLabel = diagramLabel(node, nodeStyles);
-      const labelLines = p.labelLines || splitLabelLines(rawLabel);
-      const labelClasses = ["label-node"];
-      if (viewState.selectedNodeIds.has(nodeId)) {
-        labelClasses.push("selected");
-      }
-      if (nodeId === viewState.selectedNodeId) {
-        labelClasses.push("primary-selected");
-      }
-      if (isAliasNode(node)) {
-        labelClasses.push("alias-label");
-        labelClasses.push(isBrokenAlias(node) ? "alias-broken-label" : (aliasAccess(node) === "write" ? "alias-write-label" : "alias-read-label"));
-      }
-      if (nodeStyles.status) {
-        labelClasses.push(`status-${nodeStyles.status}`);
-      }
-      const hasExplicitNodeBox = nodeStyles.shape === "diamond"
-        || nodeStyles.bg
-        || nodeStyles.border
-        || nodeStyles.borderWidth != null;
-      const needsStateVisualBox = structuredMode === "mindmap" || visualClasses.length > 1;
-      if (!isFolderNode(node) && (hasExplicitNodeBox || needsStateVisualBox)) {
-        const shapePadX = structuredMode === "mindmap" ? 0 : 14;
-        const shapePadY = structuredMode === "mindmap" ? 0 : 6;
-        const shapeX = p.x - shapePadX;
-        const shapeY = p.y - Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h) / 2 + shapePadY;
-        const shapeW = p.w + shapePadX * 2;
-        const shapeH = Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h) - shapePadY * 2;
-        const shapeInline = buildNodeVisualStyle(nodeStyles);
-        if (nodeStyles.shape === "diamond") {
-          nodes += `<path class="node-shape ${visualClasses.join(" ")}" data-node-id="${nodeId}" d="${diamondPath(p.x + p.w / 2, p.y, shapeW, shapeH)}"${shapeInline ? ` style="${shapeInline}"` : ""} />`;
-        } else {
-          const rx = structuredMode === "mindmap" ? 4 : shapeRx(nodeStyles.shape, false);
-          nodes += `<path class="node-shape ${visualClasses.join(" ")}" data-node-id="${nodeId}" d="${rectPath(shapeX, shapeY, shapeW, shapeH, rx)}"${shapeInline ? ` style="${shapeInline}"` : ""} />`;
-        }
-      }
-      if (isFolderNode(node)) {
-        const frameInsetY = structuredMode === "mindmap" ? 0 : 12;
-        const framePadX = structuredMode === "mindmap" ? 0 : 14;
-        const frameH = Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h) - frameInsetY;
-        const folderFrameX = p.x - framePadX;
-        const folderFrameY = p.y - frameH / 2;
-        const folderFrameW = p.w + framePadX * 2;
-        const folderFrameH = frameH;
-        const folderBoxStyle = buildNodeVisualStyle(nodeStyles);
-        const folderBoxInline = folderBoxStyle ? ` style="${folderBoxStyle}"` : "";
-        if (isScopePortalNode(node)) {
-          const leftX = folderFrameX + 2;
-          const rightX = folderFrameX + folderFrameW - 2;
-          const topY = folderFrameY;
-          const bottomY = folderFrameY + folderFrameH;
-          const arm = 12;
-          nodes += `<path class="portal-bracket ${visualClasses.join(" ")}" data-node-id="${nodeId}" d="M ${leftX + arm} ${topY} H ${leftX} V ${bottomY} H ${leftX + arm}"${folderBoxInline} />`;
-          nodes += `<path class="portal-bracket ${visualClasses.join(" ")}" data-node-id="${nodeId}" d="M ${rightX - arm} ${topY} H ${rightX} V ${bottomY} H ${rightX - arm}"${folderBoxInline} />`;
-        } else if (nodeStyles.shape === "diamond") {
-          nodes += `<path class="folder-box ${visualClasses.join(" ")}" data-node-id="${nodeId}" d="${diamondPath(p.x + p.w / 2, p.y, folderFrameW, folderFrameH)}"${folderBoxInline} />`;
-        } else {
-          nodes += `<rect class="folder-box ${visualClasses.join(" ")}" data-node-id="${nodeId}" x="${folderFrameX}" y="${folderFrameY}" width="${folderFrameW}" height="${folderFrameH}" rx="${structuredMode === "mindmap" ? 4 : 8}"${folderBoxInline} />`;
-        }
-        if (previewLayout) {
-          const previewIds = new Set(previewLayout.childIds);
-          Object.values(state.links || {}).forEach((rawLink) => {
-            const link = normalizeGraphLink(rawLink);
-            const sourceNode = state.nodes[link.sourceNodeId];
-            const targetNode = state.nodes[link.targetNodeId];
-            if (!sourceNode || !targetNode || isParentChildPair(sourceNode, targetNode)) {
-              return;
-            }
-            if (!previewIds.has(link.sourceNodeId) || !previewIds.has(link.targetNodeId)) {
-              return;
-            }
-            const sourcePreview = previewLayout.positions[link.sourceNodeId];
-            const targetPreview = previewLayout.positions[link.targetNodeId];
-            if (!sourcePreview || !targetPreview) {
-              return;
-            }
-            const sourceRect = {
-              x: folderFrameX + sourcePreview.x,
-              y: folderFrameY + sourcePreview.y,
-              w: sourcePreview.w,
-              h: sourcePreview.h,
-            };
-            const targetRect = {
-              x: folderFrameX + targetPreview.x,
-              y: folderFrameY + targetPreview.y,
-              w: targetPreview.w,
-              h: targetPreview.h,
-            };
-            const { source: sourceEnd, target: targetEnd } = edgePortPairBetweenRects(sourceRect, targetRect);
-            const sx = sourceEnd.x;
-            const sy = sourceEnd.y;
-            const tx = targetEnd.x;
-            const ty = targetEnd.y;
-            const previewEdgePath = smoothGraphLinkPath(sx, sy, tx, ty);
-            nodes += `<path class="flow-preview-edge" d="${previewEdgePath}" />`;
-            const edgeLabel = (link.label || link.relationType || "").trim();
-            if (edgeLabel) {
-              nodes += `<text class="flow-preview-edge-label" x="${(sx + tx) / 2}" y="${(sy + ty) / 2 - 6}" text-anchor="middle">${escapeXml(edgeLabel)}</text>`;
-            }
-          });
+    const output = renderNodeSvg(toNodeDrawInput(node, p, nodeStyles));
+    nodes += output.svg;
+    maxX = Math.max(maxX, output.bounds.maxX);
+    maxY = Math.max(maxY, output.bounds.maxY);
 
-          previewLayout.childIds.forEach((previewChildId) => {
-            const previewChild = state.nodes[previewChildId];
-            const previewPos = previewLayout.positions[previewChildId];
-            if (!previewChild || !previewPos) {
-              return;
-            }
-            const previewStyles = readNodeStyleAttrs(previewChild.attributes || {});
-            const previewLabel = escapeXml(diagramLabel(previewChild, previewStyles));
-            const previewX = folderFrameX + previewPos.x;
-            const previewY = folderFrameY + previewPos.y;
-            const previewClass = isFolderNode(previewChild) ? "flow-preview-node flow-preview-node-scope" : "flow-preview-node";
-            nodes += `<rect class="${previewClass}" x="${previewX}" y="${previewY}" width="${previewPos.w}" height="${previewPos.h}" rx="8" />`;
-            nodes += `<text class="flow-preview-node-label" x="${previewX + 10}" y="${previewY + previewPos.h / 2}" dominant-baseline="middle" text-anchor="start">${previewLabel}</text>`;
-          });
-        }
-        // Lock icon on locked folder nodes
-        if (nodeLock) {
-          const lockIconX = folderFrameX + folderFrameW - 14;
-          const lockIconY = folderFrameY + 14;
-          const lockClass = nodeLock.entityId === collabEntityId ? "lock-icon" : "lock-icon lock-icon-other";
-          nodes += `<text class="${lockClass}" x="${lockIconX}" y="${lockIconY}" text-anchor="middle" dominant-baseline="middle">\uD83D\uDD12</text>`;
-        }
-      }
-      if (isLatexNode(node)) {
-        let htmlStr = latexHtmlCache.get(node.text);
-        if (!htmlStr) {
-          const { latex, displayMode } = latexSource(node.text);
-          htmlStr = katex.renderToString(latex, { displayMode, throwOnError: false });
-          latexHtmlCache.set(node.text, htmlStr);
-        }
-        const foH = p.h;
-        const foY = p.y - foH / 2;
-        nodes += `<foreignObject data-node-id="${nodeId}" x="${p.x}" y="${foY}" width="${p.w}" height="${foH}"><div xmlns="http://www.w3.org/1999/xhtml" class="latex-node-content">${htmlStr}</div></foreignObject>`;
-      } else {
-        const nodeFont = p.fontSize ?? VIEWER_TUNING.typography.nodeFont;
-        const lineHeight = lineHeightForFont(nodeFont);
-        const startY = previewLayout
-          ? p.y - Math.max(VIEWER_TUNING.layout.nodeHitHeight, p.h) / 2 + 36
-          : multilineTextStartY(p.y, labelLines.length, nodeFont, lineHeight);
-        const labelX = structuredMode === "mindmap"
-          ? p.x + p.w / 2
-          : isScopePortalNode(node)
-          ? p.x + 12
-          : p.x;
-        const tspans = multilineTspans(labelLines, labelX, lineHeight);
-        const labelInline = buildLabelStyle(nodeStyles);
-        const labelStyle = [`font-size:${nodeFont}px`];
-        if (labelInline) labelStyle.push(labelInline);
-        nodes += `<text class="${labelClasses.join(" ")}" data-node-id="${nodeId}" x="${labelX}" y="${startY}" text-anchor="${structuredMode === "mindmap" ? "middle" : "start"}" style="${labelStyle.join(";")}">${tspans}</text>`;
-      }
-      const badge = nodeBadge(node);
-      if (badge) {
-        nodes += `<text class="alias-badge alias-badge-${badge}" x="${p.x + p.w + 18}" y="${p.y}" dominant-baseline="middle">${escapeXml(badge)}</text>`;
-      }
-      // Band confidence badge (deep band or explicit confidence)
-      if (nodeStyles.confidence != null) {
-        const cColor = confidenceColor(nodeStyles.confidence);
-        const cLabel = (nodeStyles.confidence * 100).toFixed(0) + "%";
-        const cX = p.x + p.w + (badge ? 60 : 18);
-        nodes += `<rect class="confidence-badge" x="${cX}" y="${p.y - 12}" width="42" height="22" rx="11" style="fill:${cColor}" />`;
-        nodes += `<text class="confidence-badge-text" x="${cX + 21}" y="${p.y + 1}" text-anchor="middle" dominant-baseline="middle">${escapeXml(cLabel)}</text>`;
-      }
-      // Status badge
-      if (nodeStyles.status) {
-        const statusColors: Record<string, string> = {
-          placeholder: "#999", confirmed: "#2d8c4e", contested: "#d94040",
-          frozen: "#4a7fb5", active: "#e89b1a", review: "#9b59b6",
-        };
-        const sColor = statusColors[nodeStyles.status] || "#666";
-        const sX = p.x + p.w + (badge ? 60 : 18) + (nodeStyles.confidence != null ? 56 : 0);
-        nodes += `<rect class="status-badge" x="${sX}" y="${p.y - 12}" width="${nodeStyles.status.length * 8 + 12}" height="22" rx="11" style="fill:${sColor}" />`;
-        nodes += `<text class="status-badge-text" x="${sX + nodeStyles.status.length * 4 + 6}" y="${p.y + 1}" text-anchor="middle" dominant-baseline="middle">${escapeXml(nodeStyles.status)}</text>`;
-      }
-    }
-
-    if (viewState.collapsedIds.has(nodeId) && (node.children || []).length > 0) {
-      const indicatorX =
-        treatAsRoot
-          ? p.x + p.w + VIEWER_TUNING.layout.rootIndicatorPad
-          : p.x + p.w + VIEWER_TUNING.layout.nodeIndicatorPad;
-      const hiddenCount = countHiddenDescendants(nodeId);
-      const badgeLabel = String(Math.max(1, hiddenCount));
-      const badgeWidth = Math.max(26, badgeLabel.length * 14 + 14);
-      const badgeHeight = 24;
-      const badgeX = indicatorX - badgeWidth / 2;
-      const badgeY = p.y - badgeHeight / 2;
-      nodes += `<rect class="collapsed-badge" data-collapse-node-id="${nodeId}" x="${badgeX}" y="${badgeY}" width="${badgeWidth}" height="${badgeHeight}" rx="12" />`;
-      nodes += `<circle class="collapsed-badge-node" data-collapse-node-id="${nodeId}" cx="${badgeX - 8}" cy="${p.y}" r="8" />`;
-      nodes += `<text class="collapsed-badge-count" data-collapse-node-id="${nodeId}" x="${indicatorX}" y="${p.y}" text-anchor="middle" dominant-baseline="middle">${escapeXml(badgeLabel)}</text>`;
+    if (!scatterSurface && isFolderNode(node)) {
+      nodes += renderFolderPreview(node, nodeStyles, p);
     }
 
     if (nodeComponent) {

--- a/beta/src/labs/node/node-lab.css
+++ b/beta/src/labs/node/node-lab.css
@@ -1,0 +1,84 @@
+body {
+  margin: 0;
+  background: #f5f7fb;
+  color: #1f2937;
+  font-family: "Segoe UI", "Yu Gothic UI", sans-serif;
+}
+
+.node-lab {
+  display: grid;
+  grid-template-columns: 280px minmax(560px, 1fr) 360px;
+  min-height: 100vh;
+}
+
+.lab-panel {
+  border-right: 1px solid #d8dee9;
+  background: #ffffff;
+  padding: 18px;
+}
+
+.lab-panel.right {
+  border-right: 0;
+  border-left: 1px solid #d8dee9;
+}
+
+.lab-title {
+  margin: 0 0 18px;
+  font-size: 18px;
+}
+
+.control-group {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+  font-size: 13px;
+}
+
+.control-group select {
+  min-height: 34px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 0 8px;
+  background: white;
+}
+
+.stage {
+  overflow: auto;
+  padding: 24px;
+}
+
+.node-lab-canvas {
+  width: 860px;
+  height: 520px;
+  background: white;
+  border: 1px solid #d8dee9;
+}
+
+.json-block,
+.fragment-block {
+  max-height: 42vh;
+  overflow: auto;
+  border: 1px solid #d8dee9;
+  border-radius: 6px;
+  background: #f8fafc;
+  padding: 10px;
+}
+
+.json-block pre,
+.fragment-block pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+}
+
+.lab-status {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+  font-size: 13px;
+}
+
+.lab-status-pass {
+  color: #1f7a43;
+}

--- a/beta/src/labs/node/node-lab.html
+++ b/beta/src/labs/node/node-lab.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>M3E Node Lab</title>
+    <link rel="stylesheet" href="/viewer.css" data-node-lab-stylesheet="viewer" />
+    <link rel="stylesheet" href="/katex/katex.min.css" data-node-lab-stylesheet="katex" />
+  </head>
+  <body>
+    <div id="node-lab-root"></div>
+    <script type="module" src="./node-lab.tsx"></script>
+  </body>
+</html>

--- a/beta/src/labs/node/node-lab.tsx
+++ b/beta/src/labs/node/node-lab.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { renderNode } from "../../shared/node_draw_svg";
+import { nodeLabSamples, surfaceViews, withSurface, type NodeLabSampleId } from "./node_samples";
+import "./node-lab.css";
+
+function App(): React.ReactElement {
+  const [sampleId, setSampleId] = useState<NodeLabSampleId>("plain");
+  const [surface, setSurface] = useState(surfaceViews[0]!);
+  const sample = nodeLabSamples.find((item) => item.sample_id === sampleId) || nodeLabSamples[0]!;
+  const input = useMemo(() => withSurface(sample.input, surface), [sample, surface]);
+  const output = useMemo(() => renderNode(input), [input]);
+  const loadedStyleSheets = typeof document === "undefined"
+    ? []
+    : Array.from(document.querySelectorAll<HTMLLinkElement>("link[data-node-lab-stylesheet]"))
+        .map((link) => `${link.dataset.nodeLabStylesheet}:${link.sheet ? "loaded" : "pending"}`);
+
+  return (
+    <main className="node-lab">
+      <aside className="lab-panel">
+        <h1 className="lab-title">Node Lab</h1>
+        <div className="control-group">
+          <label htmlFor="sample">Sample</label>
+          <select id="sample" value={sampleId} onChange={(event) => setSampleId(event.currentTarget.value as NodeLabSampleId)}>
+            {nodeLabSamples.map((item) => <option key={item.sample_id} value={item.sample_id}>{item.sample_id}</option>)}
+          </select>
+        </div>
+        <div className="control-group">
+          <label htmlFor="surface">Surface View</label>
+          <select id="surface" value={surface} onChange={(event) => setSurface(event.currentTarget.value as typeof surface)}>
+            {surfaceViews.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </div>
+        <div className="lab-status" data-testid="node-lab-status">
+          <div className="lab-status-pass">renderer: shared node_draw_svg</div>
+          <div data-testid="loaded-stylesheets">{loadedStyleSheets.join(" ")}</div>
+        </div>
+      </aside>
+      <section className="stage">
+        <svg className="node-lab-canvas" viewBox="0 0 860 520" role="img" aria-label="Node draw sample">
+          <g data-testid="node-fragment" dangerouslySetInnerHTML={{ __html: output.svg }} />
+        </svg>
+      </section>
+      <aside className="lab-panel right">
+        <h2 className="lab-title">Snapshot</h2>
+        <div className="json-block">
+          <pre>{JSON.stringify({ input, bounds: output.bounds }, null, 2)}</pre>
+        </div>
+        <h2 className="lab-title">Fragment</h2>
+        <div className="fragment-block" data-testid="node-fragment-text">
+          <pre>{output.svg}</pre>
+        </div>
+      </aside>
+    </main>
+  );
+}
+
+const root = document.getElementById("node-lab-root");
+if (!root) throw new Error("node-lab-root not found");
+createRoot(root).render(<App />);

--- a/beta/src/labs/node/node_samples.ts
+++ b/beta/src/labs/node/node_samples.ts
@@ -1,0 +1,177 @@
+import { renderToString } from "katex";
+import type { NodeDrawInput, SurfaceViewName } from "../../shared/node_draw_port";
+
+export type NodeLabSampleId =
+  | "plain"
+  | "long-wrap"
+  | "multiline"
+  | "root"
+  | "folder"
+  | "alias-read"
+  | "alias-write"
+  | "alias-broken"
+  | "selected"
+  | "multi"
+  | "cut"
+  | "link-source"
+  | "collapsed"
+  | "scope-locked"
+  | "fill"
+  | "color"
+  | "border"
+  | "status"
+  | "confidence"
+  | "katex";
+
+export interface NodeLabSample {
+  sample_id: NodeLabSampleId;
+  input: NodeDrawInput;
+}
+
+export const surfaceViews: SurfaceViewName[] = ["Tree", "Axial", "Radial", "Disperse", "System"];
+
+function renderLatex(source: string): { html: string; displayMode: boolean } {
+  const displayMode = false;
+  return {
+    html: renderToString(source, { displayMode, throwOnError: false }),
+    displayMode,
+  };
+}
+
+const base = {
+  selected: false,
+  primarySelected: false,
+  multiSelected: false,
+  linkSource: false,
+  cutPending: false,
+  reparentSource: false,
+  dragSource: false,
+  dropTarget: false,
+  lockedBy: "none" as const,
+};
+
+interface NodeSampleOverrides {
+  node?: Partial<NodeDrawInput["node"]>;
+  position?: Partial<NodeDrawInput["position"]>;
+  style?: Partial<NodeDrawInput["style"]>;
+  view?: Partial<NodeDrawInput["view"]>;
+  surface?: Partial<NodeDrawInput["surface"]>;
+  content?: NodeDrawInput["content"];
+}
+
+function sample(
+  sample_id: NodeLabSampleId,
+  overrides: NodeSampleOverrides,
+): NodeLabSample {
+  const label = sample_id.replace(/-/g, " ");
+  return {
+    sample_id,
+    input: {
+      node: {
+        id: sample_id,
+        type: "text",
+        kind: "plain",
+        label,
+        text: label,
+        alias: "none",
+        isFolder: false,
+        isScopePortal: false,
+        isRoot: false,
+        isLatex: false,
+        ...overrides.node,
+      },
+      position: {
+        x: 120,
+        y: 90,
+        w: 180,
+        h: 42,
+        depth: 1,
+        labelLines: [label],
+        fontSize: 14,
+        ...overrides.position,
+      },
+      style: {
+        ...overrides.style,
+      },
+      view: {
+        ...base,
+        ...overrides.view,
+      },
+      surface: {
+        view: "Tree",
+        structuredMode: "Tree",
+        displayRootId: "root",
+        rootless: false,
+        ...overrides.surface,
+      },
+      content: overrides.content || { kind: "plainLabel", labelLines: [label], fontSize: 14 },
+    },
+  };
+}
+
+export function withSurface(input: NodeDrawInput, view: SurfaceViewName): NodeDrawInput {
+  return {
+    ...input,
+    surface: { ...input.surface, view, structuredMode: view },
+    position: view === "Disperse"
+      ? { ...input.position, w: 72, h: 72, scatterCollapsedGroup: input.node.isFolder }
+      : input.position,
+  };
+}
+
+export const nodeLabSamples: NodeLabSample[] = [
+  sample("plain", {}),
+  sample("long-wrap", {
+    position: { w: 220, h: 66, labelLines: ["A deliberately long", "wrapped node label"], fontSize: 14 },
+    content: { kind: "plainLabel", labelLines: ["A deliberately long", "wrapped node label"], fontSize: 14 },
+  }),
+  sample("multiline", {
+    position: { h: 74, labelLines: ["Line one", "Line two", "Line three"], fontSize: 13 },
+    content: { kind: "plainLabel", labelLines: ["Line one", "Line two", "Line three"], fontSize: 13 },
+  }),
+  sample("root", {
+    node: { id: "root", kind: "root", isRoot: true, label: "Root Node" },
+    position: { x: 80, y: 100, w: 260, h: 72, depth: 0, labelLines: ["Root Node"], fontSize: 18 },
+    content: { kind: "plainLabel", labelLines: ["Root Node"], fontSize: 18, textAnchor: "middle" },
+  }),
+  sample("folder", {
+    node: { type: "folder", kind: "folder", isFolder: true, label: "Folder Scope", badge: "scope" },
+    position: { w: 210, h: 58, labelLines: ["Folder Scope"] },
+    content: { kind: "plainLabel", labelLines: ["Folder Scope"], fontSize: 14 },
+  }),
+  sample("alias-read", {
+    node: { type: "alias", alias: "read", label: "Read Alias", badge: "read" },
+    content: { kind: "plainLabel", labelLines: ["Read Alias"], fontSize: 14 },
+  }),
+  sample("alias-write", {
+    node: { type: "alias", alias: "write", label: "Write Alias", badge: "write" },
+    content: { kind: "plainLabel", labelLines: ["Write Alias"], fontSize: 14 },
+  }),
+  sample("alias-broken", {
+    node: { type: "alias", alias: "broken", label: "Broken Alias", badge: "broken", snapshotLabel: "Deleted" },
+    content: { kind: "plainLabel", labelLines: ["Broken Alias"], fontSize: 14 },
+  }),
+  sample("selected", { view: { selected: true, primarySelected: true, multiSelected: true } }),
+  sample("multi", { view: { selected: true, multiSelected: true } }),
+  sample("cut", { view: { cutPending: true } }),
+  sample("link-source", { view: { linkSource: true } }),
+  sample("collapsed", { view: { collapsedCount: 12 } }),
+  sample("scope-locked", {
+    node: { type: "folder", kind: "folder", isFolder: true, label: "Locked Scope", badge: "scope" },
+    view: { lockedBy: "other" },
+    content: { kind: "plainLabel", labelLines: ["Locked Scope"], fontSize: 14 },
+  }),
+  sample("fill", { style: { fill: "#dff3ff" } }),
+  sample("color", { style: { text: "#9b2f2f" } }),
+  sample("border", { style: { border: "#2d5bd1", borderStyle: "dashed", borderWidth: 3, shape: "rounded" } }),
+  sample("status", { style: { status: "review" } }),
+  sample("confidence", { style: { confidence: 0.82 } }),
+  sample("katex", {
+    node: { kind: "latex", label: "KaTeX", isLatex: true },
+    position: { w: 180, h: 58, labelLines: ["KaTeX"] },
+    content: {
+      kind: "latexHtml",
+      ...renderLatex("x^2+y^2"),
+    },
+  }),
+];

--- a/beta/src/shared/node_draw_port.ts
+++ b/beta/src/shared/node_draw_port.ts
@@ -1,0 +1,247 @@
+import type { LayoutNodePosition } from "./layout_port";
+
+export type SurfaceViewName = "Tree" | "Axial" | "Radial" | "Disperse" | "System";
+export type NodeDrawKind = "root" | "plain" | "folder" | "latex" | "status";
+export type NodeDrawType = "text" | "image" | "folder" | "alias";
+export type AliasDrawState = "none" | "read" | "write" | "broken";
+export type ScopeLockDrawState = "none" | "self" | "other";
+export type NodeDrawShape = "rect" | "rounded" | "pill" | "diamond";
+export type NodeDrawStatus = "placeholder" | "confirmed" | "contested" | "frozen" | "active" | "review";
+
+export interface NodeDrawNode {
+  id: string;
+  type: NodeDrawType;
+  kind: NodeDrawKind;
+  label: string;
+  text?: string;
+  alias: AliasDrawState;
+  aliasLabel?: string;
+  targetLabel?: string;
+  snapshotLabel?: string;
+  isFolder: boolean;
+  isScopePortal: boolean;
+  isRoot: boolean;
+  isLatex: boolean;
+  isScatterGroup?: boolean;
+  scatterRole?: "upstream" | "sample" | "downstream" | null;
+  badge?: string;
+}
+
+export interface NodeDrawStyle {
+  fill?: string;
+  text?: string;
+  border?: string;
+  borderStyle?: "solid" | "dashed" | "dotted" | "none";
+  borderWidth?: number;
+  shape?: NodeDrawShape;
+  icon?: string;
+  status?: NodeDrawStatus;
+  confidence?: number;
+  urgency?: number;
+  importance?: number;
+  band?: "flash" | "rapid" | "deep";
+}
+
+export interface NodeDrawViewState {
+  selected: boolean;
+  primarySelected: boolean;
+  multiSelected: boolean;
+  linkSource: boolean;
+  cutPending: boolean;
+  reparentSource: boolean;
+  dragSource: boolean;
+  dropTarget: boolean;
+  collapsedCount?: number;
+  lockedBy: ScopeLockDrawState;
+}
+
+export interface NodeDrawSurface {
+  view: SurfaceViewName;
+  structuredMode?: SurfaceViewName;
+  displayRootId?: string;
+  rootless?: boolean;
+}
+
+export type NodeDrawContent =
+  | { kind: "plainLabel"; labelLines: string[]; fontSize?: number; textAnchor?: "start" | "middle" }
+  | { kind: "latexHtml"; html: string; displayMode: boolean };
+
+export interface NodeDrawInput {
+  node: NodeDrawNode;
+  position: LayoutNodePosition;
+  style: NodeDrawStyle;
+  view: NodeDrawViewState;
+  surface: NodeDrawSurface;
+  content: NodeDrawContent;
+}
+
+export interface NodeDrawBounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  maxX: number;
+  maxY: number;
+}
+
+export interface NodeDrawOutput {
+  svg: string;
+  overlays?: string;
+  bounds: NodeDrawBounds;
+}
+
+export interface NodeDrawLatexAdapter {
+  renderLatex(source: string): { html: string; displayMode: boolean };
+  measureLatex?(source: string): { w: number; h: number };
+}
+
+export interface RawNodeDrawStyleInput {
+  styleJson?: string;
+  legacy?: Record<string, string | undefined>;
+  surfaceShape?: NodeDrawShape | "rounded" | null;
+}
+
+const VALID_STATUSES = new Set<NodeDrawStatus>([
+  "placeholder",
+  "confirmed",
+  "contested",
+  "frozen",
+  "active",
+  "review",
+]);
+
+export function normalizeNodeDrawStyle(raw: RawNodeDrawStyleInput): NodeDrawStyle {
+  const legacy = raw.legacy || {};
+  const parsed = parseStyleJson(raw.styleJson);
+  const urgency = finiteNumber(parsed.urgency);
+  const importance = finiteNumber(parsed.importance);
+  const jsonFill = typeof parsed.fill === "string" ? sanitizeColor(parsed.fill) : undefined;
+  const legacyFill = sanitizeColor(legacy["m3e:bg"]);
+  const fill = jsonFill ?? legacyFill ?? (
+    urgency !== undefined || importance !== undefined
+      ? deriveFillFromUrgencyImportance(urgency ?? 0, importance ?? 0)
+      : undefined
+  );
+  return dropUndefined({
+    fill,
+    text: (typeof parsed.text === "string" ? sanitizeColor(parsed.text) : undefined) ?? sanitizeColor(legacy["m3e:color"]),
+    border: (typeof parsed.border === "string" ? sanitizeColor(parsed.border) : undefined) ?? sanitizeColor(legacy["m3e:border"]),
+    borderStyle: sanitizeBorderStyle(legacy["m3e:border-style"]),
+    borderWidth: sanitizeNumeric(legacy["m3e:border-width"], 0, 8),
+    shape: raw.surfaceShape ?? sanitizeShape(legacy["m3e:shape"]),
+    icon: sanitizeIcon(legacy["m3e:icon"]),
+    status: sanitizeStatus(parsed.status) ?? sanitizeStatus(legacy["m3e:status"]),
+    confidence: sanitizeNumeric(legacy["m3e:confidence"], 0, 1),
+    urgency,
+    importance,
+    band: sanitizeBand(legacy["m3e:band"]),
+  });
+}
+
+export function nodeDrawConfidenceColor(c: number): string {
+  const v = clamp01(c);
+  if (v <= 0.5) {
+    const r = 220;
+    const g = Math.round(60 + v * 2 * 160);
+    return `rgb(${r},${g},40)`;
+  }
+  const r = Math.round(220 - (v - 0.5) * 2 * 180);
+  const g = Math.round(180 + (v - 0.5) * 2 * 40);
+  return `rgb(${r},${g},40)`;
+}
+
+export function canonicalSurfaceViewName(raw: string | undefined | null): SurfaceViewName {
+  switch ((raw || "").trim().toLowerCase()) {
+    case "timeline":
+    case "axial":
+      return "Axial";
+    case "scatter":
+    case "disperse":
+      return "Disperse";
+    case "system":
+      return "System";
+    case "radial":
+      return "Radial";
+    case "tree":
+    case "mindmap":
+    case "logic-chart":
+    default:
+      return "Tree";
+  }
+}
+
+function parseStyleJson(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function sanitizeColor(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim();
+  if (/^#[0-9a-fA-F]{3,8}$/.test(value)) return value;
+  if (/^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)$/.test(value)) return value;
+  return undefined;
+}
+
+function sanitizeBorderStyle(raw: unknown): NodeDrawStyle["borderStyle"] | undefined {
+  if (raw === "solid" || raw === "dashed" || raw === "dotted" || raw === "none") return raw;
+  return undefined;
+}
+
+function sanitizeShape(raw: unknown): NodeDrawShape | undefined {
+  if (raw === "rect" || raw === "rounded" || raw === "pill" || raw === "diamond") return raw;
+  return undefined;
+}
+
+function sanitizeIcon(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim();
+  return value.length > 0 && [...value].length <= 4 ? value : undefined;
+}
+
+function sanitizeBand(raw: unknown): NodeDrawStyle["band"] | undefined {
+  if (raw === "flash" || raw === "rapid" || raw === "deep") return raw;
+  return undefined;
+}
+
+function sanitizeStatus(raw: unknown): NodeDrawStatus | undefined {
+  if (typeof raw !== "string") return undefined;
+  const status = raw.trim().toLowerCase() as NodeDrawStatus;
+  return VALID_STATUSES.has(status) ? status : undefined;
+}
+
+function sanitizeNumeric(raw: unknown, min: number, max: number): number | undefined {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? Math.max(min, Math.min(max, n)) : undefined;
+}
+
+function finiteNumber(raw: unknown): number | undefined {
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
+
+function clamp01(x: number): number {
+  return Math.max(0, Math.min(1, x));
+}
+
+function deriveFillFromUrgencyImportance(urgency: number, importance: number): string {
+  const u = clamp01(urgency / 3);
+  const i = clamp01(importance / 3);
+  const w00 = (1 - u) * (1 - i);
+  const w01 = (1 - u) * i;
+  const w10 = u * (1 - i);
+  const w11 = u * i;
+  const r = Math.round(w00 * 255 + w01 * 255 + w10 * 0 + w11 * 255);
+  const g = Math.round(w00 * 255 + w01 * 255 + w10 * 0 + w11 * 0);
+  const b = Math.round(w00 * 255 + w01 * 0 + w10 * 255 + w11 * 0);
+  const hex = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+function dropUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T;
+}

--- a/beta/src/shared/node_draw_svg.ts
+++ b/beta/src/shared/node_draw_svg.ts
@@ -1,0 +1,350 @@
+import {
+  nodeDrawConfidenceColor,
+  type NodeDrawInput,
+  type NodeDrawOutput,
+  type NodeDrawStatus,
+  type NodeDrawStyle,
+} from "./node_draw_port";
+
+const NODE_HIT_HEIGHT = 34;
+const ROOT_INDICATOR_PAD = 28;
+const NODE_INDICATOR_PAD = 18;
+const NODE_RIGHT_PAD = 180;
+const NODE_BOTTOM_PAD = 96;
+
+const STATUS_COLORS: Record<NodeDrawStatus, string> = {
+  placeholder: "#999",
+  confirmed: "#2d8c4e",
+  contested: "#d94040",
+  frozen: "#4a7fb5",
+  active: "#e89b1a",
+  review: "#9b59b6",
+};
+
+export function renderNode(input: NodeDrawInput): NodeDrawOutput {
+  const svg = input.surface.view === "Disperse" ? renderScatterNode(input) : renderStructuredNode(input);
+  return {
+    svg,
+    bounds: {
+      x: input.position.x,
+      y: input.position.y - input.position.h / 2,
+      w: input.position.w,
+      h: input.position.h,
+      maxX: input.position.x + input.position.w + NODE_RIGHT_PAD,
+      maxY: input.position.y + input.position.h + NODE_BOTTOM_PAD,
+    },
+  };
+}
+
+function renderStructuredNode(input: NodeDrawInput): string {
+  const p = input.position;
+  const treatAsRoot = input.node.isRoot && !input.surface.rootless;
+  const hitH = Math.max(NODE_HIT_HEIGHT, p.h);
+  const hitX = treatAsRoot ? p.x : p.x - 8;
+  const hitY = p.y - hitH / 2;
+  const hitW = treatAsRoot ? p.w : p.w + 36;
+  const hitRx = shapeRx(input.style, treatAsRoot);
+  const classNames = nodeStateClasses(input, ["node-hit"]);
+  const parts: string[] = [
+    `<rect class="${classNames.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" x="${fmt(hitX)}" y="${fmt(hitY)}" width="${fmt(hitW)}" height="${fmt(hitH)}" rx="${fmt(hitRx)}" />`,
+  ];
+  if (treatAsRoot) {
+    parts.push(renderRootNode(input));
+  } else {
+    parts.push(renderNonRootNode(input));
+  }
+  if (input.view.collapsedCount !== undefined && input.view.collapsedCount > 0) {
+    parts.push(renderCollapsedBadge(input, treatAsRoot));
+  }
+  return parts.join("");
+}
+
+function renderRootNode(input: NodeDrawInput): string {
+  const p = input.position;
+  const h = p.h;
+  const y = p.y - h / 2;
+  const rx = input.surface.structuredMode === "Tree" ? shapeRx(input.style, true) : Math.min(28, h / 2);
+  const visualClasses = nodeStateClasses(input, ["root-box", "node-visual-box"]);
+  const inline = visualStyle(input.style);
+  const label = plainLabel(input);
+  const font = label.fontSize ?? p.fontSize ?? 16;
+  const lineHeight = lineHeightForFont(font);
+  const startY = multilineTextStartY(p.y, label.labelLines.length, font, lineHeight);
+  const labelStyle = labelStyleAttr(input.style, font);
+  return [
+    `<rect class="${visualClasses.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" x="${fmt(p.x)}" y="${fmt(y)}" width="${fmt(p.w)}" height="${fmt(h)}" rx="${fmt(rx)}"${inline} />`,
+    `<text class="label-root" data-node-id="${escapeAttr(input.node.id)}" x="${fmt(p.x + p.w / 2)}" y="${fmt(startY)}" text-anchor="middle" style="${labelStyle}">${multilineTspans(label.labelLines, p.x + p.w / 2, lineHeight)}</text>`,
+  ].join("");
+}
+
+function renderNonRootNode(input: NodeDrawInput): string {
+  const p = input.position;
+  const parts: string[] = [];
+  const visualClasses = nodeStateClasses(input, ["node-visual-box"]);
+  const labelClasses = nodeStateClasses(input, ["label-node"], {
+    aliasLabel: true,
+    status: true,
+  });
+  if (input.style.shape === "diamond" || input.style.fill || input.style.border || input.style.borderWidth !== undefined || visualClasses.length > 1) {
+    parts.push(renderNodeShape(input, visualClasses));
+  }
+  if (input.node.isFolder) {
+    parts.push(renderFolderFrame(input, visualClasses));
+  }
+  if (input.content.kind === "latexHtml") {
+    const y = p.y - p.h / 2;
+    parts.push(`<foreignObject data-node-id="${escapeAttr(input.node.id)}" x="${fmt(p.x)}" y="${fmt(y)}" width="${fmt(p.w)}" height="${fmt(p.h)}"><div xmlns="http://www.w3.org/1999/xhtml" class="latex-node-content">${input.content.html}</div></foreignObject>`);
+  } else {
+    const font = input.content.fontSize ?? p.fontSize ?? 14;
+    const lineHeight = lineHeightForFont(font);
+    const startY = multilineTextStartY(p.y, input.content.labelLines.length, font, lineHeight);
+    const textAnchor = input.content.textAnchor ?? (input.surface.structuredMode === "Tree" ? "start" : "middle");
+    const x = textAnchor === "middle" ? p.x + p.w / 2 : input.node.isScopePortal ? p.x + 12 : p.x;
+    parts.push(`<text class="${labelClasses.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" x="${fmt(x)}" y="${fmt(startY)}" text-anchor="${textAnchor}" style="${labelStyleAttr(input.style, font)}">${multilineTspans(input.content.labelLines, x, lineHeight)}</text>`);
+  }
+  parts.push(renderBadges(input));
+  return parts.join("");
+}
+
+function renderScatterNode(input: NodeDrawInput): string {
+  const p = input.position;
+  const r = Math.max(8, Math.min(p.w, p.h) / 2);
+  const cx = p.x + r;
+  const cy = p.y;
+  const circleClasses = nodeStateClasses(input, ["node-hit", "scatter-node-circle"]);
+  circleClasses.push(input.node.isRoot ? "scatter-root" : input.node.isScatterGroup ? "scatter-group" : "scatter-branch");
+  if (input.node.scatterRole) circleClasses.push(`scatter-role-${input.node.scatterRole}`);
+  const inline = circleStyle(input.style);
+  const label = plainLabel(input);
+  const labelText = label.labelLines.join(" ");
+  const font = label.fontSize ?? p.fontSize ?? scatterFontSizeFor(r);
+  return [
+    `<circle class="${circleClasses.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" cx="${fmt(cx)}" cy="${fmt(cy)}" r="${fmt(r)}"${inline} />`,
+    `<text class="${input.node.isRoot ? "label-root" : "label-node"} scatter-label" data-node-id="${escapeAttr(input.node.id)}" x="${fmt(cx + r + 7)}" y="${fmt(cy)}" text-anchor="start" dominant-baseline="middle" style="${labelStyleAttr(input.style, font)}">${escapeXml(labelText)}</text>`,
+  ].join("");
+}
+
+function renderNodeShape(input: NodeDrawInput, classes: string[]): string {
+  const p = input.position;
+  const hitH = Math.max(NODE_HIT_HEIGHT, p.h);
+  const shapePadX = input.surface.structuredMode === "Tree" ? 14 : 0;
+  const shapePadY = input.surface.structuredMode === "Tree" ? 6 : 0;
+  const x = p.x - shapePadX;
+  const y = p.y - hitH / 2 + shapePadY;
+  const w = p.w + shapePadX * 2;
+  const h = hitH - shapePadY * 2;
+  const inline = visualStyle(input.style);
+  if (input.style.shape === "diamond") {
+    return `<path class="node-shape ${classes.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" d="${diamondPath(p.x + p.w / 2, p.y, w, h)}"${inline} />`;
+  }
+  return `<path class="node-shape ${classes.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" d="${rectPath(x, y, w, h, shapeRx(input.style, false))}"${inline} />`;
+}
+
+function renderFolderFrame(input: NodeDrawInput, classes: string[]): string {
+  const p = input.position;
+  const frameInsetY = input.surface.structuredMode === "Tree" ? 12 : 0;
+  const framePadX = input.surface.structuredMode === "Tree" ? 14 : 0;
+  const frameH = Math.max(NODE_HIT_HEIGHT, p.h) - frameInsetY;
+  const x = p.x - framePadX;
+  const y = p.y - frameH / 2;
+  const w = p.w + framePadX * 2;
+  const h = frameH;
+  const inline = visualStyle(input.style);
+  const parts: string[] = [];
+  if (input.node.isScopePortal) {
+    const leftX = x + 2;
+    const rightX = x + w - 2;
+    const arm = 12;
+    parts.push(`<path class="portal-bracket ${classes.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" d="M ${fmt(leftX + arm)} ${fmt(y)} H ${fmt(leftX)} V ${fmt(y + h)} H ${fmt(leftX + arm)}"${inline} />`);
+    parts.push(`<path class="portal-bracket ${classes.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" d="M ${fmt(rightX - arm)} ${fmt(y)} H ${fmt(rightX)} V ${fmt(y + h)} H ${fmt(rightX - arm)}"${inline} />`);
+  } else if (input.style.shape === "diamond") {
+    parts.push(`<path class="folder-box ${classes.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" d="${diamondPath(p.x + p.w / 2, p.y, w, h)}"${inline} />`);
+  } else {
+    parts.push(`<rect class="folder-box ${classes.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" x="${fmt(x)}" y="${fmt(y)}" width="${fmt(w)}" height="${fmt(h)}" rx="${input.surface.structuredMode === "Tree" ? 8 : 4}"${inline} />`);
+  }
+  if (input.view.lockedBy !== "none") {
+    const lockClass = input.view.lockedBy === "self" ? "lock-icon" : "lock-icon lock-icon-other";
+    parts.push(`<text class="${lockClass}" x="${fmt(x + w - 14)}" y="${fmt(y + 14)}" text-anchor="middle" dominant-baseline="middle">&#128274;</text>`);
+  }
+  return parts.join("");
+}
+
+function renderBadges(input: NodeDrawInput): string {
+  const parts: string[] = [];
+  const p = input.position;
+  const badge = input.node.badge || "";
+  if (badge) {
+    parts.push(`<text class="alias-badge alias-badge-${escapeAttr(badge)}" x="${fmt(p.x + p.w + 18)}" y="${fmt(p.y)}" dominant-baseline="middle">${escapeXml(badge)}</text>`);
+  }
+  if (input.style.confidence !== undefined) {
+    const cColor = nodeDrawConfidenceColor(input.style.confidence);
+    const cLabel = `${(input.style.confidence * 100).toFixed(0)}%`;
+    const cX = p.x + p.w + (badge ? 60 : 18);
+    parts.push(`<rect class="confidence-badge" x="${fmt(cX)}" y="${fmt(p.y - 12)}" width="42" height="22" rx="11" style="fill:${cColor}" />`);
+    parts.push(`<text class="confidence-badge-text" x="${fmt(cX + 21)}" y="${fmt(p.y + 1)}" text-anchor="middle" dominant-baseline="middle">${escapeXml(cLabel)}</text>`);
+  }
+  if (input.style.status) {
+    const sX = p.x + p.w + (badge ? 60 : 18) + (input.style.confidence !== undefined ? 56 : 0);
+    const width = input.style.status.length * 8 + 12;
+    parts.push(`<rect class="status-badge" x="${fmt(sX)}" y="${fmt(p.y - 12)}" width="${fmt(width)}" height="22" rx="11" style="fill:${STATUS_COLORS[input.style.status]}" />`);
+    parts.push(`<text class="status-badge-text" x="${fmt(sX + input.style.status.length * 4 + 6)}" y="${fmt(p.y + 1)}" text-anchor="middle" dominant-baseline="middle">${escapeXml(input.style.status)}</text>`);
+  }
+  return parts.join("");
+}
+
+function renderCollapsedBadge(input: NodeDrawInput, treatAsRoot: boolean): string {
+  const p = input.position;
+  const indicatorX = treatAsRoot ? p.x + p.w + ROOT_INDICATOR_PAD : p.x + p.w + NODE_INDICATOR_PAD;
+  const label = String(Math.max(1, input.view.collapsedCount ?? 1));
+  const width = Math.max(26, label.length * 14 + 14);
+  const height = 24;
+  const x = indicatorX - width / 2;
+  const y = p.y - height / 2;
+  return [
+    `<rect class="collapsed-badge" data-collapse-node-id="${escapeAttr(input.node.id)}" x="${fmt(x)}" y="${fmt(y)}" width="${fmt(width)}" height="${fmt(height)}" rx="12" />`,
+    `<circle class="collapsed-badge-node" data-collapse-node-id="${escapeAttr(input.node.id)}" cx="${fmt(x - 8)}" cy="${fmt(p.y)}" r="8" />`,
+    `<text class="collapsed-badge-count" data-collapse-node-id="${escapeAttr(input.node.id)}" x="${fmt(indicatorX)}" y="${fmt(p.y)}" text-anchor="middle" dominant-baseline="middle">${escapeXml(label)}</text>`,
+  ].join("");
+}
+
+function nodeStateClasses(input: NodeDrawInput, base: string[], opts: { aliasLabel?: boolean; status?: boolean } = {}): string[] {
+  const classes = [...base];
+  if (input.view.selected) classes.push("selected");
+  if (input.view.multiSelected) classes.push("multi-selected");
+  if (input.view.primarySelected) classes.push("primary-selected");
+  if (input.node.alias !== "none") {
+    classes.push(opts.aliasLabel ? "alias-label" : "alias");
+    classes.push(aliasClass(input.node.alias, Boolean(opts.aliasLabel)));
+  }
+  if (opts.status && input.style.status) classes.push(`status-${input.style.status}`);
+  if (!opts.status && input.style.status) classes.push(`status-${input.style.status}`);
+  if (input.view.reparentSource) classes.push("reparent-source");
+  if (input.view.linkSource) classes.push("link-source");
+  if (input.view.cutPending) classes.push("cut-pending");
+  if (input.view.dropTarget) classes.push("drop-target");
+  if (input.view.dragSource) classes.push("drag-source");
+  if (input.view.lockedBy !== "none") {
+    classes.push("scope-locked");
+    if (input.view.lockedBy === "other") classes.push("scope-locked-by-other");
+  }
+  return classes;
+}
+
+function aliasClass(alias: string, label: boolean): string {
+  const suffix = label ? "-label" : "";
+  if (alias === "broken") return `alias-broken${suffix}`;
+  if (alias === "write") return `alias-write${suffix}`;
+  return `alias-read${suffix}`;
+}
+
+function plainLabel(input: NodeDrawInput): Extract<NodeDrawInput["content"], { kind: "plainLabel" }> {
+  return input.content.kind === "plainLabel"
+    ? input.content
+    : { kind: "plainLabel", labelLines: [input.node.label || input.node.id], fontSize: input.position.fontSize };
+}
+
+function visualStyle(style: NodeDrawStyle): string {
+  const parts = baseShapeStyles(style);
+  if (style.band === "flash") {
+    parts.push("opacity:0.6");
+    if (!style.borderStyle) parts.push("stroke-dasharray:6 4");
+  } else if (style.band === "deep") {
+    if (style.borderWidth === undefined) parts.push("stroke-width:4px");
+    if (!style.border) parts.push("stroke:#333");
+  }
+  if (style.status && !style.fill && !style.border) {
+    if (style.status === "placeholder") parts.push("stroke:#999;stroke-dasharray:4 4;stroke-width:3px");
+    if (style.status === "confirmed") parts.push("stroke:#2d8c4e;stroke-width:6px");
+    if (style.status === "contested") parts.push("stroke:#d94040;stroke-width:6px");
+    if (style.status === "frozen") parts.push("stroke:#4a7fb5;stroke-width:4.5px;stroke-dasharray:2 3");
+    if (style.status === "active") parts.push("stroke:#e89b1a;stroke-width:7.5px");
+    if (style.status === "review") parts.push("stroke:#9b59b6;stroke-width:6px;stroke-dasharray:6 3");
+  }
+  return parts.length ? ` style="${parts.join(";")}"` : "";
+}
+
+function circleStyle(style: NodeDrawStyle): string {
+  const parts = baseShapeStyles(style);
+  return parts.length ? ` style="${parts.join(";")}"` : "";
+}
+
+function baseShapeStyles(style: NodeDrawStyle): string[] {
+  const parts: string[] = [];
+  if (style.fill) parts.push(`fill:${style.fill}`);
+  if (style.border) parts.push(`stroke:${style.border}`);
+  if (style.borderWidth !== undefined) parts.push(`stroke-width:${style.borderWidth}px`);
+  if (style.borderStyle === "dashed") parts.push("stroke-dasharray:8 5");
+  if (style.borderStyle === "dotted") parts.push("stroke-dasharray:3 3");
+  if (style.borderStyle === "none") parts.push("stroke:none");
+  return parts;
+}
+
+function labelStyleAttr(style: NodeDrawStyle, fontSize: number): string {
+  const parts = [`font-size:${fontSize}px`];
+  if (style.text) parts.push(`fill:${style.text}`);
+  return parts.join(";");
+}
+
+function shapeRx(style: NodeDrawStyle, isRoot: boolean): number {
+  if (!style.shape) return isRoot ? 60 : 12;
+  if (style.shape === "rect") return isRoot ? 8 : 2;
+  if (style.shape === "rounded") return isRoot ? 24 : 12;
+  if (style.shape === "pill") return 999;
+  return 0;
+}
+
+function rectPath(x: number, y: number, w: number, h: number, rx: number): string {
+  if (rx <= 0) return `M ${fmt(x)} ${fmt(y)} H ${fmt(x + w)} V ${fmt(y + h)} H ${fmt(x)} Z`;
+  const r = Math.min(rx, w / 2, h / 2);
+  return [
+    `M ${fmt(x + r)} ${fmt(y)}`,
+    `H ${fmt(x + w - r)}`,
+    `Q ${fmt(x + w)} ${fmt(y)} ${fmt(x + w)} ${fmt(y + r)}`,
+    `V ${fmt(y + h - r)}`,
+    `Q ${fmt(x + w)} ${fmt(y + h)} ${fmt(x + w - r)} ${fmt(y + h)}`,
+    `H ${fmt(x + r)}`,
+    `Q ${fmt(x)} ${fmt(y + h)} ${fmt(x)} ${fmt(y + h - r)}`,
+    `V ${fmt(y + r)}`,
+    `Q ${fmt(x)} ${fmt(y)} ${fmt(x + r)} ${fmt(y)}`,
+    "Z",
+  ].join(" ");
+}
+
+function diamondPath(cx: number, cy: number, w: number, h: number): string {
+  return `M ${fmt(cx)} ${fmt(cy - h / 2)} L ${fmt(cx + w / 2)} ${fmt(cy)} L ${fmt(cx)} ${fmt(cy + h / 2)} L ${fmt(cx - w / 2)} ${fmt(cy)} Z`;
+}
+
+function multilineTextStartY(centerY: number, lines: number, fontSize: number, lineHeight: number): number {
+  if (lines <= 1) return centerY + fontSize * 0.35;
+  return centerY - ((lines - 1) * lineHeight) / 2 + fontSize * 0.35;
+}
+
+function multilineTspans(lines: string[], x: number, lineHeight: number): string {
+  return lines.map((line, index) => (
+    index === 0
+      ? `<tspan x="${fmt(x)}">${escapeXml(line)}</tspan>`
+      : `<tspan x="${fmt(x)}" dy="${fmt(lineHeight)}">${escapeXml(line)}</tspan>`
+  )).join("");
+}
+
+function lineHeightForFont(fontSize: number): number {
+  return Math.max(14, Math.round(fontSize * 1.25));
+}
+
+function scatterFontSizeFor(radius: number): number {
+  if (radius <= 22) return 10;
+  if (radius <= 30) return 11;
+  return 12;
+}
+
+function fmt(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(3).replace(/\.?0+$/, "");
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttr(value: string): string {
+  return escapeXml(value).replace(/"/g, "&quot;");
+}

--- a/beta/tests/fixtures/node-draw-golden/samples.json
+++ b/beta/tests/fixtures/node-draw-golden/samples.json
@@ -1,0 +1,37 @@
+[
+  {
+    "schema_version": 1,
+    "sample_id": "plain",
+    "selectors": [".node-hit", ".label-node"]
+  },
+  {
+    "schema_version": 1,
+    "sample_id": "alias-read",
+    "selectors": [".alias-read", ".alias-badge-read"]
+  },
+  {
+    "schema_version": 1,
+    "sample_id": "collapsed",
+    "selectors": [".collapsed-badge", ".collapsed-badge-count"]
+  },
+  {
+    "schema_version": 1,
+    "sample_id": "scope-locked",
+    "selectors": [".scope-locked", ".lock-icon-other"]
+  },
+  {
+    "schema_version": 1,
+    "sample_id": "status",
+    "selectors": [".status-review", ".status-badge"]
+  },
+  {
+    "schema_version": 1,
+    "sample_id": "confidence",
+    "selectors": [".confidence-badge", ".confidence-badge-text"]
+  },
+  {
+    "schema_version": 1,
+    "sample_id": "katex",
+    "selectors": ["foreignObject", ".latex-node-content"]
+  }
+]

--- a/beta/tests/unit/node_draw_contract.test.ts
+++ b/beta/tests/unit/node_draw_contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import type { LayoutNodePosition } from "../../src/shared/layout_port";
+import {
+  canonicalSurfaceViewName,
+  normalizeNodeDrawStyle,
+  type NodeDrawInput,
+  type NodeDrawOutput,
+  type NodeDrawStyle,
+  type NodeDrawSurface,
+  type NodeDrawViewState,
+} from "../../src/shared/node_draw_port";
+import { renderNode } from "../../src/shared/node_draw_svg";
+
+describe("NodeDrawPort contract", () => {
+  test("renders a positioned plain node through the public renderer", () => {
+    const position: LayoutNodePosition = { x: 100, y: 80, w: 160, h: 40, depth: 1, labelLines: ["Plain"], fontSize: 14 };
+    const style: NodeDrawStyle = { fill: "#ffffff", border: "#333333" };
+    const view: NodeDrawViewState = {
+      selected: false,
+      primarySelected: false,
+      multiSelected: false,
+      linkSource: false,
+      cutPending: false,
+      reparentSource: false,
+      dragSource: false,
+      dropTarget: false,
+      lockedBy: "none",
+    };
+    const surface: NodeDrawSurface = { view: "Tree", structuredMode: "Tree", displayRootId: "root" };
+    const input: NodeDrawInput = {
+      node: {
+        id: "plain",
+        type: "text",
+        kind: "plain",
+        label: "Plain",
+        text: "Plain",
+        alias: "none",
+        isFolder: false,
+        isScopePortal: false,
+        isRoot: false,
+        isLatex: false,
+      },
+      position,
+      style,
+      view,
+      surface,
+      content: { kind: "plainLabel", labelLines: ["Plain"], fontSize: 14 },
+    };
+
+    const output: NodeDrawOutput = renderNode(input);
+
+    expect(output.bounds).toMatchObject({ x: 100, y: 60, w: 160, h: 40 });
+    expect(output.svg).toContain('class="node-hit');
+    expect(output.svg).toContain('data-node-id="plain"');
+    expect(output.svg).not.toContain("edge-");
+    expect(output.svg).not.toContain("markdown");
+  });
+
+  test("normalizes style JSON, legacy attrs, and legacy surface names", () => {
+    expect(normalizeNodeDrawStyle({
+      styleJson: JSON.stringify({ fill: "#abcdef", text: "#111111", urgency: 2, importance: 3, status: "review" }),
+      legacy: { "m3e:bg": "#ffffff", "m3e:border": "#222222", "m3e:confidence": "2" },
+    })).toMatchObject({
+      fill: "#abcdef",
+      text: "#111111",
+      border: "#222222",
+      confidence: 1,
+      status: "review",
+    });
+    expect(canonicalSurfaceViewName("scatter")).toBe("Disperse");
+    expect(canonicalSurfaceViewName("timeline")).toBe("Axial");
+    expect(canonicalSurfaceViewName("mindmap")).toBe("Tree");
+  });
+});

--- a/beta/tests/unit/node_draw_fragment_golden.test.ts
+++ b/beta/tests/unit/node_draw_fragment_golden.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { nodeLabSamples, withSurface, type NodeLabSampleId } from "../../src/labs/node/node_samples";
+import { renderNode } from "../../src/shared/node_draw_svg";
+
+interface GoldenSelectorSample {
+  schema_version: 1;
+  sample_id: NodeLabSampleId;
+  selectors: string[];
+}
+
+const selectorFixtures = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "../fixtures/node-draw-golden/samples.json"), "utf8"),
+) as GoldenSelectorSample[];
+
+function normalizeFragment(svg: string): string {
+  return svg.replace(/>\s+</g, "><").trim();
+}
+
+describe("nodeDraw fragment golden parity", () => {
+  test("node-lab samples cover first-ratchet variants", () => {
+    expect(nodeLabSamples.map((sample) => sample.sample_id)).toEqual([
+      "plain",
+      "long-wrap",
+      "multiline",
+      "root",
+      "folder",
+      "alias-read",
+      "alias-write",
+      "alias-broken",
+      "selected",
+      "multi",
+      "cut",
+      "link-source",
+      "collapsed",
+      "scope-locked",
+      "fill",
+      "color",
+      "border",
+      "status",
+      "confidence",
+      "katex",
+    ]);
+  });
+
+  test("plain sample has deterministic fragment snapshot", () => {
+    const sample = nodeLabSamples.find((item) => item.sample_id === "plain")!;
+    const output = renderNode(sample.input);
+    expect(normalizeFragment(output.svg)).toBe('<rect class="node-hit" data-node-id="plain" x="112" y="69" width="216" height="42" rx="12" /><text class="label-node" data-node-id="plain" x="120" y="94.9" text-anchor="start" style="font-size:14px"><tspan x="120">plain</tspan></text>');
+    expect(output.bounds).toMatchObject({ x: 120, y: 69, w: 180, h: 42 });
+  });
+
+  test.each(selectorFixtures)("$sample_id emits required node-only selectors", (fixture) => {
+    const sample = nodeLabSamples.find((item) => item.sample_id === fixture.sample_id);
+    expect(sample, fixture.sample_id).toBeTruthy();
+    const output = renderNode(sample!.input);
+    for (const selector of fixture.selectors) {
+      expect(output.svg, `${fixture.sample_id} ${selector}`).toContain(selector.replace(/^\./, ""));
+    }
+    expect(output.svg).not.toContain("flow-preview-edge");
+    expect(output.svg).not.toContain("graph-link");
+    expect(output.svg).not.toContain("markdown");
+  });
+
+  test("Disperse surface renders scatter circle without calling layout or edge", () => {
+    const sample = nodeLabSamples.find((item) => item.sample_id === "folder")!;
+    const output = renderNode(withSurface(sample.input, "Disperse"));
+    expect(output.svg).toContain("scatter-node-circle");
+    expect(output.svg).not.toContain("<path class=\"edge");
+  });
+});

--- a/beta/tests/visual/node_lab.spec.js
+++ b/beta/tests/visual/node_lab.spec.js
@@ -1,0 +1,55 @@
+const { test, expect } = require("@playwright/test");
+
+async function openLab(page) {
+  await page.goto("/src/labs/node/node-lab.html");
+  await expect(page.locator("#sample")).toBeVisible();
+}
+
+async function expectStylesheetsLoaded(page) {
+  const loaded = await page.evaluate(() => {
+    return Array.from(document.querySelectorAll("link[data-node-lab-stylesheet]")).map((link) => ({
+      name: link.getAttribute("data-node-lab-stylesheet"),
+      href: link.getAttribute("href"),
+      loaded: Boolean(link.sheet),
+    }));
+  });
+  expect(loaded).toEqual([
+    expect.objectContaining({ name: "viewer", href: "/viewer.css", loaded: true }),
+    expect.objectContaining({ name: "katex", href: "/katex/katex.min.css", loaded: true }),
+  ]);
+}
+
+test.describe("node-lab", () => {
+  test("renders samples through shared nodeDraw and loads product CSS plus KaTeX", async ({ page }) => {
+    await openLab(page);
+    await expectStylesheetsLoaded(page);
+    await expect(page.locator("#surface")).toHaveText(/Tree[\s\S]*Axial[\s\S]*Radial[\s\S]*Disperse[\s\S]*System/);
+
+    await page.locator("#sample").selectOption("katex");
+    await expect(page.locator("foreignObject .latex-node-content")).toBeVisible();
+
+    await page.locator("#sample").selectOption("collapsed");
+    await expect(page.locator(".collapsed-badge-count")).toHaveText("12");
+
+    await page.locator("#sample").selectOption("scope-locked");
+    await expect(page.locator(".lock-icon-other")).toBeVisible();
+
+    await page.locator("#sample").selectOption("alias-read");
+    await expect(page.locator(".alias-badge-read")).toBeVisible();
+    await page.locator("#sample").selectOption("alias-write");
+    await expect(page.locator(".alias-badge-write")).toBeVisible();
+    await page.locator("#sample").selectOption("alias-broken");
+    await expect(page.locator(".alias-badge-broken")).toBeVisible();
+
+    await page.locator("#sample").selectOption("status");
+    await expect(page.locator(".status-badge-text")).toHaveText("review");
+    await page.locator("#sample").selectOption("confidence");
+    await expect(page.locator(".confidence-badge-text")).toHaveText("82%");
+
+    await page.locator("#surface").selectOption("Disperse");
+    await expect(page.locator(".scatter-node-circle")).toBeVisible();
+    await expect(page.locator("path.edge, .graph-link, .flow-preview-edge")).toHaveCount(0);
+
+    await expect(page).toHaveScreenshot("node-lab-first-ratchet.png");
+  });
+});

--- a/beta/tsconfig.labs.json
+++ b/beta/tsconfig.labs.json
@@ -11,5 +11,13 @@
     "resolveJsonModule": true,
     "types": ["react", "react-dom"]
   },
-  "include": ["src/labs/**/*.ts", "src/labs/**/*.tsx", "src/shared/layout_port.ts", "src/shared/edge_port.ts", "src/shared/edge_route.ts"]
+  "include": [
+    "src/labs/**/*.ts",
+    "src/labs/**/*.tsx",
+    "src/shared/layout_port.ts",
+    "src/shared/edge_port.ts",
+    "src/shared/edge_route.ts",
+    "src/shared/node_draw_port.ts",
+    "src/shared/node_draw_svg.ts"
+  ]
 }

--- a/beta/tsconfig.layout.json
+++ b/beta/tsconfig.layout.json
@@ -17,6 +17,8 @@
     "src/shared/layout_port.ts",
     "src/shared/edge_port.ts",
     "src/shared/edge_route.ts",
+    "src/shared/node_draw_port.ts",
+    "src/shared/node_draw_svg.ts",
     "src/shared/parent_child_edge_adapter.ts",
     "src/shared/types.ts"
   ]

--- a/beta/vite.config.mjs
+++ b/beta/vite.config.mjs
@@ -1,8 +1,21 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import fs from "node:fs";
+import path from "node:path";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "m3e-static-viewer-css",
+      configureServer(server) {
+        server.middlewares.use("/viewer.css", (_req, res) => {
+          res.setHeader("Content-Type", "text/css; charset=utf-8");
+          fs.createReadStream(path.resolve(process.cwd(), "viewer.css")).pipe(res);
+        });
+      },
+    },
+  ],
   build: {
     emptyOutDir: false,
     outDir: "dist/browser",
@@ -12,12 +25,14 @@ export default defineConfig({
         "workbench-ui": "src/browser/workbench-ui.tsx",
         "layout-lab": "src/labs/layout/layout-lab.html",
         "edge-port-lab": "src/labs/edge-port/edge-port-lab.html",
+        "node-lab": "src/labs/node/node-lab.html",
       },
       output: {
         entryFileNames: "[name].js",
         assetFileNames: (assetInfo) => {
           const name = assetInfo.names?.[0] || assetInfo.name || "";
           if (name.includes("edge-port-lab")) return "edge-port-lab.css";
+          if (name.includes("node-lab")) return "node-lab.css";
           return name.includes("layout-lab") ? "layout-lab.css" : "workbench-ui.css";
         },
       },


### PR DESCRIPTION
## What

Third seam: **NodeDraw** — the node rendering pure layer, extracted from `viewer.ts` `drawNode()` into a shared `node_draw_svg` renderer used by both the product and the lab.

- `beta/src/shared/node_draw_port.ts` — `NodeDrawPort` contract: `node + LayoutNodePosition + normalized style + ViewState + Surface + content(plainLabel|latexHtml) -> { svg, overlays?, bounds }`.
- `beta/src/shared/node_draw_svg.ts` — shared SVG fragment renderer (viewer + node-lab import the same one). Cannot import `viewer.ts` / `markdown_renderer.ts` / edge helpers (dependency-cruiser ratchet).
- `viewer.ts` — `drawNode()` routed through `node_draw_svg`; parent-child edge generation extracted to `renderParentChildEdges` (toward EdgePort).
- KaTeX is in nodeDraw via the real render path (lab uses `katex.renderToString` + real fonts/CSS — verified `x²+y²` renders with true superscripts). Markdown/Mermaid preview, parent-child edge, folder-preview mini graph, and `tabular` are OUT (separate seams).
- canonical Surface View names.
- `beta/src/labs/node/` node-lab loads the product's real `viewer.css` + KaTeX stylesheet; samples: plain / long-wrap / multiline / root / folder / alias(read/write/broken) / selected / multi / cut / link-source / collapsed / scope-locked / fill / color / border / status / confidence / KaTeX.

## Verification (Director fresh-verified)

- `typecheck` PASS · `lint:deps` PASS (node-draw ratchet) · `lint:copy` PASS · node_draw unit 12 PASS.
- `node_draw_svg.ts` imports none of viewer/markdown/edge (exclusive-seam confirmed by grep + ratchet).
- node-lab Playwright screenshots (Director): all samples render with product CSS fidelity — `status` shows dashed border + REVIEW badge; KaTeX renders `x²+y²` (real superscripts, no literal carets after fix); 0 console errors; real `viewer.css` + `katex.min.css` + fonts served (200).
- An earlier faked-KaTeX lab sample (raw source in a `.katex` span) was caught in Director visual review and fixed to use real KaTeX before this PR.

## Gate note

EN5-Lite for this first ratchet (pure fragment golden + node-lab Playwright + dependency-cruiser ratchet + typecheck/jscpd). Automated G-GUI (codex computer-use) blocked by macOS automation perms; Director self-verified via Playwright. EN5-Full real-server node snapshot route is a documented follow-up. Human visual approval pending (lab at `127.0.0.1:14274`).

## Related

- Spec: `.kiro/specs/node-draw-seam/`
- Steering: `.kiro/steering/ui_view_taxonomy_and_ports.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
