### PR TITLE
docs: organize docs with LLM wiki index

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -21,7 +21,7 @@ import {
 import { renderNode as renderNodeSvg } from "../shared/node_draw_svg";
 import { routeParentChildEdge, type ParentChildSurfaceMode } from "../shared/parent_child_edge_adapter";
 import type { EdgeRouteStyle } from "../shared/edge_route";
-import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, localPathLinkToOpen, safeExternalLinkToOpen } from "../shared/markdown_link_node";
+import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, isMarkdownLinkSubtype, localPathLinkToOpen, safeExternalLinkToOpen } from "../shared/markdown_link_node";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
 
 type PublicLayoutOptions = Pick<LayoutOptions, "spacing" | "direction" | "depthAlign" | "edge" | "link">;
@@ -3195,7 +3195,26 @@ function effectiveNodeStyleAttrs(node: TreeNode): NodeStyleAttrs {
   if (view?.shape) {
     base.shape = view.shape;
   }
+  // Hyperlink/link text nodes are visually distinguished in green (like scope nodes),
+  // unless the user has set explicit colors on the node.
+  if (isHyperlinkNode(node)) {
+    if (!base.bg) base.bg = HYPERLINK_NODE_GREEN.bg;
+    if (!base.border) base.border = HYPERLINK_NODE_GREEN.border;
+    if (!base.color) base.color = HYPERLINK_NODE_GREEN.text;
+  }
   return base;
+}
+
+const HYPERLINK_NODE_GREEN = {
+  bg: "#e6f4ea",
+  border: "#2d8c4e",
+  text: "#1b5e2a",
+} as const;
+
+function isHyperlinkNode(node: TreeNode | null | undefined): boolean {
+  if (!node || isAliasNode(node)) return false;
+  if (isMarkdownLinkSubtype(node.attributes || undefined)) return true;
+  return Boolean(String(node.link || "").trim());
 }
 
 function rawAttr(node: TreeNode | null | undefined, key: string): string {

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -21,7 +21,7 @@ import {
 import { renderNode as renderNodeSvg } from "../shared/node_draw_svg";
 import { routeParentChildEdge, type ParentChildSurfaceMode } from "../shared/parent_child_edge_adapter";
 import type { EdgeRouteStyle } from "../shared/edge_route";
-import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode } from "../shared/markdown_link_node";
+import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, safeExternalLinkToOpen } from "../shared/markdown_link_node";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
 
 type PublicLayoutOptions = Pick<LayoutOptions, "spacing" | "direction" | "depthAlign" | "edge" | "link">;
@@ -406,7 +406,7 @@ function isReadOnlyAllowedKey(event: KeyboardEvent): boolean {
     return ["i", "j", "k"].includes(event.key.toLowerCase());
   }
   if (event.altKey && !event.ctrlKey && !event.metaKey) {
-    return ["h", "v", "d"].includes(event.key.toLowerCase());
+    return ["h", "v", "d", "o"].includes(event.key.toLowerCase());
   }
   if ((event.ctrlKey || event.metaKey) && !event.altKey) {
     return ["c", "s"].includes(event.key.toLowerCase());
@@ -10657,6 +10657,29 @@ function selectedLinkableNode(): TreeNode | null {
   return node;
 }
 
+function openSelectedHyperlinkNode(): boolean {
+  if (inlineEditor || inlineEdgeLabelEditor) {
+    return false;
+  }
+  if (!map || !viewState.selectedNodeId) {
+    setStatus("No hyperlink node selected.", true);
+    return false;
+  }
+  const node = map.state.nodes[viewState.selectedNodeId];
+  if (!node || isAliasNode(node)) {
+    setStatus("Select a non-alias hyperlink node.", true);
+    return false;
+  }
+  const url = safeExternalLinkToOpen(node.link || "");
+  if (!url) {
+    setStatus("Selected node has no safe hyperlink to open.", true);
+    return false;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+  setStatus(`Opened link: ${uiLabel(node)}`);
+  return true;
+}
+
 function findExistingGraphLink(sourceNodeId: string, targetNodeId: string): GraphLink | null {
   if (!map) {
     return null;
@@ -15060,6 +15083,12 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
   if (event.altKey && event.key.toLowerCase() === "d") {
     event.preventDefault();
     toggleMarkdownPreviewForSelectedNode();
+    return;
+  }
+
+  if (event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey && event.key.toLowerCase() === "o") {
+    event.preventDefault();
+    openSelectedHyperlinkNode();
     return;
   }
 

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -21,6 +21,7 @@ import {
 import { renderNode as renderNodeSvg } from "../shared/node_draw_svg";
 import { routeParentChildEdge, type ParentChildSurfaceMode } from "../shared/parent_child_edge_adapter";
 import type { EdgeRouteStyle } from "../shared/edge_route";
+import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode } from "../shared/markdown_link_node";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
 
 type PublicLayoutOptions = Pick<LayoutOptions, "spacing" | "direction" | "depthAlign" | "edge" | "link">;
@@ -10953,6 +10954,30 @@ function applyNodeTextEdit(nodeId: string, nextRaw: string, mode: "node-text" | 
     preserveNodeViewportCenter(nodeId, viewportCenterBefore);
     return true;
   }
+  if (mode === "node-text") {
+    const applied = applyMarkdownLinkNodeInput({
+      text: node.text,
+      link: node.link || "",
+      attributes: node.attributes || {},
+    }, next);
+    if (
+      node.text === applied.text &&
+      (node.link || "") === applied.link &&
+      stringRecordEquals(node.attributes || {}, applied.attributes)
+    ) {
+      return true;
+    }
+    pushUndoSnapshot();
+    latexMetricsCache.delete(node.text);
+    latexHtmlCache.delete(node.text);
+    node.text = applied.text;
+    node.link = applied.link;
+    node.attributes = applied.attributes;
+    syncAliasDisplayForTarget(node.id);
+    touchDocument();
+    preserveNodeViewportCenter(nodeId, viewportCenterBefore);
+    return true;
+  }
   if (node.text === next) {
     return true;
   }
@@ -10964,6 +10989,15 @@ function applyNodeTextEdit(nodeId: string, nextRaw: string, mode: "node-text" | 
   touchDocument();
   preserveNodeViewportCenter(nodeId, viewportCenterBefore);
   return true;
+}
+
+function stringRecordEquals(left: Record<string, string>, right: Record<string, string>): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  return leftKeys.every((key) => left[key] === right[key]);
 }
 
 function stopInlineEdit(commit: boolean, options?: { focusBoard?: boolean }): void {
@@ -11122,7 +11156,11 @@ function startInlineEdit(nodeId: string, options?: { selectAll?: boolean; nudgeI
     : "node-text";
   const input = document.createElement("textarea");
   input.rows = 1;
-  input.value = mode === "target-text" ? (resolveAliasTarget(node)?.text || node.text || "") : uiLabel(node);
+  input.value = mode === "target-text"
+    ? (resolveAliasTarget(node)?.text || node.text || "")
+    : mode === "node-text"
+      ? editInputForMarkdownLinkNode({ text: node.text || "", link: node.link || "", attributes: node.attributes || {} })
+      : uiLabel(node);
   input.className = "inline-node-editor";
   input.setAttribute("aria-label", mode === "target-text" ? "Edit target node text" : "Edit node label");
   board.appendChild(input);

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -406,10 +406,10 @@ function isReadOnlyAllowedKey(event: KeyboardEvent): boolean {
     return ["i", "j", "k"].includes(event.key.toLowerCase());
   }
   if (event.altKey && !event.ctrlKey && !event.metaKey) {
-    return ["h", "v", "d", "o"].includes(event.key.toLowerCase());
+    return ["h", "v", "d"].includes(event.key.toLowerCase());
   }
   if ((event.ctrlKey || event.metaKey) && !event.altKey) {
-    return ["c", "s"].includes(event.key.toLowerCase());
+    return ["c", "s", "o"].includes(event.key.toLowerCase());
   }
   return false;
 }
@@ -15086,7 +15086,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     return;
   }
 
-  if (event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey && event.key.toLowerCase() === "o") {
+  if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "o") {
     event.preventDefault();
     openSelectedHyperlinkNode();
     return;

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -21,7 +21,7 @@ import {
 import { renderNode as renderNodeSvg } from "../shared/node_draw_svg";
 import { routeParentChildEdge, type ParentChildSurfaceMode } from "../shared/parent_child_edge_adapter";
 import type { EdgeRouteStyle } from "../shared/edge_route";
-import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, safeExternalLinkToOpen } from "../shared/markdown_link_node";
+import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, localPathLinkToOpen, safeExternalLinkToOpen } from "../shared/markdown_link_node";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
 
 type PublicLayoutOptions = Pick<LayoutOptions, "spacing" | "direction" | "depthAlign" | "edge" | "link">;
@@ -10671,13 +10671,37 @@ function openSelectedHyperlinkNode(): boolean {
     return false;
   }
   const url = safeExternalLinkToOpen(node.link || "");
-  if (!url) {
-    setStatus("Selected node has no safe hyperlink to open.", true);
-    return false;
+  if (url) {
+    window.open(url, "_blank", "noopener,noreferrer");
+    setStatus(`Opened link: ${uiLabel(node)}`);
+    return true;
   }
-  window.open(url, "_blank", "noopener,noreferrer");
-  setStatus(`Opened link: ${uiLabel(node)}`);
-  return true;
+  const localPath = localPathLinkToOpen(node.link || "");
+  if (localPath) {
+    void openLocalPathViaServer(localPath, uiLabel(node));
+    return true;
+  }
+  setStatus("Selected node has no safe hyperlink to open.", true);
+  return false;
+}
+
+async function openLocalPathViaServer(localPath: string, label: string): Promise<void> {
+  setStatus(`Opening: ${label}…`);
+  try {
+    const response = await fetch("/api/open-local-path", {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ path: localPath }),
+    });
+    const payload = await response.json().catch(() => null) as { ok?: boolean; error?: string } | null;
+    if (!response.ok || !payload?.ok) {
+      setStatus(`Could not open: ${payload?.error || `HTTP ${response.status}`}`, true);
+      return;
+    }
+    setStatus(`Opened link: ${label}`);
+  } catch (err) {
+    setStatus(`Could not open link: ${(err as Error).message || "request failed"}`, true);
+  }
 }
 
 function findExistingGraphLink(sourceNodeId: string, targetNodeId: string): GraphLink | null {

--- a/beta/src/browser/workbench-ui.tsx
+++ b/beta/src/browser/workbench-ui.tsx
@@ -1292,6 +1292,7 @@ function HelpModal({ close }: { close: () => void }): React.ReactElement {
           <span><kbd>Ctrl+Alt+I</kbd>Copy scope ID</span>
           <span><kbd>Alt+E</kbd>Entity list</span>
           <span><kbd>Alt+D</kbd>Markdown preview</span>
+          <span><kbd>Alt+O</kbd>Open hyperlink node</span>
         </div>
       </section>
     </div>

--- a/beta/src/browser/workbench-ui.tsx
+++ b/beta/src/browser/workbench-ui.tsx
@@ -1292,7 +1292,7 @@ function HelpModal({ close }: { close: () => void }): React.ReactElement {
           <span><kbd>Ctrl+Alt+I</kbd>Copy scope ID</span>
           <span><kbd>Alt+E</kbd>Entity list</span>
           <span><kbd>Alt+D</kbd>Markdown preview</span>
-          <span><kbd>Alt+O</kbd>Open hyperlink node</span>
+          <span><kbd>Cmd/Ctrl+O</kbd>Open hyperlink node</span>
         </div>
       </section>
     </div>

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -2,9 +2,10 @@
 
 import "dotenv/config";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import http from "http";
-import { spawnSync, exec } from "child_process";
+import { spawnSync, spawn, exec } from "child_process";
 import Database from "better-sqlite3";
 import { RapidMvpModel } from "./rapid_mvp";
 import { loadCloudSyncConfig, pushWithConflictBackup, startAutoSync, type AutoSyncHandle } from "./cloud_sync";
@@ -629,6 +630,56 @@ function readSystemClipboard(): { ok: true; method: string; text: string } | { o
   const xsel = run("xsel", ["--clipboard", "--output"], "xsel");
   if (xsel.ok) return xsel;
   return { ok: false, error: xsel.error || xclip.error || wlPaste.error || "No clipboard command available." };
+}
+
+async function handleOpenLocalPathApi(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean> {
+  const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+  if (pathname !== "/api/open-local-path") {
+    return false;
+  }
+  if (req.method !== "POST") {
+    sendJson(res, 405, { ok: false, error: "Method not allowed." });
+    return true;
+  }
+  try {
+    const rawBody = await readRequestBody(req, 1_000_000);
+    const body = JSON.parse(rawBody) as { path?: unknown };
+    const requested = typeof body.path === "string" ? body.path.trim() : "";
+    if (!requested) {
+      sendJson(res, 400, { ok: false, error: "Field 'path' must be a non-empty string." });
+      return true;
+    }
+    // Reject control chars and URL schemes. Windows drive-letter paths (C:\\...) are local paths.
+    const isWindowsDrivePath = /^[A-Za-z]:[\\/]/.test(requested);
+    if (/[\u0000-\u001f\u007f]/.test(requested) || (!isWindowsDrivePath && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(requested))) {
+      sendJson(res, 400, { ok: false, error: "Path is not a safe local filesystem path." });
+      return true;
+    }
+    const expanded = requested.startsWith("~/")
+      ? path.join(os.homedir(), requested.slice(2))
+      : requested;
+    const isAbsolute = path.isAbsolute(expanded) || /^[A-Za-z]:[\\/]/.test(expanded);
+    if (!isAbsolute) {
+      sendJson(res, 400, { ok: false, error: "Path must be absolute." });
+      return true;
+    }
+    if (!fs.existsSync(expanded)) {
+      sendJson(res, 404, { ok: false, error: "Path does not exist." });
+      return true;
+    }
+    const platform = process.platform;
+    const command = platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+    const args = platform === "win32" ? ["/c", "start", "", expanded] : [expanded];
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {
+      /* swallow — response already sent */
+    });
+    child.unref();
+    sendJson(res, 200, { ok: true, path: expanded });
+  } catch (err) {
+    sendJson(res, 400, { ok: false, error: (err as Error).message || "Invalid open-local-path request." });
+  }
+  return true;
 }
 
 async function handleSystemClipboardApi(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean> {
@@ -3714,6 +3765,9 @@ export function createAppServer(): http.Server {
   return http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
     instrumentRequestForPerfLog(req, res);
     if (redirectLoopbackHost(req, res)) {
+      return;
+    }
+    if (await handleOpenLocalPathApi(req, res)) {
       return;
     }
     if (await handleSystemClipboardApi(req, res)) {

--- a/beta/src/shared/markdown_link_node.ts
+++ b/beta/src/shared/markdown_link_node.ts
@@ -1,0 +1,67 @@
+export const MARKDOWN_LINK_NODE_SUBTYPE_ATTR = "m3e:subtype";
+export const MARKDOWN_LINK_NODE_SUBTYPE_VALUE = "hyperlink";
+
+export interface MarkdownLinkNodeFields {
+  text: string;
+  link?: string;
+  attributes?: Record<string, string>;
+}
+
+export interface ParsedMarkdownLinkNodeInput {
+  text: string;
+  link: string;
+  isMarkdownLink: boolean;
+}
+
+export interface AppliedMarkdownLinkNodeInput extends ParsedMarkdownLinkNodeInput {
+  attributes: Record<string, string>;
+}
+
+export function parseMarkdownLinkNodeInput(raw: string): ParsedMarkdownLinkNodeInput {
+  const input = String(raw || "").trim();
+  const match = /^\[([^\]\n]+)\]\(([^()\s]+)\)$/.exec(input);
+  if (!match) {
+    return { text: input, link: "", isMarkdownLink: false };
+  }
+  return {
+    text: match[1].trim(),
+    link: match[2].trim(),
+    isMarkdownLink: true,
+  };
+}
+
+export function formatMarkdownLinkNodeInput(node: MarkdownLinkNodeFields): string {
+  const text = String(node.text || "").trim();
+  const link = String(node.link || "").trim();
+  if (!link) {
+    return text;
+  }
+  return `[${text}](${link})`;
+}
+
+export function isMarkdownLinkSubtype(attributes: Record<string, string> | undefined): boolean {
+  return (attributes?.[MARKDOWN_LINK_NODE_SUBTYPE_ATTR] || "").trim() === MARKDOWN_LINK_NODE_SUBTYPE_VALUE;
+}
+
+export function editInputForMarkdownLinkNode(node: MarkdownLinkNodeFields): string {
+  return formatMarkdownLinkNodeInput(node);
+}
+
+export function applyMarkdownLinkNodeInput(
+  current: MarkdownLinkNodeFields,
+  raw: string,
+): AppliedMarkdownLinkNodeInput {
+  const parsed = parseMarkdownLinkNodeInput(raw);
+  const attributes = { ...(current.attributes || {}) };
+  if (parsed.isMarkdownLink) {
+    attributes[MARKDOWN_LINK_NODE_SUBTYPE_ATTR] = MARKDOWN_LINK_NODE_SUBTYPE_VALUE;
+    return { ...parsed, attributes };
+  }
+
+  if (String(current.link || "").trim() || isMarkdownLinkSubtype(attributes)) {
+    delete attributes[MARKDOWN_LINK_NODE_SUBTYPE_ATTR];
+    return { ...parsed, link: "", attributes };
+  }
+
+  return { ...parsed, link: String(current.link || ""), attributes };
+}

--- a/beta/src/shared/markdown_link_node.ts
+++ b/beta/src/shared/markdown_link_node.ts
@@ -80,3 +80,17 @@ export function safeExternalLinkToOpen(raw: string | null | undefined): string |
     return null;
   }
 }
+
+export function localPathLinkToOpen(raw: string | null | undefined): string | null {
+  const input = String(raw || "").trim();
+  if (!input || /[\u0000-\u001f\u007f]/.test(input)) {
+    return null;
+  }
+  if (input.startsWith("/") || input.startsWith("~/") || /^[A-Za-z]:[\\/]/.test(input)) {
+    return input;
+  }
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(input)) {
+    return null;
+  }
+  return null;
+}

--- a/beta/src/shared/markdown_link_node.ts
+++ b/beta/src/shared/markdown_link_node.ts
@@ -17,6 +17,8 @@ export interface AppliedMarkdownLinkNodeInput extends ParsedMarkdownLinkNodeInpu
   attributes: Record<string, string>;
 }
 
+const SAFE_EXTERNAL_LINK_PROTOCOLS = new Set(["http:", "https:", "obsidian:"]);
+
 export function parseMarkdownLinkNodeInput(raw: string): ParsedMarkdownLinkNodeInput {
   const input = String(raw || "").trim();
   const match = /^\[([^\]\n]+)\]\(([^()\s]+)\)$/.exec(input);
@@ -64,4 +66,17 @@ export function applyMarkdownLinkNodeInput(
   }
 
   return { ...parsed, link: String(current.link || ""), attributes };
+}
+
+export function safeExternalLinkToOpen(raw: string | null | undefined): string | null {
+  const input = String(raw || "").trim();
+  if (!input) {
+    return null;
+  }
+  try {
+    const url = new URL(input);
+    return SAFE_EXTERNAL_LINK_PROTOCOLS.has(url.protocol) ? url.href : null;
+  } catch {
+    return null;
+  }
 }

--- a/beta/tests/unit/markdown_link_node.test.js
+++ b/beta/tests/unit/markdown_link_node.test.js
@@ -6,6 +6,7 @@ const {
   formatMarkdownLinkNodeInput,
   isMarkdownLinkSubtype,
   parseMarkdownLinkNodeInput,
+  safeExternalLinkToOpen,
 } = require("../../dist/shared/markdown_link_node.js");
 
 describe("Markdown hyperlink node helpers", () => {
@@ -71,5 +72,20 @@ describe("Markdown hyperlink node helpers", () => {
       attributes: { keep: "yes" },
       isMarkdownLink: false,
     });
+  });
+
+  test("allows http, https, and obsidian URLs for external opening", () => {
+    expect(safeExternalLinkToOpen("http://example.com")).toBe("http://example.com/");
+    expect(safeExternalLinkToOpen("https://example.com/path?q=1")).toBe("https://example.com/path?q=1");
+    expect(safeExternalLinkToOpen("obsidian://open?vault=X")).toBe("obsidian://open?vault=X");
+  });
+
+  test("rejects blank, malformed, file, javascript, data, and vbscript URLs", () => {
+    expect(safeExternalLinkToOpen("")).toBeNull();
+    expect(safeExternalLinkToOpen("not a url")).toBeNull();
+    expect(safeExternalLinkToOpen("file:///Users/example/note.md")).toBeNull();
+    expect(safeExternalLinkToOpen("javascript:alert(1)")).toBeNull();
+    expect(safeExternalLinkToOpen("data:text/html,<h1>x</h1>")).toBeNull();
+    expect(safeExternalLinkToOpen("vbscript:msgbox(1)")).toBeNull();
   });
 });

--- a/beta/tests/unit/markdown_link_node.test.js
+++ b/beta/tests/unit/markdown_link_node.test.js
@@ -5,6 +5,7 @@ const {
   editInputForMarkdownLinkNode,
   formatMarkdownLinkNodeInput,
   isMarkdownLinkSubtype,
+  localPathLinkToOpen,
   parseMarkdownLinkNodeInput,
   safeExternalLinkToOpen,
 } = require("../../dist/shared/markdown_link_node.js");
@@ -87,5 +88,19 @@ describe("Markdown hyperlink node helpers", () => {
     expect(safeExternalLinkToOpen("javascript:alert(1)")).toBeNull();
     expect(safeExternalLinkToOpen("data:text/html,<h1>x</h1>")).toBeNull();
     expect(safeExternalLinkToOpen("vbscript:msgbox(1)")).toBeNull();
+  });
+
+  test("recognizes local filesystem paths separately from external URLs", () => {
+    expect(localPathLinkToOpen("/Users/example/note.md")).toBe("/Users/example/note.md");
+    expect(localPathLinkToOpen("~/vault/note.md")).toBe("~/vault/note.md");
+    expect(localPathLinkToOpen("C:\\Users\\example\\note.md")).toBe("C:\\Users\\example\\note.md");
+  });
+
+  test("rejects URL schemes and unsafe local path strings for local opening", () => {
+    expect(localPathLinkToOpen("obsidian://open?vault=X")).toBeNull();
+    expect(localPathLinkToOpen("https://example.com")).toBeNull();
+    expect(localPathLinkToOpen("javascript:alert(1)")).toBeNull();
+    expect(localPathLinkToOpen("relative/path.md")).toBeNull();
+    expect(localPathLinkToOpen("/tmp/a\u0000b")).toBeNull();
   });
 });

--- a/beta/tests/unit/markdown_link_node.test.js
+++ b/beta/tests/unit/markdown_link_node.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+
+const {
+  applyMarkdownLinkNodeInput,
+  editInputForMarkdownLinkNode,
+  formatMarkdownLinkNodeInput,
+  isMarkdownLinkSubtype,
+  parseMarkdownLinkNodeInput,
+} = require("../../dist/shared/markdown_link_node.js");
+
+describe("Markdown hyperlink node helpers", () => {
+  test("parses Markdown link input into text, link, and subtype marker", () => {
+    expect(parseMarkdownLinkNodeInput("[Obsidian](obsidian://open?vault=X)")).toEqual({
+      text: "Obsidian",
+      link: "obsidian://open?vault=X",
+      isMarkdownLink: true,
+    });
+  });
+
+  test("leaves bare URLs as plain node text", () => {
+    expect(parseMarkdownLinkNodeInput("https://example.com")).toEqual({
+      text: "https://example.com",
+      link: "",
+      isMarkdownLink: false,
+    });
+  });
+
+  test("formats a hyperlink node as Markdown link edit input", () => {
+    expect(formatMarkdownLinkNodeInput({ text: "Obsidian", link: "obsidian://open?vault=X" }))
+      .toBe("[Obsidian](obsidian://open?vault=X)");
+  });
+
+  test("does not format plain text nodes as Markdown links", () => {
+    expect(formatMarkdownLinkNodeInput({ text: "Plain", link: "" })).toBe("Plain");
+  });
+
+  test("recognizes the compatibility subtype attribute", () => {
+    expect(isMarkdownLinkSubtype({ "m3e:subtype": "hyperlink" })).toBe(true);
+    expect(isMarkdownLinkSubtype({ "m3e:subtype": "tabular" })).toBe(false);
+  });
+
+  test("uses Markdown link syntax when editing a text node with a stored link", () => {
+    expect(editInputForMarkdownLinkNode({
+      text: "Obsidian",
+      link: "obsidian://open?vault=X",
+      attributes: {},
+    })).toBe("[Obsidian](obsidian://open?vault=X)");
+  });
+
+  test("commit stores Markdown link label, URL, and compatibility subtype", () => {
+    expect(applyMarkdownLinkNodeInput({
+      text: "Old",
+      link: "",
+      attributes: {},
+    }, "[Obsidian](obsidian://open?vault=X)")).toEqual({
+      text: "Obsidian",
+      link: "obsidian://open?vault=X",
+      attributes: { "m3e:subtype": "hyperlink" },
+      isMarkdownLink: true,
+    });
+  });
+
+  test("plain-text edit of an existing hyperlink clears link and subtype", () => {
+    expect(applyMarkdownLinkNodeInput({
+      text: "Obsidian",
+      link: "obsidian://open?vault=X",
+      attributes: { "m3e:subtype": "hyperlink", keep: "yes" },
+    }, "Plain")).toEqual({
+      text: "Plain",
+      link: "",
+      attributes: { keep: "yes" },
+      isMarkdownLink: false,
+    });
+  });
+});

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -322,7 +322,7 @@
               <div class="cheatsheet-row"><kbd>Alt+S</kbd><span>Scope navigator</span></div>
               <div class="cheatsheet-row"><kbd>Alt+E</kbd><span>Entity list panel</span></div>
               <div class="cheatsheet-row"><kbd>Alt+D</kbd><span>Markdown preview (details/note)</span></div>
-              <div class="cheatsheet-row"><kbd>Alt+O</kbd><span>Open hyperlink node</span></div>
+              <div class="cheatsheet-row"><kbd>Cmd/Ctrl+O</kbd><span>Open hyperlink node</span></div>
               <div class="cheatsheet-row"><kbd>Alt+V</kbd><span>Toggle focus / fit</span></div>
               <div class="cheatsheet-row"><kbd>Alt+J</kbd><span>Jump to alias target</span></div>
               <div class="cheatsheet-row"><kbd>Flow LR</kbd><span>Arrows follow left/right and up/down lanes</span></div>

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -322,6 +322,7 @@
               <div class="cheatsheet-row"><kbd>Alt+S</kbd><span>Scope navigator</span></div>
               <div class="cheatsheet-row"><kbd>Alt+E</kbd><span>Entity list panel</span></div>
               <div class="cheatsheet-row"><kbd>Alt+D</kbd><span>Markdown preview (details/note)</span></div>
+              <div class="cheatsheet-row"><kbd>Alt+O</kbd><span>Open hyperlink node</span></div>
               <div class="cheatsheet-row"><kbd>Alt+V</kbd><span>Toggle focus / fit</span></div>
               <div class="cheatsheet-row"><kbd>Alt+J</kbd><span>Jump to alias target</span></div>
               <div class="cheatsheet-row"><kbd>Flow LR</kbd><span>Arrows follow left/right and up/down lanes</span></div>

--- a/docs/06_Operations/Documentation_Rules.md
+++ b/docs/06_Operations/Documentation_Rules.md
@@ -1,6 +1,6 @@
 # Documentation Rules
 
-最終更新: 2026-06-14
+最終更新: 2026-06-27
 
 ## Language Policy
 
@@ -24,6 +24,20 @@
 5. 作業領域は Codex task worktree で分離し、同一ファイルの同時編集を避ける
 
 Claude sub-agent worker (`manage` / `visual` / `data` / `team`) は廃止済み。
+
+## LLM Wiki 型の文書整理
+
+`docs/` 全体は [LLM_Wiki_Schema.md](./LLM_Wiki_Schema.md) に従って、次の 3 layer として扱う。
+
+1. Source Layer: `ideas/`, `research/`, `daily/`, `for-akaghef/`, `legacy/`, `competitive_research/`
+2. Canonical Layer: `00_Home/`, `01_Vision/`, `03_Spec/`, `04_Architecture/`, `06_Operations/`, `09_Decisions/`
+3. Navigation Layer: `index.md`, `log.md`, `_generated/`
+
+整理は原則として非破壊に行う。既存文書を一括移動・削除・リネームせず、まず `docs/index.md` と `docs/log.md` で横断性を作る。索引 coverage は次で確認する。
+
+```bash
+node scripts/ops/check-docs-index.mjs --check
+```
 
 ## セッション開始ゲート
 

--- a/docs/06_Operations/LLM_Wiki_Schema.md
+++ b/docs/06_Operations/LLM_Wiki_Schema.md
@@ -1,0 +1,78 @@
+# LLM Wiki Schema for M3E Documents
+
+Status: working-agreement
+Source: `docs/ideas/260627_llm_wiki_pattern.md`
+Scope: `docs/`
+
+## Purpose
+
+M3E の `docs/` を、既存の正本構造を壊さずに LLM Wiki 型で運用する。
+
+ここでいう LLM Wiki 型とは、raw source を保存し、LLM が索引・要約・相互参照・ログを継続更新する運用である。M3E では既存の仕様書や運用文書が正本なので、全ファイルを新しい wiki ディレクトリへ移動しない。索引とログを上に重ねる。
+
+## Layers
+
+### 1. Source Layer
+
+Raw source / historical source / draft source.
+
+- `docs/ideas/`: 未確定の発想、stow された外部メモ、会話由来の草案
+- `docs/research/`: 調査、会話抽出、根拠資料
+- `docs/daily/`: 日次ログ。追記中心で、過去ログを通常編集しない
+- `docs/for-akaghef/`: Akaghef 向け共有物、demo、説明資料
+- `docs/legacy/`: 現行方針ではない旧設計
+- `docs/competitive_research/`: 競合・周辺ツール調査
+
+この layer は、明示指示なしに削除・大規模移動しない。必要な場合は、まず `docs/06_Operations/Decision_Pool.md` で判断を残す。
+
+### 2. Canonical Layer
+
+現在の M3E の正本または準正本。
+
+- `docs/00_Home/`: 入口、現在地、用語辞書
+- `docs/01_Vision/`: Principle / Vision / Strategy
+- `docs/03_Spec/`: 機能仕様
+- `docs/04_Architecture/`: 実装構造
+- `docs/06_Operations/`: 運用ルール、判断プール、手順
+- `docs/09_Decisions/`: ADR
+
+この layer は LLM が編集してよいが、該当 scope と検証観点を先に定義する。`Current_Status.md` は短期 Strategy スナップショットだけを書く。
+
+### 3. Navigation Layer
+
+LLM と人間が `docs/` を横断するための生成・維持物。
+
+- `docs/index.md`: content-oriented index。LLM はまずここを読んでから詳細ファイルへ進む
+- `docs/log.md`: chronological log。ingest / organize / lint / query の履歴
+- `docs/_generated/`: 明示的な生成物。正本として直接編集しない
+
+## Operations
+
+### Ingest
+
+1. Raw source を適切な Source Layer に stow する。
+2. Source が外部メモなら、verbatim 保存を優先する。
+3. 必要なら Canonical Layer へ昇格する候補を `Decision_Pool.md` に書く。
+4. `docs/index.md` を更新する。
+5. `docs/log.md` に `ingest` entry を追記する。
+
+### Query
+
+1. `docs/index.md` を先に読む。
+2. 関連する Canonical Layer を読む。
+3. 根拠が必要な場合だけ Source Layer へ掘る。
+4. 回答が再利用価値を持つ場合は、ユーザー指示または明確な必要性がある時だけ文書化する。
+
+### Lint
+
+1. `node scripts/ops/check-docs-index.mjs --check` で索引 coverage を確認する。
+2. orphan / stale / duplicate / broken link は、削除せず候補として報告する。
+3. Canonical Layer への反映が必要なものは `Decision_Pool.md` または該当 spec / architecture / ADR へ送る。
+
+## Safety Rules
+
+- 既存文書の一括移動・削除・リネームは、この schema の通常運用には含めない。
+- Raw source と generated navigation を混同しない。
+- `docs/_generated/` は projection であり、正本ではない。
+- `docs/daily/` は append-only を基本にする。
+- `map` / `scope` / `node` など M3E 正規語は `docs/00_Home/Glossary.md` に従う。

--- a/docs/06_Operations/README.md
+++ b/docs/06_Operations/README.md
@@ -8,6 +8,8 @@
   会話中に出た決定、仮決め、保留、確認待ちを時系列で蓄積する
 - `Documentation_Rules.md`
   どこに何を書くか、いつ正式文書へ移すかの運用ルールをまとめる
+- `LLM_Wiki_Schema.md`
+  `docs/` を raw source / canonical document / generated navigation に分けて整理する LLM Wiki 型の運用スキーマ
 - `Commit_Message_Rules.md`
   コミットメッセージの形式と `type` の使い分けを定義する
 - `Test_and_CICD_Guide.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,59 +1,56 @@
 # M3E Software Docs
-## Added Operations Area (2026-03-30)
 
-- `06_Operations/README.md`
-- `06_Operations/Decision_Pool.md`
-- `06_Operations/Documentation_Rules.md`
-- `06_Operations/Commit_Message_Rules.md`
+このディレクトリは、M3E の思想・戦略・仕様・アーキテクチャ・運用・判断記録を置く場所である。
 
-会話で決まったことは、まず `06_Operations/Decision_Pool.md` に記録する。
-仕様として固まったら `03_Spec` `04_Architecture` `09_Decisions` に昇格する。
+LLM / 人間が横断検索する入口として、まず [index.md](./index.md) を読む。運用ログは [log.md](./log.md)、LLM Wiki 型の整理スキーマは [06_Operations/LLM_Wiki_Schema.md](./06_Operations/LLM_Wiki_Schema.md) に置く。
 
-このディレクトリは、科学研究を中心とした思考ツールとしての M3E のソフトウェア設計を、「入口」「思想」「戦略」「仕様」「アーキテクチャ」「外部連携」「意思決定」に分けて整理したものです。  
-現行方針と旧方針を混在させないため、廃止済み前提は `legacy/` に分離しています。
+## Reading Order
 
-## 読み順
-
-1. [00_Home/Home.md](./00_Home/Home.md)
+1. [00_Home/Agent_Brief.md](./00_Home/Agent_Brief.md)
 2. [00_Home/Current_Status.md](./00_Home/Current_Status.md)
-3. [01_Vision/Principle.md](./01_Vision/Principle.md)
-4. [02_Strategy/Current_Pivot_Freeplane_First.md](./02_Strategy/Current_Pivot_Freeplane_First.md)
-5. [03_Spec/Data_Model.md](./03_Spec/Data_Model.md)
-6. [03_Spec/Scope_and_Alias.md](./03_Spec/Scope_and_Alias.md)
-7. [03_Spec/Cloud_Sync.md](./03_Spec/Cloud_Sync.md)
-8. [03_Spec/Band_Spec.md](./03_Spec/Band_Spec.md)
-9. [04_Architecture/MVC_and_Command.md](./04_Architecture/MVC_and_Command.md)
-10. [04_Architecture/Drag_and_Reparent.md](./04_Architecture/Drag_and_Reparent.md)
-11. [05_Freeplane_Integration/Freeplane_Data_Model_Mapping.md](./05_Freeplane_Integration/Freeplane_Data_Model_Mapping.md)
-12. [06_Operations/Test_and_CICD_Guide.md](./06_Operations/Test_and_CICD_Guide.md)
-13. [09_Decisions/ADR_001_Freeplane_First.md](./09_Decisions/ADR_001_Freeplane_First.md)
-14. [09_Decisions/ADR_002_React_UI_Basis.md](./09_Decisions/ADR_002_React_UI_Basis.md)
+3. [00_Home/Glossary.md](./00_Home/Glossary.md)
+4. [00_Home/Home.md](./00_Home/Home.md)
+5. [00_Home/Objective.md](./00_Home/Objective.md)
+6. [01_Vision/Principle.md](./01_Vision/Principle.md)
+7. [01_Vision/Vision.md](./01_Vision/Vision.md)
+8. [01_Vision/Strategy.md](./01_Vision/Strategy.md)
+9. [03_Spec/README.md](./03_Spec/README.md)
+10. [04_Architecture/README.md](./04_Architecture/README.md)
+11. [06_Operations/README.md](./06_Operations/README.md)
+12. [09_Decisions/README.md](./09_Decisions/README.md)
 
-## ディレクトリ構成
+## Directory Roles
 
-- `00_Home`: 全体像と現在地
-- `01_Vision`: プロダクトの原則
-- `02_Strategy`: 現在の進め方
-- `03_Spec`: ドメイン仕様
-- `04_Architecture`: 実装構造と操作設計
-- `05_Freeplane_Integration`: Freeplane を土台にする際の写像
-- `09_Decisions`: ADR
-- `legacy`: 現行では採用しない旧設計要件
+- `00_Home/`: セッション入口、現在地、用語辞書、Planning Hierarchy 入口
+- `01_Vision/`: Principle / Vision / Strategy
+- `03_Spec/`: 機能仕様。何を作るか
+- `04_Architecture/`: 実装構造。どう作るか
+- `06_Operations/`: 運用ルール、判断プール、手順、handoff
+- `09_Decisions/`: ADR
+- `competitive_research/`: 競合・周辺ツール調査
+- `daily/`: 日次ログ。追記中心
+- `for-akaghef/`: Akaghef 向け共有物、demo、説明資料
+- `ideas/`: 未確定の発想、stow された外部メモ
+- `legacy/`: 現行方針ではない旧設計
+- `research/`: 調査資料、会話抽出、根拠資料
+- `tasks/`: Codex worker / Director handoff と task notes
+- `_generated/`: 生成物。正本として直接編集しない
 
-## 文書設計の方針
+## Document Flow
 
-- `Vision` は変わりにくい原則を書く
-- `Strategy` は現時点の方針と優先順位を書く
-- `Spec` は実装に依存しないドメイン制約を書く
-- `Architecture` は UI/状態管理/コマンドの責務分離を書く
-- `Decisions` は採用済み判断の理由と影響を書く
-- `legacy` は歴史的経緯の保管場所であり、現行実装方針ではない
+1. 外部メモや未確定の発想は `ideas/` または `research/` に stow する。
+2. 会話で決まったことは、まず `06_Operations/Decision_Pool.md` に記録する。
+3. 仕様として固まったら `03_Spec/`、実装構造なら `04_Architecture/`、継続判断なら `09_Decisions/` へ昇格する。
+4. 横断索引は `index.md`、時系列運用ログは `log.md` で維持する。
 
-## 元メモ
+## Checks
 
-この構成は以下の既存メモを再編成したものです。
+```bash
+node scripts/ops/check-docs-index.mjs --check
+```
 
-- `docs/M3E仕様設計書.md`
-- `docs/M3E仕様2.md`
-- `docs/DragOperate.md`
-- `docs/freeplane利用について.txt`
+`docs/index.md` が stale の場合は次で再生成する。
+
+```bash
+node scripts/ops/check-docs-index.mjs --write
+```

--- a/docs/ideas/260627_llm_wiki_pattern.md
+++ b/docs/ideas/260627_llm_wiki_pattern.md
@@ -1,0 +1,75 @@
+# LLM Wiki
+
+A pattern for building personal knowledge bases using LLMs.
+
+This is an idea file, it is designed to be copy pasted to your own LLM Agent (e.g. OpenAI Codex, Claude Code, OpenCode / Pi, or etc.). Its goal is to communicate the high level idea, but your agent will build out the specifics in collaboration with you.
+
+## The core idea
+
+Most people's experience with LLMs and documents looks like RAG: you upload a collection of files, the LLM retrieves relevant chunks at query time, and generates an answer. This works, but the LLM is rediscovering knowledge from scratch on every question. There's no accumulation. Ask a subtle question that requires synthesizing five documents, and the LLM has to find and piece together the relevant fragments every time. Nothing is built up. NotebookLM, ChatGPT file uploads, and most RAG systems work this way.
+
+The idea here is different. Instead of just retrieving from raw documents at query time, the LLM **incrementally builds and maintains a persistent wiki** — a structured, interlinked collection of markdown files that sits between you and the raw sources. When you add a new source, the LLM doesn't just index it for later retrieval. It reads it, extracts the key information, and integrates it into the existing wiki — updating entity pages, revising topic summaries, noting where new data contradicts old claims, strengthening or challenging the evolving synthesis. The knowledge is compiled once and then *kept current*, not re-derived on every query.
+
+This is the key difference: **the wiki is a persistent, compounding artifact.** The cross-references are already there. The contradictions have already been flagged. The synthesis already reflects everything you've read. The wiki keeps getting richer with every source you add and every question you ask.
+
+You never (or rarely) write the wiki yourself — the LLM writes and maintains all of it. You're in charge of sourcing, exploration, and asking the right questions. The LLM does all the grunt work — the summarizing, cross-referencing, filing, and bookkeeping that makes a knowledge base actually useful over time. In practice, I have the LLM agent open on one side and Obsidian open on the other. The LLM makes edits based on our conversation, and I browse the results in real time — following links, checking the graph view, reading the updated pages. Obsidian is the IDE; the LLM is the programmer; the wiki is the codebase.
+
+This can apply to a lot of different contexts. A few examples:
+
+- **Personal**: tracking your own goals, health, psychology, self-improvement — filing journal entries, articles, podcast notes, and building up a structured picture of yourself over time.
+- **Research**: going deep on a topic over weeks or months — reading papers, articles, reports, and incrementally building a comprehensive wiki with an evolving thesis.
+- **Reading a book**: filing each chapter as you go, building out pages for characters, themes, plot threads, and how they connect. By the end you have a rich companion wiki. Think of fan wikis like [Tolkien Gateway](https://tolkiengateway.net/wiki/Main_Page) — thousands of interlinked pages covering characters, places, events, languages, built by a community of volunteers over years. You could build something like that personally as you read, with the LLM doing all the cross-referencing and maintenance.
+- **Business/team**: an internal wiki maintained by LLMs, fed by Slack threads, meeting transcripts, project documents, customer calls. Possibly with humans in the loop reviewing updates. The wiki stays current because the LLM does the maintenance that no one on the team wants to do.
+- **Competitive analysis, due diligence, trip planning, course notes, hobby deep-dives** — anything where you're accumulating knowledge over time and want it organized rather than scattered.
+
+## Architecture
+
+There are three layers:
+
+**Raw sources** — your curated collection of source documents. Articles, papers, images, data files. These are immutable — the LLM reads from them but never modifies them. This is your source of truth.
+
+**The wiki** — a directory of LLM-generated markdown files. Summaries, entity pages, concept pages, comparisons, an overview, a synthesis. The LLM owns this layer entirely. It creates pages, updates them when new sources arrive, maintains cross-references, and keeps everything consistent. You read it; the LLM writes it.
+
+**The schema** — a document (e.g. CLAUDE.md for Claude Code or AGENTS.md for Codex) that tells the LLM how the wiki is structured, what the conventions are, and what workflows to follow when ingesting sources, answering questions, or maintaining the wiki. This is the key configuration file — it's what makes the LLM a disciplined wiki maintainer rather than a generic chatbot. You and the LLM co-evolve this over time as you figure out what works for your domain.
+
+## Operations
+
+**Ingest.** You drop a new source into the raw collection and tell the LLM to process it. An example flow: the LLM reads the source, discusses key takeaways with you, writes a summary page in the wiki, updates the index, updates relevant entity and concept pages across the wiki, and appends an entry to the log. A single source might touch 10-15 wiki pages. Personally I prefer to ingest sources one at a time and stay involved — I read the summaries, check the updates, and guide the LLM on what to emphasize. But you could also batch-ingest many sources at once with less supervision. It's up to you to develop the workflow that fits your style and document it in the schema for future sessions.
+
+**Query.** You ask questions against the wiki. The LLM searches for relevant pages, reads them, and synthesizes an answer with citations. Answers can take different forms depending on the question — a markdown page, a comparison table, a slide deck (Marp), a chart (matplotlib), a canvas. The important insight: **good answers can be filed back into the wiki as new pages.** A comparison you asked for, an analysis, a connection you discovered — these are valuable and shouldn't disappear into chat history. This way your explorations compound in the knowledge base just like ingested sources do.
+
+**Lint.** Periodically, ask the LLM to health-check the wiki. Look for: contradictions between pages, stale claims that newer sources have superseded, orphan pages with no inbound links, important concepts mentioned but lacking their own page, missing cross-references, data gaps that could be filled with a web search. The LLM is good at suggesting new questions to investigate and new sources to look for. This keeps the wiki healthy as it grows.
+
+## Indexing and logging
+
+Two special files help the LLM (and you) navigate the wiki as it grows. They serve different purposes:
+
+**index.md** is content-oriented. It's a catalog of everything in the wiki — each page listed with a link, a one-line summary, and optionally metadata like date or source count. Organized by category (entities, concepts, sources, etc.). The LLM updates it on every ingest. When answering a query, the LLM reads the index first to find relevant pages, then drills into them. This works surprisingly well at moderate scale (~100 sources, ~hundreds of pages) and avoids the need for embedding-based RAG infrastructure.
+
+**log.md** is chronological. It's an append-only record of what happened and when — ingests, queries, lint passes. A useful tip: if each entry starts with a consistent prefix (e.g. `## [2026-04-02] ingest | Article Title`), the log becomes parseable with simple unix tools — `grep "^## \[" log.md | tail -5` gives you the last 5 entries. The log gives you a timeline of the wiki's evolution and helps the LLM understand what's been done recently.
+
+## Optional: CLI tools
+
+At some point you may want to build small tools that help the LLM operate on the wiki more efficiently. A search engine over the wiki pages is the most obvious one — at small scale the index file is enough, but as the wiki grows you want proper search. [qmd](https://github.com/tobi/qmd) is a good option: it's a local search engine for markdown files with hybrid BM25/vector search and LLM re-ranking, all on-device. It has both a CLI (so the LLM can shell out to it) and an MCP server (so the LLM can use it as a native tool). You could also build something simpler yourself — the LLM can help you vibe-code a naive search script as the need arises.
+
+## Tips and tricks
+
+- **Obsidian Web Clipper** is a browser extension that converts web articles to markdown. Very useful for quickly getting sources into your raw collection.
+- **Download images locally.** In Obsidian Settings → Files and links, set "Attachment folder path" to a fixed directory (e.g. `raw/assets/`). Then in Settings → Hotkeys, search for "Download" to find "Download attachments for current file" and bind it to a hotkey (e.g. Ctrl+Shift+D). After clipping an article, hit the hotkey and all images get downloaded to local disk. This is optional but useful — it lets the LLM view and reference images directly instead of relying on URLs that may break. Note that LLMs can't natively read markdown with inline images in one pass — the workaround is to have the LLM read the text first, then view some or all of the referenced images separately to gain additional context. It's a bit clunky but works well enough.
+- **Obsidian's graph view** is the best way to see the shape of your wiki — what's connected to what, which pages are hubs, which are orphans.
+- **Marp** is a markdown-based slide deck format. Obsidian has a plugin for it. Useful for generating presentations directly from wiki content.
+- **Dataview** is an Obsidian plugin that runs queries over page frontmatter. If your LLM adds YAML frontmatter to wiki pages (tags, dates, source counts), Dataview can generate dynamic tables and lists.
+- The wiki is just a git repo of markdown files. You get version history, branching, and collaboration for free.
+
+## Why this works
+
+The tedious part of maintaining a knowledge base is not the reading or the thinking — it's the bookkeeping. Updating cross-references, keeping summaries current, noting when new data contradicts old claims, maintaining consistency across dozens of pages. Humans abandon wikis because the maintenance burden grows faster than the value. LLMs don't get bored, don't forget to update a cross-reference, and can touch 15 files in one pass. The wiki stays maintained because the cost of maintenance is near zero.
+
+The human's job is to curate sources, direct the analysis, ask good questions, and think about what it all means. The LLM's job is everything else.
+
+The idea is related in spirit to Vannevar Bush's Memex (1945) — a personal, curated knowledge store with associative trails between documents. Bush's vision was closer to this than to what the web became: private, actively curated, with the connections between documents as valuable as the documents themselves. The part he couldn't solve was who does the maintenance. The LLM handles that.
+
+
+## Note
+
+This document is intentionally abstract. It describes the idea, not a specific implementation. The exact directory structure, the schema conventions, the page formats, the tooling — all of that will depend on your domain, your preferences, and your LLM of choice. Everything mentioned above is optional and modular — pick what's useful, ignore what isn't. For example: your sources might be text-only, so you don't need image handling at all. Your wiki might be small enough that the index file is all you need, no search engine required. You might not care about slide decks and just want markdown pages. You might want a completely different set of output formats. The right way to use this is to share it with your LLM agent and work together to instantiate a version that fits your needs. The document's only job is to communicate the pattern. Your LLM can figure out the rest.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,410 @@
+# M3E Documents Index
+
+This file is the content-oriented index for `docs/`. It is generated from the current file tree and maintained as the navigation layer described in `06_Operations/LLM_Wiki_Schema.md`.
+
+- Regenerate: `node scripts/ops/check-docs-index.mjs --write`
+- Check: `node scripts/ops/check-docs-index.mjs --check`
+- Coverage: all files under `docs/`, excluding `docs/.obsidian/` and `.DS_Store`
+- Indexed files: 317
+
+## Reading Routes
+
+- Session bootstrap: `00_Home/Agent_Brief.md`, `00_Home/Current_Status.md`, `00_Home/Glossary.md`
+- Current product direction: `00_Home/Home.md`, `00_Home/Objective.md`, `01_Vision/Strategy.md`
+- Feature meaning: `03_Spec/` first, then `04_Architecture/`
+- Operations and handoff: `06_Operations/`, then `tasks/`
+- Raw ideas and research: `ideas/`, `research/`, `competitive_research/`, `legacy/`
+
+## Directory Catalog
+
+### 00_Home - entry and current state
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [00_Home/Agent_Brief.md](<./00_Home/Agent_Brief.md>) | Markdown | Agent Brief | 最終更新: 2026-04-20 |
+| [00_Home/Current_Status.md](<./00_Home/Current_Status.md>) | Markdown | Current Status | 最終更新: 2026-06-12 |
+| [00_Home/Glossary.md](<./00_Home/Glossary.md>) | Markdown | Glossary — M3E 用語辞書 | M3E プロジェクト固有の語、および揺れがちな語を正規化する辞書。 |
+| [00_Home/Home.md](<./00_Home/Home.md>) | Markdown | M3E — Home | 最終更新: 2026-04-20 |
+| [00_Home/Objective.md](<./00_Home/Objective.md>) | Markdown | Objective — Planning Hierarchy | 最終更新: 2026-04-20 |
+| [00_Home/README.md](<./00_Home/README.md>) | Markdown | 00_Home/ | **役割**: LLM / 人間の入口。セッション開始時に最初に読む場所。 |
+
+### 01_Vision - principles, vision, strategy
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [01_Vision/Axes.md](<./01_Vision/Axes.md>) | Markdown | M3E の帯域軸（粒度・構造・操作の連動進化） | M3E は同じ基礎データを **単位（粒度）と構造の性質が連動して変化する帯域** で扱う。 |
+| [01_Vision/Core_Principles.md](<./01_Vision/Core_Principles.md>) | Markdown | Core Principles | この文書の内容は [Principle.md](./Principle.md) に統合した。 |
+| [01_Vision/Principle.md](<./01_Vision/Principle.md>) | Markdown | Principle | 最終更新: 2026-04-20 |
+| [01_Vision/README.md](<./01_Vision/README.md>) | Markdown | 01_Vision/ | **役割**: M3E の `Planning Hierarchy` 上位層を置く場所。原則・未達ギャップ・攻略方針を階層ごとに分けて管理する。 |
+| [01_Vision/Strategy.md](<./01_Vision/Strategy.md>) | Markdown | Strategy | 最終更新: 2026-04-20 |
+| [01_Vision/Vision.md](<./01_Vision/Vision.md>) | Markdown | Vision | 最終更新: 2026-04-20 |
+| [01_Vision/Weekly_Advance.md](<./01_Vision/Weekly_Advance.md>) | Markdown | Weekly Advance | 最終更新: 2026-04-20 |
+
+### 03_Spec - functional specifications
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [03_Spec/AI_Common_API.md](<./03_Spec/AI_Common_API.md>) | Markdown | AI 共通 API 仕様 | 最終更新: 2026-04-02 |
+| [03_Spec/AI_Integration.md](<./03_Spec/AI_Integration.md>) | Markdown | AI連携仕様 | 最終更新: 2026-04-02 |
+| [03_Spec/AI_Use_Cases.md](<./03_Spec/AI_Use_Cases.md>) | Markdown | AI 利用シナリオ集 | 最終更新: 2026-04-02 |
+| [03_Spec/Band_Spec.md](<./03_Spec/Band_Spec.md>) | Markdown | Band Spec | M3E は同一の基礎構造を、思考密度の異なる 3 つの帯域で扱う。 |
+| [03_Spec/Cloud_Sync_Conflict_Resolution.md](<./03_Spec/Cloud_Sync_Conflict_Resolution.md>) | Markdown | Cloud Sync Conflict Resolution — 仕様書 | Cloud Sync で競合が発生した際に、GitHub の merge conflict resolution に相当する |
+| [03_Spec/Cloud_Sync.md](<./03_Spec/Cloud_Sync.md>) | Markdown | Cloud Sync | この文書は、Beta におけるクラウド同期の最小戦略を定義する。 |
+| [03_Spec/Command_Language.md](<./03_Spec/Command_Language.md>) | Markdown | M3E コマンド言語仕様 | > **設計フェーズ:** Beta 以降の実装対象。MVP には未実装。 |
+| [03_Spec/data_import_export.md](<./03_Spec/data_import_export.md>) | Markdown | Data & Import/Export 設計ドキュメント | 最終更新: 2026-04-09 |
+| [03_Spec/Data_Model.md](<./03_Spec/Data_Model.md>) | Markdown | Data Model | この文書は、M3E の実体モデルに関する不変条件を定義する。 |
+| [03_Spec/Data_Runtime_Layout.md](<./03_Spec/Data_Runtime_Layout.md>) | Markdown | Data Runtime Layout | 永続データ実体。`data.sqlite` だけでなく backup, audit, cloud-sync, conflict-backups を含むフォルダ単位 |
+| [03_Spec/home_scope_navigator.md](<./03_Spec/home_scope_navigator.md>) | Markdown | Home Screen / Scope Navigator -- Design Document | Date: 2025-04-09 |
+| [03_Spec/Home_Screen.md](<./03_Spec/Home_Screen.md>) | Markdown | Home Screen 仕様書 | 作成日: 2026-04-14 |
+| [03_Spec/Import_Export.md](<./03_Spec/Import_Export.md>) | Markdown | Import / Export 仕様 | > **MVP 対応状況を含む。** 未実装のものは「未実装」と明記する。 |
+| [03_Spec/Joint_Integration_Hub.md](<./03_Spec/Joint_Integration_Hub.md>) | Markdown | Joint Integration Hub — リマインダー & 外部サービス共通連携層 | 最終更新: 2026-04-22 |
+| [03_Spec/Linear_Tree_Conversion.md](<./03_Spec/Linear_Tree_Conversion.md>) | Markdown | Linear <-> Tree 変換仕様（Draft） | M3E の主構造（Tree）と線形表現（Linear）を相互に変換し、 |
+| [03_Spec/local_file_integration.md](<./03_Spec/local_file_integration.md>) | Markdown | ローカルファイル連携設計 | 最終更新: 2026-04-15 |
+| [03_Spec/map_layout_modes.md](<./03_Spec/map_layout_modes.md>) | Markdown | Map Layout Modes 設計ドキュメント | > **Status**: Draft (Surface View 正本更新済み、コード移行は別タスク) |
+| [03_Spec/Map_Structure_Index.md](<./03_Spec/Map_Structure_Index.md>) | Markdown | Map Structure Index | このファイルは索引のみ。canonical rule の本文を重複させない。 |
+| [03_Spec/Model_State_And_Schema_V2.md](<./03_Spec/Model_State_And_Schema_V2.md>) | Markdown | Model State 分離と Schema v2 仕様 | 本仕様は以下を明確化する。 |
+| [03_Spec/Node_Path_Notation.md](<./03_Spec/Node_Path_Notation.md>) | Markdown | Node Path Notation | M3E マップ上のノードを、会話・ログ・スキル指示・Map Manager 指示で指し示すための公式表記法。 |
+| [03_Spec/Obsidian_Vault_Integration.md](<./03_Spec/Obsidian_Vault_Integration.md>) | Markdown | Obsidian Vault 連携仕様（Import / Export / Live Mode） | 最終更新: 2026-04-15 |
+| [03_Spec/README.md](<./03_Spec/README.md>) | Markdown | 03_Spec/ | **役割**: 機能仕様。**何を作るか**を記述する。 |
+| [03_Spec/Resource_Design.md](<./03_Spec/Resource_Design.md>) | Markdown | Resource Design | この文書は M3E における「Resource（資源）」概念の設計仕様を定義する。 |
+| [03_Spec/REST_API.md](<./03_Spec/REST_API.md>) | Markdown | REST API 仕様 | 最終更新: 2026-04-17 |
+| [03_Spec/Scope_and_Alias.md](<./03_Spec/Scope_and_Alias.md>) | Markdown | Scope and Alias | この文書は、M3E の `scope` と `alias` を Beta 実装で扱える粒度まで定義する。 |
+| [03_Spec/Scope_Binding.md](<./03_Spec/Scope_Binding.md>) | Markdown | Scope Binding | 最終更新: 2026-06-06 |
+| [03_Spec/Scope_Routing_Shortcuts.md](<./03_Spec/Scope_Routing_Shortcuts.md>) | Markdown | Scope Routing Shortcuts | 最終更新: 2026-06-05 |
+| [03_Spec/Scope_Transition.md](<./03_Spec/Scope_Transition.md>) | Markdown | Scope 遷移仕様 | 最終更新: 2026-04-01 |
+| [03_Spec/supabase_migration_docs_to_maps.sql](<./03_Spec/supabase_migration_docs_to_maps.sql>) | SQL | supabase migration docs to maps | -- ========================================================================== |
+| [03_Spec/supabase_schema.sql](<./03_Spec/supabase_schema.sql>) | SQL | supabase schema | -- ========================================================================== |
+| [03_Spec/Team_Collaboration.md](<./03_Spec/Team_Collaboration.md>) | Markdown | Team Collaboration | 最終更新: 2026-04-08 |
+| [03_Spec/V4_Product_Experience_Blueprint.md](<./03_Spec/V4_Product_Experience_Blueprint.md>) | Markdown | V4 Product Experience Blueprint | 更新日: 2026-05-02 |
+| [03_Spec/V4_Service_Equivalent_Design.md](<./03_Spec/V4_Service_Equivalent_Design.md>) | Markdown | V4 Service-Equivalent Design | 更新日: 2026-05-02 |
+| [03_Spec/x_tech_radar.md](<./03_Spec/x_tech_radar.md>) | Markdown | X Tech Radar — Design Doc | *2026-04-14 — design only, no implementation* |
+
+### 04_Architecture - implementation architecture
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [04_Architecture/AI_Infrastructure.md](<./04_Architecture/AI_Infrastructure.md>) | Markdown | AI インフラ設計 | 最終更新: 2026-04-02 |
+| [04_Architecture/Drag_and_Reparent.md](<./04_Architecture/Drag_and_Reparent.md>) | Markdown | Drag and Reparent | ノードのドラッグによる親付け替えを、Model を壊さずに扱うための操作設計を定義する。 |
+| [04_Architecture/DragOperate.md](<./04_Architecture/DragOperate.md>) | Markdown | DragOperate | 以下は「ノードAをドラッグして、別の親P’の子に付け替える」一連操作を、MVC（＋Command）で忠実に流した場合の連携です。Konva等の有無に依存しない抽象形で書きます。 |
+| [04_Architecture/Editing_Design.md](<./04_Architecture/Editing_Design.md>) | Markdown | Editing Design | この文書は、M3E の独自描画エンジン上で行う |
+| [04_Architecture/Layout_Algorithm.md](<./04_Architecture/Layout_Algorithm.md>) | Markdown | Layout Algorithm | この文書は、M3E の独自描画エンジンにおける |
+| [04_Architecture/Multi_Select.md](<./04_Architecture/Multi_Select.md>) | Markdown | Multi-Select（複数ノード選択） | 単一選択（`selectedNodeId: string`）だけでは実現できない以下の操作を可能にする： |
+| [04_Architecture/MVC_and_Command.md](<./04_Architecture/MVC_and_Command.md>) | Markdown | MVC and Command | この文書は、M3E を独自実装する場合の責務分離の基本線を定義する。 |
+| [04_Architecture/Pipeline_UI_Reference.md](<./04_Architecture/Pipeline_UI_Reference.md>) | Markdown | Pipeline UI Reference | この文書は、参照 UI を M3E にそのままコピーするための仕様ではない。 |
+| [04_Architecture/README.md](<./04_Architecture/README.md>) | Markdown | 04_Architecture/ | **役割**: 実装アーキテクチャ。**どう作るか**を記述する。 |
+| [04_Architecture/Storage_And_Collab_Overview.md](<./04_Architecture/Storage_And_Collab_Overview.md>) | Markdown | Storage & Collab — アーキテクチャ概観 | 最終更新: 2026-04-20 |
+| [04_Architecture/Visual_Design_Guidelines.md](<./04_Architecture/Visual_Design_Guidelines.md>) | Markdown | Visual Design Guidelines | This document defines the visual design policy for the M3E MVP viewer/editor. |
+
+### 06_Operations - operation rules and handoff
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [06_Operations/Actions_Beta.md](<./06_Operations/Actions_Beta.md>) | Markdown | アクション定義（beta） | > アクション名 → 説明のリスト。アルファベット順。 |
+| [06_Operations/Agent_Roles.md](<./06_Operations/Agent_Roles.md>) | Markdown | Agent Roles | 最終更新: 2026-06-14 |
+| [06_Operations/AI_Instruction_Routing.md](<./06_Operations/AI_Instruction_Routing.md>) | Markdown | AI Instruction Routing | 最終更新: 2026-06-14 |
+| [06_Operations/Codex_Task_Scope_Reference.md](<./06_Operations/Codex_Task_Scope_Reference.md>) | Markdown | Codex Task Scope Reference | 最終更新: 2026-06-14 |
+| [06_Operations/Command_Panel_Security_Test_Cases.md](<./06_Operations/Command_Panel_Security_Test_Cases.md>) | Markdown | Command Panel Security Test Cases | `Command_Language.md` の Security Model 受け入れ条件を、実装前から検証可能なテストケースとして固定する。 |
+| [06_Operations/Command_Reference.md](<./06_Operations/Command_Reference.md>) | Markdown | コマンド操作リファレンス（Rapid） | > **Rapid 用:** このリファレンスは current beta 実装に基づきます。 |
+| [06_Operations/Commit_Message_Rules.md](<./06_Operations/Commit_Message_Rules.md>) | Markdown | Commit Message Rules | コミット履歴を見たときに、変更の種類と意図を短時間で判別できる状態を保つ。 |
+| [06_Operations/Decision_Pool.md](<./06_Operations/Decision_Pool.md>) | Markdown | Decision Pool | 会話や作業中に出た判断を、正式文書に昇格する前にためる場所。 |
+| [06_Operations/Development_System.md](<./06_Operations/Development_System.md>) | Markdown | Development System（開発体制） | 最終更新: 2026-06-25 |
+| [06_Operations/Director_Playbook.md](<./06_Operations/Director_Playbook.md>) | Markdown | Director Playbook | The operating manual for Claude-as-Director driving Codex workers on M3E. |
+| [06_Operations/Distribution_Validation_Balanced_Plan.md](<./06_Operations/Distribution_Validation_Balanced_Plan.md>) | Markdown | Distribution Validation Balanced Plan | 個人利用フェーズでの手元運用負担を最小化しつつ、将来の企業配布へ移行可能な配布・検証導線を先に設計する。 |
+| [06_Operations/Documentation_Rules.md](<./06_Operations/Documentation_Rules.md>) | Markdown | Documentation Rules | 最終更新: 2026-06-27 |
+| [06_Operations/gates/layout-lab-gui-check.md](<./06_Operations/gates/layout-lab-gui-check.md>) | Markdown | FAIL — layout-lab G-GUI independent check | Date: 2026-06-25 |
+| [06_Operations/Integration_Handoff_260401_codex2.md](<./06_Operations/Integration_Handoff_260401_codex2.md>) | Markdown | Integration Handoff (codex2) - 2026-04-01 | This note fixes the minimum merge target from `dev-beta-data` into `dev-beta` for scope normalization and scope trans... |
+| [06_Operations/Keybindings_Beta.md](<./06_Operations/Keybindings_Beta.md>) | Markdown | キーバインド（beta） | > キー → アクション名のマッピング。リマップ時はこのファイルを編集する。 |
+| [06_Operations/Keyboard_Reference_Beta.md](<./06_Operations/Keyboard_Reference_Beta.md>) | Markdown | キーボード・操作リファレンス（beta） | このファイルは以下の2ファイルに分割されました。 |
+| [06_Operations/LLM_Wiki_Schema.md](<./06_Operations/LLM_Wiki_Schema.md>) | Markdown | LLM Wiki Schema for M3E Documents | Status: working-agreement |
+| [06_Operations/README.md](<./06_Operations/README.md>) | Markdown | Operations | このディレクトリは、会話や作業の中で発生した判断を、運用に耐える形で一時保存し、正式文書へ昇格させるための場所です。 |
+| [06_Operations/Release_Notes_v260419-2.md](<./06_Operations/Release_Notes_v260419-2.md>) | Markdown | Release Notes v260419-2 | 日付: 2026-04-19 |
+| [06_Operations/Rule_Backlog.md](<./06_Operations/Rule_Backlog.md>) | Markdown | Rule_Backlog | 正式ルール化する前の草案プール。思いつきを捨てずに貯める場所。 |
+| [06_Operations/Test_and_CICD_Guide.md](<./06_Operations/Test_and_CICD_Guide.md>) | Markdown | Test and CI/CD Guide | Rapid 期間における品質担保を、次の 2 点で実装運用に落とす。 |
+| [06_Operations/Todo_Collected_260407.md](<./06_Operations/Todo_Collected_260407.md>) | Markdown | MOVED | 全項目を [Todo_Pool.md](Todo_Pool.md) に統合済み（2026-04-15）。 |
+| [06_Operations/Todo_Pool.md](<./06_Operations/Todo_Pool.md>) | Markdown | Todo Pool | 確定前の粗い TODO を一時プールし、正式タスク化前の取りこぼしを防ぐ。 |
+| [06_Operations/TODO_today.md](<./06_Operations/TODO_today.md>) | Markdown | TODO_today — 2026-04-15 | > 今日処理する課題。正本は [Todo_Pool.md](Todo_Pool.md)。 |
+| [06_Operations/Version_Registry.md](<./06_Operations/Version_Registry.md>) | Markdown | Version Registry | リリースタグとデータスキーマバージョンの対応表。 |
+| [06_Operations/Worktree_Separation_Rules.md](<./06_Operations/Worktree_Separation_Rules.md>) | Markdown | Worktree Separation Rules | 最終更新: 2026-06-14 |
+
+### 09_Decisions - ADR
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [09_Decisions/ADR_001_Freeplane_First.md](<./09_Decisions/ADR_001_Freeplane_First.md>) | Markdown | ADR 001: Freeplane First | Superseded |
+| [09_Decisions/ADR_002_React_UI_Basis.md](<./09_Decisions/ADR_002_React_UI_Basis.md>) | Markdown | ADR 002: React UI Basis | Accepted |
+| [09_Decisions/ADR_003_Freeplane_Informed_Custom_Engine.md](<./09_Decisions/ADR_003_Freeplane_Informed_Custom_Engine.md>) | Markdown | ADR 003: Freeplane-Informed Custom Engine | Accepted |
+| [09_Decisions/ADR_004_SQLite_For_Rapid_MVP.md](<./09_Decisions/ADR_004_SQLite_For_Rapid_MVP.md>) | Markdown | ADR 004: SQLite for Rapid MVP | Accepted |
+| [09_Decisions/ADR_005_DataDir_Config.md](<./09_Decisions/ADR_005_DataDir_Config.md>) | Markdown | ADR 005: Data Directory Configuration per Environment | Accepted |
+| [09_Decisions/ADR_006_Resource_Schema_Version.md](<./09_Decisions/ADR_006_Resource_Schema_Version.md>) | Markdown | ADR 006: Resource 追加時の Schema Version 方針 | Open (議論中) |
+| [09_Decisions/ADR_007_Resource_Collab_Locking.md](<./09_Decisions/ADR_007_Resource_Collab_Locking.md>) | Markdown | ADR 007: Collab 環境での Resource 定義の排他制御 | Open (議論中) |
+| [09_Decisions/README.md](<./09_Decisions/README.md>) | Markdown | 09_Decisions/ | **役割**: Architecture Decision Record (ADR)。**なぜそう決めたか**の歴史記録。 |
+
+### _generated - generated projections
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [_generated/README.md](<./_generated/README.md>) | Markdown | _generated/ | 機械生成ドキュメント置き場。**人間は読まない。手編集禁止。** |
+| [_generated/TheDesign.md](<./_generated/TheDesign.md>) | Markdown | TheDesign — docs 統合ドキュメント | > Auto-generated by `scripts/concat-docs.mjs` on 2026-04-30T11:45:57 UTC |
+
+### competitive_research - external tool research
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [competitive_research/freeplane/Freeplane_Data_Model_Mapping.md](<./competitive_research/freeplane/Freeplane_Data_Model_Mapping.md>) | Markdown | Freeplane Data Model Mapping | この文書は、Freeplane を土台に使うときに M3E の概念をどう写像するかを整理する。 |
+| [competitive_research/freeplane/Repository_Structure_Summary.md](<./competitive_research/freeplane/Repository_Structure_Summary.md>) | Markdown | Freeplane Repository Structure Summary | Freeplane のリポジトリは、単一アプリの小さなコードベースではなく、Gradle のマルチプロジェクト構成で組まれたデスクトップアプリケーション群として整理されている。 |
+| [competitive_research/mapify.md](<./competitive_research/mapify.md>) | Markdown | Mapify (mapify.so) 競合調査レポート | 調査日: 2026-04-10 |
+| [competitive_research/mindmapsoftwares.md](<./competitive_research/mindmapsoftwares.md>) | Markdown | mindmapsoftwares | 前回の提案（MindMup、Freeplane）以外に、マインドマップツールをさらに調査しました。焦点はオープンソースで、オフライン対応、拡張性が高く、KGFの仕様（ツリー構造、スコープ/folder、alias参照、キャンバスUI、... |
+| [competitive_research/README.md](<./competitive_research/README.md>) | Markdown | competitive_research/ | **役割**: 競合ツール・類似プロダクトの調査。M3E の差別化判断に使う。 |
+| [competitive_research/use_freeplane.md](<./competitive_research/use_freeplane.md>) | Markdown | use freeplane | Freeplaneを土台にするなら、まず押さえるべき実装上の事実は3つです。 |
+| [competitive_research/use_obsidian.md](<./competitive_research/use_obsidian.md>) | Markdown | use obsidian | 結論だけ言うと、ラップはできる。ただし、**M3Eの外側層として使うのは現実的**で、**M3Eの正本データをそのままObsidian Canvas側に置くのは厳しい**です。 |
+| [competitive_research/use_WiseMapping.md](<./competitive_research/use_WiseMapping.md>) | Markdown | use WiseMapping | 結論だけ先に言うと、**WiseMappingは「そのままラップしてM3Eを成立させる」には弱いが、** |
+
+### daily - chronological work logs
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [daily/260330.md](<./daily/260330.md>) | Markdown | 2026-03-30 Daily | 2026-03-30 Daily |
+| [daily/260331.md](<./daily/260331.md>) | Markdown | 2026-03-31 Daily | 2026-03-31 Daily |
+| [daily/260401.md](<./daily/260401.md>) | Markdown | 2026-04-01 Daily | 2026-04-01 Daily |
+| [daily/260402.md](<./daily/260402.md>) | Markdown | 2026-04-02 Daily | 2026-04-02 Daily |
+| [daily/260403.md](<./daily/260403.md>) | Markdown | 2026-04-03 Daily | 2026-04-03 Daily |
+| [daily/260408.md](<./daily/260408.md>) | Markdown | 2026-04-08 Daily | 2026-04-08 Daily |
+| [daily/260409.md](<./daily/260409.md>) | Markdown | 2026-04-09 Daily | 2026-04-09 Daily |
+| [daily/260412.md](<./daily/260412.md>) | Markdown | 2026-04-12 Daily | **概念:** ファイルシステムの `/`（ルートディレクトリ）と同じ。直接編集不可、システム操作のみ。 |
+| [daily/260413.md](<./daily/260413.md>) | Markdown | 2026-04-13 Daily | 1. Vault path を設定 |
+| [daily/260414.md](<./daily/260414.md>) | Markdown | 2026-04-14 | 2026-04-14 |
+| [daily/260415.md](<./daily/260415.md>) | Markdown | 2026-04-15 | 2026-04-15 |
+| [daily/260417.md](<./daily/260417.md>) | Markdown | 2026-04-17 | DAG 書き込み規約を文書化した。 |
+| [daily/260418.md](<./daily/260418.md>) | Markdown | 2026-04-18 | 既定 abort と `--force-reset` の意味を明記した。 |
+| [daily/260419.md](<./daily/260419.md>) | Markdown | 2026-04-19 | `M3E_CLOUD_SYNC=1`, `M3E_CLOUD_TRANSPORT=supabase`, `M3E_SUPABASE_*`, `workspace/map` が保存されることを確認 |
+| [daily/260420.md](<./daily/260420.md>) | Markdown | 2026-04-20 | を明文化 |
+| [daily/260422.md](<./daily/260422.md>) | Markdown | 2026-04-22 | 2026-04-22 |
+| [daily/260429.md](<./daily/260429.md>) | Markdown | 260429 | 260429 |
+| [daily/260430.md](<./daily/260430.md>) | Markdown | 260430 | 260430 |
+| [daily/260502.md](<./daily/260502.md>) | Markdown | 260502 | 260502 |
+| [daily/README.md](<./daily/README.md>) | Markdown | daily/ | **役割**: 日次作業ログ。**追記のみ・改変禁止**。 |
+
+### for-akaghef - Akaghef-facing materials
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [for-akaghef/260409_claude_managed_agents.md](<./for-akaghef/260409_claude_managed_agents.md>) | Markdown | Claude Managed Agents 調査レポート | 調査日: 2026-04-09 |
+| [for-akaghef/260409_cloud_strategy.md](<./for-akaghef/260409_cloud_strategy.md>) | Markdown | Cloud Sync — Akaghef がやること・やらなくていいこと | 1. **初回**: `launch-full.bat` をダブルクリック（5秒） |
+| [for-akaghef/260409_handoff.md](<./for-akaghef/260409_handoff.md>) | Markdown | セッション引き継ぎ書 — 2026-04-09 | 次のセッション（クラウド選定の議論等）に必要な文脈をまとめる。 |
+| [for-akaghef/260409_session_summary.md](<./for-akaghef/260409_session_summary.md>) | Markdown | 2026-04-09 セッション サマリ | Cloud Sync の実装を進めるには、バックエンドのクラウドストレージが必要。 |
+| [for-akaghef/260409_todo_next_week.md](<./for-akaghef/260409_todo_next_week.md>) | Markdown | Akaghef TODO — 次週（~2026-04-16） | 1. 25人が URL でマップを読める状態 |
+| [for-akaghef/260414_obsidian_integration_trial.md](<./for-akaghef/260414_obsidian_integration_trial.md>) | Markdown | Obsidian 連携を実際に試す手順 | 2026-04-14 時点での「いま自分で触る」ための最短ガイド。 |
+| [for-akaghef/260414_review_options_summary.md](<./for-akaghef/260414_review_options_summary.md>) | Markdown | 2026-04-14 レビュー選択肢まとめ | 今日の batch review で通った決定と、まだ未解決で残っている選択肢の一覧。 |
+| [for-akaghef/260416_idea_to_satisfaction_pipeline.md](<./for-akaghef/260416_idea_to_satisfaction_pipeline.md>) | Markdown | アイデア → ユーザー満足までの導線（dump） | 2026-04-16 ダンプ。後で詰める前提。 |
+| [for-akaghef/260416_workspace_map_inventory.md](<./for-akaghef/260416_workspace_map_inventory.md>) | Markdown | Workspace / Map 棚卸し (2026-04-16) | akaghef の個人データを機能別にどう分けているか、現状の実データから確認したもの。 |
+| [for-akaghef/260502_m3e_progress_replay.html](<./for-akaghef/260502_m3e_progress_replay.html>) | HTML | 260502 m3e progress replay | HTML |
+| [for-akaghef/260502_swingby_conflict_lab.md](<./for-akaghef/260502_swingby_conflict_lab.md>) | Markdown | Swingby conflict lab runbook | Date: 2026-05-02 |
+| [for-akaghef/260502_swingby_monthly_meeting_public_link.md](<./for-akaghef/260502_swingby_monthly_meeting_public_link.md>) | Markdown | Swingby 定例会 公開リンク運用メモ | 日付: 2026-05-02 |
+| [for-akaghef/assets/260502_m3e_conflict_lab_snapshot.png](<./for-akaghef/assets/260502_m3e_conflict_lab_snapshot.png>) | Image | 260502 m3e conflict lab snapshot | Image |
+| [for-akaghef/assets/260606_pipeline_flow_ui_reference.jpg](<./for-akaghef/assets/260606_pipeline_flow_ui_reference.jpg>) | Image | 260606 pipeline flow ui reference | Image |
+| [for-akaghef/db_tasks_checklist.md](<./for-akaghef/db_tasks_checklist.md>) | Markdown | Akaghef DB / Cloud Sync タスクチェックリスト | 最終更新: 2026-04-10 |
+| [for-akaghef/distribution_test_flow.md](<./for-akaghef/distribution_test_flow.md>) | Markdown | 配布テストフロー | M3E のインストーラーが別環境で正常に動くかを検証するフロー。 |
+| [for-akaghef/handoff_data_issue.md](<./for-akaghef/handoff_data_issue.md>) | Markdown | 引継ぎ: データ読み込み問題 | Downloads にある `M3E_dataV1.sqlite` の正しいデータ（`akaghef-beta` ドキュメント、350ノード）をbetaアプリで開きたいが、起動すると別のデータ（4ノードや9ノード）が表示される。 |
+| [for-akaghef/pj05_presentation/260514_v4_embedded_presentation.html](<./for-akaghef/pj05_presentation/260514_v4_embedded_presentation.html>) | HTML | 260514 v4 embedded presentation | HTML |
+| [for-akaghef/README.md](<./for-akaghef/README.md>) | Markdown | for-akaghef/ | akaghef 専用の読み物フォルダ。エージェントが作成した要約・判断依頼・進捗レポートをここに置く。 |
+| [for-akaghef/v4_demo/260502_v4_service_slice_report.html](<./for-akaghef/v4_demo/260502_v4_service_slice_report.html>) | HTML | 260502 v4 service slice report | HTML |
+| [for-akaghef/v4_demo/assets/v4_service_slice_m3e.png](<./for-akaghef/v4_demo/assets/v4_service_slice_m3e.png>) | Image | v4 service slice m3e | Image |
+| [for-akaghef/v4_demo/obsidian_vault/V4 service-equivalent demo.md](<./for-akaghef/v4_demo/obsidian_vault/V4 service-equivalent demo.md>) | Markdown | V4 service-equivalent demo | This paragraph was edited in the exported vault and imported back to M3E. |
+| [for-akaghef/v4_demo/v4_service_slice_summary.json](<./for-akaghef/v4_demo/v4_service_slice_summary.json>) | JSON | v4 service slice summary | JSON |
+| [for-akaghef/video_script_intro_draft.md](<./for-akaghef/video_script_intro_draft.md>) | Markdown | M3E 解説動画ドラフト（約5分） | > 形式: マップのチュートリアル操作を画面録画しながらナレーション |
+| [for-akaghef/WS早見.png](<./for-akaghef/WS早見.png>) | Image | WS早見 | Image |
+
+### ideas - raw ideas and stowed notes
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [ideas/20260330_dual_root_design_graph.md](<./ideas/20260330_dual_root_design_graph.md>) | Markdown | Dual Root Design Graph Idea (2026-03-30) | この二つのルートを持つ木がつながる過程は生物的だ なぜこういう構造なのか？自然か？すでに導入されているか？ |
+| [ideas/260401_important_goal.md](<./ideas/260401_important_goal.md>) | Markdown | 260401 important goal | Linear<->Tree相互変換機能 |
+| [ideas/260401_memo.md](<./ideas/260401_memo.md>) | Markdown | 260401 memo | 設計が不十分な箇所 |
+| [ideas/260402subagent.md](<./ideas/260402subagent.md>) | Markdown | AI Subagent 連携仕様（DeepSeek 含む） | 最終更新: 2026-04-02 |
+| [ideas/260407_latex_rendering.md](<./ideas/260407_latex_rendering.md>) | Markdown | LaTeX Rendering in Nodes | Math expressions in mind-map nodes are currently stored as raw LaTeX strings and displayed as plain text. Rendering t... |
+| [ideas/260407organized_ideas.md](<./ideas/260407organized_ideas.md>) | Markdown | M3E アイデア整理（2026-04-07） | 最近追加されたアイデアを分類・整理したもの。 |
+| [ideas/260409_edge_typed_attributes.md](<./ideas/260409_edge_typed_attributes.md>) | Markdown | 親子エッジに型/属性を持たせる設計案 | 現在の M3E では、親子エッジ（parentId / children[]）にはいかなるメタデータもない。 |
+| [ideas/260409_typed_edges.md](<./ideas/260409_typed_edges.md>) | Markdown | 枝（エッジ）に型・属性を持たせる設計案 | Date: 2026-04-09 |
+| [ideas/260410_ai_integration_architecture.md](<./ideas/260410_ai_integration_architecture.md>) | Markdown | AI Integration Architecture -- Claude API 直接利用方式 | 作成日: 2026-04-10 |
+| [ideas/260410_confidence_testing_brainstorm.md](<./ideas/260410_confidence_testing_brainstorm.md>) | Markdown | AI Confidence テスト方法 ブレインストーミング整理 | > 作成日: 2026-04-10 |
+| [ideas/260410_flash_data_model.md](<./ideas/260410_flash_data_model.md>) | Markdown | Flash バンド: データモデルと UX フロー設計 | 最終更新: 2026-04-10 |
+| [ideas/260410_flash_input_pipeline.md](<./ideas/260410_flash_input_pipeline.md>) | Markdown | Flash 入力パイプライン設計 | 作成日: 2026-04-10 |
+| [ideas/260410_layout_depth_offset.md](<./ideas/260410_layout_depth_offset.md>) | Markdown | Layout Depth Offset Design: Parent-Grouped Subtree Indentation | Date: 2026-04-10 |
+| [ideas/260410_local_binding_design.md](<./ideas/260410_local_binding_design.md>) | Markdown | ローカルファイルとの強い結合方式 -- 設計比較と推奨案 | 最終更新: 2026-04-10 |
+| [ideas/260410_node_styling_menu.md](<./ideas/260410_node_styling_menu.md>) | Markdown | Node Styling Menu -- UI Design | **Date:** 2026-04-10 |
+| [ideas/260410_scalable_knowledge_base_vision.md](<./ideas/260410_scalable_knowledge_base_vision.md>) | Markdown | スケーラブル知識ベース — M3E の根本ビジョン | > 夢は出来たら人に語るようにしている。叶うので。 |
+| [ideas/260420_m3e_vision_twitter_dump.md](<./ideas/260420_m3e_vision_twitter_dump.md>) | Markdown | M3E Vision — Twitter/X ダンプ（Grok 収集） | 収集日: 2026-04-20 |
+| [ideas/260420_math_transition_vision.md](<./ideas/260420_math_transition_vision.md>) | Markdown | 数学学習から数学研究へ移るための M3E 構想 | 作成日: 2026-04-20 |
+| [ideas/260420_math_transition_vision2.md](<./ideas/260420_math_transition_vision2.md>) | Markdown | 数学学習から数学研究へ移るための M3E 構想（拡張版） | 作成日: 2026-04-20 |
+| [ideas/260627_llm_wiki_pattern.md](<./ideas/260627_llm_wiki_pattern.md>) | Markdown | LLM Wiki | A pattern for building personal knowledge bases using LLMs. |
+| [ideas/ChatGPT-M3Eのコンテンツ販売.md](<./ideas/ChatGPT-M3Eのコンテンツ販売.md>) | Markdown | M3Eのコンテンツ販売 | **User:** Anonymous (kawami.s.aa@m.titech.ac.jp) |
+| [ideas/ChatGPT-Map Logic Limitations.md](<./ideas/ChatGPT-Map Logic Limitations.md>) | Markdown | Map Logic Limitations | **User:** Anonymous (kawami.s.aa@m.titech.ac.jp) |
+| [ideas/ChatGPT-ハードコピーとソフトコピー.md](<./ideas/ChatGPT-ハードコピーとソフトコピー.md>) | Markdown | ハードコピーとソフトコピー | **User:** Anonymous (kawami.s.aa@m.titech.ac.jp) |
+| [ideas/ChatGPT-固定費と戦略.md](<./ideas/ChatGPT-固定費と戦略.md>) | Markdown | 固定費と戦略 | **User:** Anonymous (kawami.s.aa@m.titech.ac.jp) |
+| [ideas/ChatGPT-温度とグラフ構造.md](<./ideas/ChatGPT-温度とグラフ構造.md>) | Markdown | 温度とグラフ構造 | **User:** Anonymous (kawami.s.aa@m.titech.ac.jp) |
+| [ideas/description_example.md](<./ideas/description_example.md>) | Markdown | M3E 機能紹介 — 開発プロジェクト活用ガイド | M3E（Model, Map, Meaning Engine）は、科学研究者の構造的思考を支援するツールです。ツリー構造のデータモデルを中核に、論文分解・仮説比較・前提整理・設計判断といった知的作業を扱います。本ドキュメントでは、開発... |
+| [ideas/Home_page.md](<./ideas/Home_page.md>) | Markdown | Home page | 回のセッションで実装した差分を自然言語でまとめます。 |
+| [ideas/memo_ideas.md](<./ideas/memo_ideas.md>) | Markdown | M3EのAI協働に関する知見整理 | 会話の中で得られた知見を整理すると、M3Eは単なるマインドマップではなく、人間と複数のAIが同じ構造を共有しながら仕事を進めるための共同作業基盤として捉えるのが適切である。ユーザーは技術スタックそのものを把握する必要はなく、可視化され... |
+| [ideas/README.md](<./ideas/README.md>) | Markdown | Ideas Folder | このフォルダは、実装前のアイデアを自由に追記するための場所です。 |
+| [ideas/security.md](<./ideas/security.md>) | Markdown | security | https://x.com/nobel_824/status/2038416059167121507 |
+| [ideas/tree_compatible_language.md](<./ideas/tree_compatible_language.md>) | Markdown | Tree-Compatible Language (TCL) 仕様 | Tree-Compatible Language（TCL）は、マインドマップ（木構造）と自然言語文章の間の**準同型変換**を実現するための制約付き記述言語である。自由な自然言語ではなく、可逆性を持たせたシリアライズ形式として機能する。 |
+| [ideas/tree_structure_rapid_deep.md](<./ideas/tree_structure_rapid_deep.md>) | Markdown | tree structure rapid deep | we consider about pdf->mind map. |
+| [ideas/UrgentImportanceView.mlx](<./ideas/UrgentImportanceView.mlx>) | MATLAB Live Script | UrgentImportanceView | MATLAB Live Script |
+| [ideas/定例会バックアップ.json](<./ideas/定例会バックアップ.json>) | JSON | 定例会バックアップ | JSON |
+
+### legacy - historical designs
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [legacy/Canvas_Centric_Architecture.md](<./legacy/Canvas_Centric_Architecture.md>) | Markdown | Canvas-Centric Architecture | Legacy |
+| [legacy/Current_Pivot_Freeplane_First.md](<./legacy/Current_Pivot_Freeplane_First.md>) | Markdown | Current Pivot: Freeplane-Informed Custom Engine | 当面の M3E は、Freeplane をそのまま土台 UI として使うのではなく、 |
+| [legacy/M3E仕様2.md](<./legacy/M3E仕様2.md>) | Markdown | M3E仕様2 | 現時点であなたが置いている前提を整理すると、次のようになります。 |
+| [legacy/M3E仕様設計書.md](<./legacy/M3E仕様設計書.md>) | Markdown | Mind Map Model Engine (M3E) 仕様設計書（会話ログ統合） | 本書は、これまでの会話で合意された世界観・制約・設計意図を、実装詳細に過度に踏み込まずに「仕様」として再構成したものである。特に、個人オフライン・スコープ境界・親子主構造・帯域（Flash/Rapid/Deep）・AIは提案で承認が確... |
+| [legacy/mvp-cleanup-plan.md](<./legacy/mvp-cleanup-plan.md>) | Markdown | mvp 痕跡の削除計画 | mvp/ を「バージョン履歴だけのもの」として扱い、実行可能な参照をすべて消す。 |
+| [legacy/README.md](<./legacy/README.md>) | Markdown | Legacy | このディレクトリには、現行方針では採用しない旧設計要件を置く。 |
+
+### research - source research and extracts
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [research/Claude_Code_Skills_Research.md](<./research/Claude_Code_Skills_Research.md>) | Markdown | Claude Code Skills & Subagents — M3E 適用調査 | **Author**: team agent (research branch `research/claude-code-skills`) |
+| [research/m3e_data_structure_conversations/00_README.md](<./research/m3e_data_structure_conversations/00_README.md>) | Markdown | M3E Data Structure Conversation Corpus | ChatGPT export内の M3E 関連会話から、データ構造・通信形式・正本境界・属性表現に関係する材料を M3E repo 側へコピーした作業パッケージ。 |
+| [research/m3e_data_structure_conversations/01_pure_brief.md](<./research/m3e_data_structure_conversations/01_pure_brief.md>) | Markdown | M3E Data Structure Pure Brief | このノートは会話ログから抽出した設計判断の高純度版。正式仕様ではなく、次に `docs/03_Spec/` へ昇格させるための種。 |
+| [research/m3e_data_structure_conversations/02_transport_schema_seed.md](<./research/m3e_data_structure_conversations/02_transport_schema_seed.md>) | Markdown | M3E Transport Schema Seed | 通信側だけを先に固めるための seed。正本 schema ではなく、LLM / agent と M3E runtime の境界 DTO として扱う。 |
+| [research/m3e_data_structure_conversations/03_core_i64_seed.md](<./research/m3e_data_structure_conversations/03_core_i64_seed.md>) | Markdown | core_i64 Seed | SQLiteの1列を固定フォーマット領域として使う案の seed。目的は、頻出する小さな semantic fields を JSON/attrs の文字列ノイズから逃がすこと。 |
+| [research/m3e_data_structure_conversations/04_open_questions.md](<./research/m3e_data_structure_conversations/04_open_questions.md>) | Markdown | Open Questions | 会話ログから見て、まだ固める必要がある点。 |
+| [research/m3e_data_structure_conversations/extracts/curated_core_evidence.md](<./research/m3e_data_structure_conversations/extracts/curated_core_evidence.md>) | Markdown | Curated Core Evidence | M3Eデータ構造・通信形式を仕様化するとき、まず見るべき証跡だけを手で選んだもの。 |
+| [research/m3e_data_structure_conversations/extracts/high_purity_evidence.md](<./research/m3e_data_structure_conversations/extracts/high_purity_evidence.md>) | Markdown | High Purity Evidence | TOON / MIOS / Command Patch / JSON正本 / 可変属性 / packed core に直接触れている証跡だけを抽出した版。 |
+| [research/m3e_data_structure_conversations/extracts/high_value_evidence.md](<./research/m3e_data_structure_conversations/extracts/high_value_evidence.md>) | Markdown | Extracted Evidence | M3E data-structure / communication-design conversationsから、設計判断に近い行だけを抜いた証跡。 |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_KGFとフレームワーク.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_KGFとフレームワーク.md>) | Markdown | KGFとフレームワーク | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_KGFのOS構造.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_KGFのOS構造.md>) | Markdown | KGFのOS構造 | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_Manusでプロトタイプ作成.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_Manusでプロトタイプ作成.md>) | Markdown | Manusでプロトタイプ作成 | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_Miro_Mind_Map_API.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_Miro_Mind_Map_API.md>) | Markdown | Miro Mind Map API | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_MVC通信形式_Rapid.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_MVC通信形式_Rapid.md>) | Markdown | MVC通信形式 Rapid | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_タイムボクシング連携.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_タイムボクシング連携.md>) | Markdown | タイムボクシング連携 | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_構造と文章の相互変換.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_構造と文章の相互変換.md>) | Markdown | 構造と文章の相互変換 | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260304_開発言語選定.md](<./research/m3e_data_structure_conversations/raw_conversations/260304_開発言語選定.md>) | Markdown | 開発言語選定 | <sub>2026-03-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260305_アプリ仕様とフレームワーク.md](<./research/m3e_data_structure_conversations/raw_conversations/260305_アプリ仕様とフレームワーク.md>) | Markdown | アプリ仕様とフレームワーク | <sub>2026-03-05</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260308_AIと研究のギャップ.md](<./research/m3e_data_structure_conversations/raw_conversations/260308_AIと研究のギャップ.md>) | Markdown | AIと研究のギャップ | <sub>2026-03-08</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260310_意思決定の高速化.md](<./research/m3e_data_structure_conversations/raw_conversations/260310_意思決定の高速化.md>) | Markdown | 意思決定の高速化 | <sub>2026-03-10</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260311_Agent開発の基本.md](<./research/m3e_data_structure_conversations/raw_conversations/260311_Agent開発の基本.md>) | Markdown | Agent開発の基本 | <sub>2026-03-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260311_アプリ名の略称提案.md](<./research/m3e_data_structure_conversations/raw_conversations/260311_アプリ名の略称提案.md>) | Markdown | アプリ名の略称提案 | <sub>2026-03-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260311_外部ツール利用可否.md](<./research/m3e_data_structure_conversations/raw_conversations/260311_外部ツール利用可否.md>) | Markdown | 外部ツール利用可否 | <sub>2026-03-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260312_EdrawMindラッピング検討.md](<./research/m3e_data_structure_conversations/raw_conversations/260312_EdrawMindラッピング検討.md>) | Markdown | EdrawMindラッピング検討 | <sub>2026-03-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260312_Freeplane_実装とデータ構造.md](<./research/m3e_data_structure_conversations/raw_conversations/260312_Freeplane_実装とデータ構造.md>) | Markdown | Freeplane 実装とデータ構造 | <sub>2026-03-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260312_Obsidian_Canvas_ラッピング.md](<./research/m3e_data_structure_conversations/raw_conversations/260312_Obsidian_Canvas_ラッピング.md>) | Markdown | Obsidian Canvas ラッピング | <sub>2026-03-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260312_Wisemapping_ラップ検証.md](<./research/m3e_data_structure_conversations/raw_conversations/260312_Wisemapping_ラップ検証.md>) | Markdown | Wisemapping ラップ検証 | <sub>2026-03-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260312_ライセンスと公開障害.md](<./research/m3e_data_structure_conversations/raw_conversations/260312_ライセンスと公開障害.md>) | Markdown | ライセンスと公開障害 | <sub>2026-03-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260313_M3E_Obsidianファイル構造.md](<./research/m3e_data_structure_conversations/raw_conversations/260313_M3E_Obsidianファイル構造.md>) | Markdown | M3E Obsidianファイル構造 | <sub>2026-03-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260313_ReactとCanvasの実装方針.md](<./research/m3e_data_structure_conversations/raw_conversations/260313_ReactとCanvasの実装方針.md>) | Markdown | ReactとCanvasの実装方針 | <sub>2026-03-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260313_Xiaomiセンサー表示機実装.md](<./research/m3e_data_structure_conversations/raw_conversations/260313_Xiaomiセンサー表示機実装.md>) | Markdown | Xiaomiセンサー表示機実装 | <sub>2026-03-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260313_雑多.md](<./research/m3e_data_structure_conversations/raw_conversations/260313_雑多.md>) | Markdown | 雑多 | <sub>2026-03-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260325_温度とグラフ構造.md](<./research/m3e_data_structure_conversations/raw_conversations/260325_温度とグラフ構造.md>) | Markdown | 温度とグラフ構造 | <sub>2026-03-25</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260327_Freeplane_フォークの現実性.md](<./research/m3e_data_structure_conversations/raw_conversations/260327_Freeplane_フォークの現実性.md>) | Markdown | Freeplane フォークの現実性 | <sub>2026-03-27</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_GUI操作の自動化方法.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_GUI操作の自動化方法.md>) | Markdown | GUI操作の自動化方法 | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_Industry_E4_clarification.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_Industry_E4_clarification.md>) | Markdown | Industry E4 clarification | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_LLMの不足判定設計.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_LLMの不足判定設計.md>) | Markdown | LLMの不足判定設計 | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_Map_Logic_Limitations.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_Map_Logic_Limitations.md>) | Markdown | Map Logic Limitations | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_ハードコピーとソフトコピー.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_ハードコピーとソフトコピー.md>) | Markdown | ハードコピーとソフトコピー | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_メールボックス分類フロー.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_メールボックス分類フロー.md>) | Markdown | メールボックス分類フロー | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260330_役割分離の方法.md](<./research/m3e_data_structure_conversations/raw_conversations/260330_役割分離の方法.md>) | Markdown | 役割分離の方法 | <sub>2026-03-30</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260331_BitwardenとPowerShell設定.md](<./research/m3e_data_structure_conversations/raw_conversations/260331_BitwardenとPowerShell設定.md>) | Markdown | BitwardenとPowerShell設定 | <sub>2026-03-31</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260331_CodexCLI使用方法.md](<./research/m3e_data_structure_conversations/raw_conversations/260331_CodexCLI使用方法.md>) | Markdown | CodexCLI使用方法 | <sub>2026-03-31</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260402_UIマトリクス視覚化.md](<./research/m3e_data_structure_conversations/raw_conversations/260402_UIマトリクス視覚化.md>) | Markdown | U&Iマトリクス視覚化 | <sub>2026-04-02</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260402_ノードメタデータ設計.md](<./research/m3e_data_structure_conversations/raw_conversations/260402_ノードメタデータ設計.md>) | Markdown | ノードメタデータ設計 | <sub>2026-04-02</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260402_軸の定義と整理.md](<./research/m3e_data_structure_conversations/raw_conversations/260402_軸の定義と整理.md>) | Markdown | 軸の定義と整理 | <sub>2026-04-02</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_AI_Infra_Design_for_M3E.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_AI_Infra_Design_for_M3E.md>) | Markdown | AI Infra Design for M3E | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_Worktreeによるディレクトリ管理.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_Worktreeによるディレクトリ管理.md>) | Markdown | Worktreeによるディレクトリ管理 | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_アイコン設計方針.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_アイコン設計方針.md>) | Markdown | アイコン設計方針 | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_キーコンフィグ相談.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_キーコンフィグ相談.md>) | Markdown | キーコンフィグ相談 | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_クラウド同期マージ問題.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_クラウド同期マージ問題.md>) | Markdown | クラウド同期マージ問題 | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_データマイグレーションの実際.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_データマイグレーションの実際.md>) | Markdown | データマイグレーションの実際 | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260403_固定費と戦略.md](<./research/m3e_data_structure_conversations/raw_conversations/260403_固定費と戦略.md>) | Markdown | 固定費と戦略 | <sub>2026-04-03</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_Give_push_permission.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_Give_push_permission.md>) | Markdown | Give push permission | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_HTML要素と設計.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_HTML要素と設計.md>) | Markdown | HTML要素と設計 | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_M3EとAgent_Workflow.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_M3EとAgent_Workflow.md>) | Markdown | M3EとAgent Workflow | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_M3Eのコンテンツ販売.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_M3Eのコンテンツ販売.md>) | Markdown | M3Eのコンテンツ販売 | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_ScopeとNodeの設定.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_ScopeとNodeの設定.md>) | Markdown | ScopeとNodeの設定 | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_ハイブリッド検索の重要性.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_ハイブリッド検索の重要性.md>) | Markdown | ハイブリッド検索の重要性 | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260404_評価と比較の分離.md](<./research/m3e_data_structure_conversations/raw_conversations/260404_評価と比較の分離.md>) | Markdown | 評価と比較の分離 | <sub>2026-04-04</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260405_M3E_vs_M3E.md](<./research/m3e_data_structure_conversations/raw_conversations/260405_M3E_vs_M3E.md>) | Markdown | M3E vs M^3E | <sub>2026-04-05</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260405_Obsidianのビジネスモデル.md](<./research/m3e_data_structure_conversations/raw_conversations/260405_Obsidianのビジネスモデル.md>) | Markdown | Obsidianのビジネスモデル | <sub>2026-04-05</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260406_AI_memory_reflection.md](<./research/m3e_data_structure_conversations/raw_conversations/260406_AI_memory_reflection.md>) | Markdown | AI memory reflection | <sub>2026-04-06</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260406_AI_orchestration_in_M3E.md](<./research/m3e_data_structure_conversations/raw_conversations/260406_AI_orchestration_in_M3E.md>) | Markdown | AI orchestration in M3E | <sub>2026-04-06</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260406_位相空間_定義.md](<./research/m3e_data_structure_conversations/raw_conversations/260406_位相空間_定義.md>) | Markdown | 位相空間 定義 | <sub>2026-04-06</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260407_Claude_Git自動承認設定.md](<./research/m3e_data_structure_conversations/raw_conversations/260407_Claude_Git自動承認設定.md>) | Markdown | Claude Git自動承認設定 | <sub>2026-04-07</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260408_数学書の構造化.md](<./research/m3e_data_structure_conversations/raw_conversations/260408_数学書の構造化.md>) | Markdown | 数学書の構造化 | <sub>2026-04-08</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260409_ローンチ前の自動テスト.md](<./research/m3e_data_structure_conversations/raw_conversations/260409_ローンチ前の自動テスト.md>) | Markdown | ローンチ前の自動テスト | <sub>2026-04-09</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260410_LLMの知識境界.md](<./research/m3e_data_structure_conversations/raw_conversations/260410_LLMの知識境界.md>) | Markdown | LLMの知識境界 | <sub>2026-04-10</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260410_Structural_Reasoning_Stack.md](<./research/m3e_data_structure_conversations/raw_conversations/260410_Structural_Reasoning_Stack.md>) | Markdown | Structural Reasoning Stack | <sub>2026-04-10</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260410_TCLの意味.md](<./research/m3e_data_structure_conversations/raw_conversations/260410_TCLの意味.md>) | Markdown | TCLの意味 | <sub>2026-04-10</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260410_線形からグラフ構造.md](<./research/m3e_data_structure_conversations/raw_conversations/260410_線形からグラフ構造.md>) | Markdown | 線形からグラフ構造 | <sub>2026-04-10</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260410_重要LLMとM3E構造比較.md](<./research/m3e_data_structure_conversations/raw_conversations/260410_重要LLMとM3E構造比較.md>) | Markdown | 【重要】LLMとM3E 構造比較 | <sub>2026-04-10</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260411_CodexとLLMの違い.md](<./research/m3e_data_structure_conversations/raw_conversations/260411_CodexとLLMの違い.md>) | Markdown | CodexとLLMの違い | <sub>2026-04-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260411_Entity_Party_Org_関係.md](<./research/m3e_data_structure_conversations/raw_conversations/260411_Entity_Party_Org_関係.md>) | Markdown | Entity Party Org 関係 | <sub>2026-04-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260411_GitHubインストーラ警告対策.md](<./research/m3e_data_structure_conversations/raw_conversations/260411_GitHubインストーラ警告対策.md>) | Markdown | GitHubインストーラ警告対策 | <sub>2026-04-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260411_セキュリティとスコープ設計.md](<./research/m3e_data_structure_conversations/raw_conversations/260411_セキュリティとスコープ設計.md>) | Markdown | セキュリティとスコープ設計 | <sub>2026-04-11</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260412_Codex_Git操作方法.md](<./research/m3e_data_structure_conversations/raw_conversations/260412_Codex_Git操作方法.md>) | Markdown | Codex Git操作方法 | <sub>2026-04-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260412_Party_experience_summary.md](<./research/m3e_data_structure_conversations/raw_conversations/260412_Party_experience_summary.md>) | Markdown | Party experience summary | <sub>2026-04-12</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260413_M3_Server_Online_Access.md](<./research/m3e_data_structure_conversations/raw_conversations/260413_M3_Server_Online_Access.md>) | Markdown | M3 Server Online Access | <sub>2026-04-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260413_Miro_API_Mind_Map_Editing.md](<./research/m3e_data_structure_conversations/raw_conversations/260413_Miro_API_Mind_Map_Editing.md>) | Markdown | Miro API Mind Map Editing | <sub>2026-04-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260413_Offline_XMind_Integration.md](<./research/m3e_data_structure_conversations/raw_conversations/260413_Offline_XMind_Integration.md>) | Markdown | Offline XMind Integration | <sub>2026-04-13</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260415_CI通知と失敗対策.md](<./research/m3e_data_structure_conversations/raw_conversations/260415_CI通知と失敗対策.md>) | Markdown | CI通知と失敗対策 | <sub>2026-04-15</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260415_scopen_descopen改善提案.md](<./research/m3e_data_structure_conversations/raw_conversations/260415_scopen_descopen改善提案.md>) | Markdown | scopen descopen改善提案 | <sub>2026-04-15</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260417_LLMの抽象度評価.md](<./research/m3e_data_structure_conversations/raw_conversations/260417_LLMの抽象度評価.md>) | Markdown | LLMの抽象度評価 | <sub>2026-04-17</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260417_ハーネスエンジニアリングとは.md](<./research/m3e_data_structure_conversations/raw_conversations/260417_ハーネスエンジニアリングとは.md>) | Markdown | ハーネスエンジニアリングとは | <sub>2026-04-17</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260417_重要Resource管理のアプローチ.md](<./research/m3e_data_structure_conversations/raw_conversations/260417_重要Resource管理のアプローチ.md>) | Markdown | 【重要】Resource管理のアプローチ | <sub>2026-04-17</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260419_Cloud_Code_Agent_SDK.md](<./research/m3e_data_structure_conversations/raw_conversations/260419_Cloud_Code_Agent_SDK.md>) | Markdown | Cloud Code Agent SDK | <sub>2026-04-19</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260419_PJ遂行の仕組み.md](<./research/m3e_data_structure_conversations/raw_conversations/260419_PJ遂行の仕組み.md>) | Markdown | PJ遂行の仕組み | <sub>2026-04-19</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260419_数学書の解析と構造化.md](<./research/m3e_data_structure_conversations/raw_conversations/260419_数学書の解析と構造化.md>) | Markdown | 数学書の解析と構造化 | <sub>2026-04-19</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260420_ネットワーク同期とセキュリティ.md](<./research/m3e_data_structure_conversations/raw_conversations/260420_ネットワーク同期とセキュリティ.md>) | Markdown | ネットワーク同期とセキュリティ | <sub>2026-04-20</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260420_位相と埋め込みアルゴリズム.md](<./research/m3e_data_structure_conversations/raw_conversations/260420_位相と埋め込みアルゴリズム.md>) | Markdown | 位相と埋め込みアルゴリズム | <sub>2026-04-20</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260420_戦略立案の改善.md](<./research/m3e_data_structure_conversations/raw_conversations/260420_戦略立案の改善.md>) | Markdown | 戦略立案の改善 | <sub>2026-04-20</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260420_目標整理と最小化.md](<./research/m3e_data_structure_conversations/raw_conversations/260420_目標整理と最小化.md>) | Markdown | 目標整理と最小化 | <sub>2026-04-20</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260421_M3E威力の伝え方.md](<./research/m3e_data_structure_conversations/raw_conversations/260421_M3E威力の伝え方.md>) | Markdown | M3E威力の伝え方 | <sub>2026-04-21</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260421_PDFメタデータ分類法.md](<./research/m3e_data_structure_conversations/raw_conversations/260421_PDFメタデータ分類法.md>) | Markdown | PDFメタデータ分類法 | <sub>2026-04-21</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260421_SPReADとARiSEの違い.md](<./research/m3e_data_structure_conversations/raw_conversations/260421_SPReADとARiSEの違い.md>) | Markdown | SPReADとARiSEの違い | <sub>2026-04-21</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260421_オンボーディングワークフロー.md](<./research/m3e_data_structure_conversations/raw_conversations/260421_オンボーディングワークフロー.md>) | Markdown | オンボーディングワークフロー | <sub>2026-04-21</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260421_フラクタル性と物理現象.md](<./research/m3e_data_structure_conversations/raw_conversations/260421_フラクタル性と物理現象.md>) | Markdown | フラクタル性と物理現象 | <sub>2026-04-21</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260421_情報欠落検出問題.md](<./research/m3e_data_structure_conversations/raw_conversations/260421_情報欠落検出問題.md>) | Markdown | 情報欠落検出問題 | <sub>2026-04-21</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260422_GUI自動化_Playwright.md](<./research/m3e_data_structure_conversations/raw_conversations/260422_GUI自動化_Playwright.md>) | Markdown | GUI自動化 Playwright | <sub>2026-04-22</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260422_M3Eと数学的発見.md](<./research/m3e_data_structure_conversations/raw_conversations/260422_M3Eと数学的発見.md>) | Markdown | M3Eと数学的発見 | <sub>2026-04-22</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260422_数学研究と著作権.md](<./research/m3e_data_structure_conversations/raw_conversations/260422_数学研究と著作権.md>) | Markdown | 数学研究と著作権 | <sub>2026-04-22</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260422_研究計画とコスト分析.md](<./research/m3e_data_structure_conversations/raw_conversations/260422_研究計画とコスト分析.md>) | Markdown | 研究計画とコスト分析 | <sub>2026-04-22</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260423_M3Eによる数学書の読解.md](<./research/m3e_data_structure_conversations/raw_conversations/260423_M3Eによる数学書の読解.md>) | Markdown | M3Eによる数学書の読解 | <sub>2026-04-23</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260423_ハードウェアデータ基盤設計.md](<./research/m3e_data_structure_conversations/raw_conversations/260423_ハードウェアデータ基盤設計.md>) | Markdown | ハードウェアデータ基盤設計 | <sub>2026-04-23</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260424_認知資源の効率化と物理.md](<./research/m3e_data_structure_conversations/raw_conversations/260424_認知資源の効率化と物理.md>) | Markdown | 認知資源の効率化と物理 | <sub>2026-04-24</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260425_LLMマインドマップトポロジ.md](<./research/m3e_data_structure_conversations/raw_conversations/260425_LLMマインドマップトポロジ.md>) | Markdown | LLMマインドマップトポロジ | <sub>2026-04-25</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260425_MIOSMindmap_IO_Stack.md](<./research/m3e_data_structure_conversations/raw_conversations/260425_MIOSMindmap_IO_Stack.md>) | Markdown | MIOS（Mindmap I/O Stack) | <sub>2026-04-25</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260425_分類木自動生成手法.md](<./research/m3e_data_structure_conversations/raw_conversations/260425_分類木自動生成手法.md>) | Markdown | 分類木自動生成手法 | <sub>2026-04-25</sub> |
+| [research/m3e_data_structure_conversations/raw_conversations/260425_動的粒度制御能力.md](<./research/m3e_data_structure_conversations/raw_conversations/260425_動的粒度制御能力.md>) | Markdown | 動的粒度制御能力 | <sub>2026-04-25</sub> |
+| [research/m3e_data_structure_conversations/source_manifest.csv](<./research/m3e_data_structure_conversations/source_manifest.csv>) | CSV | source manifest | file,score,high_confidence,categories,hits,line_count,bytes,source_path,raw_copy |
+| [research/m3e_data_structure_conversations/source_manifest.md](<./research/m3e_data_structure_conversations/source_manifest.md>) | Markdown | Source Manifest | Source Manifest |
+| [research/ontology_data_structure.md](<./research/ontology_data_structure.md>) | Markdown | オントロジーとデータ構造 -- NTT Data 解説からの知見 | オントロジーとは「対象世界をどのように捉えた（概念化した）かを記述するもの」であり、 |
+| [research/ontology_scientific_research.md](<./research/ontology_scientific_research.md>) | Markdown | オントロジー x 科学研究 — 競合調査 & M3E 差別化設計 | 作成日: 2026-04-09 |
+| [research/README.md](<./research/README.md>) | Markdown | research/ | **役割**: M3E の基礎研究。データモデル・思考構造の理論的背景。 |
+
+### tasks - handoffs and task notes
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [tasks/handoff_20260604_1411_mapify-io-possibilities.md](<./tasks/handoff_20260604_1411_mapify-io-possibilities.md>) | Markdown | Handoff: Mapify I/O 機能の可能性 | 作成日時: 2026-06-04 14:11 JST |
+| [tasks/handoff_cloud_sync_conflict_resolution.md](<./tasks/handoff_cloud_sync_conflict_resolution.md>) | Markdown | Handoff: Cloud Sync 競合解決 — Merge Mode 実装 | Cloud Sync 競合時に GitHub-like な diff 表示 + node 単位マージ選択を実装する。 |
+| [tasks/handoff_cloud_sync_conflict_ui.md](<./tasks/handoff_cloud_sync_conflict_ui.md>) | Markdown | Handoff: Cloud Sync 競合UI改善 | Cloud Sync で競合 (conflict) が発生した際の UI を改善する。 |
+| [tasks/handoff_layout_refactor_pn_integration.md](<./tasks/handoff_layout_refactor_pn_integration.md>) | Markdown | Handoff: layout() 純関数化 + PN layout設定統合 | **日付**: 2026-06-16 |
+| [tasks/handoff_resource_design.md](<./tasks/handoff_resource_design.md>) | Markdown | Handoff: Resource 概念の設計 | M3E に「Resource」概念を導入する。 |
+| [tasks/handoff_template.md](<./tasks/handoff_template.md>) | Markdown | Handoff: {TOPIC} | {タスクの説明。何を実装/修正/調査するか。} |
+| [tasks/README.md](<./tasks/README.md>) | Markdown | tasks/ | **役割**: 具体 task と handoff の置き場。ロール間・セッション間の引き継ぎ場所。 |
+| [tasks/todo_by_role.md](<./tasks/todo_by_role.md>) | Markdown | MOVED | ロール別タスクは [../06_Operations/Todo_Pool.md](../06_Operations/Todo_Pool.md) の Owner フィールドに統合済み（2026-04-15）。 |
+
+### root - top-level docs files
+
+| File | Type | Title | Summary |
+|---|---:|---|---|
+| [freeplane利用について.txt](<./freeplane利用について.txt>) | Text | freeplane利用について | 当面の M3E は、独自エディタの開発を主目的としない。 |
+| [index.md](<./index.md>) | Markdown | M3E Documents Index | Generated content-oriented index for docs/. |
+| [log.md](<./log.md>) | Markdown | M3E Documents Log | このファイルは `docs/` の LLM Wiki 型運用ログである。ingest / organize / lint / query を時系列で追記する。 |
+| [README.md](<./README.md>) | Markdown | M3E Software Docs | このディレクトリは、M3E の思想・戦略・仕様・アーキテクチャ・運用・判断記録を置く場所である。 |
+| [無題のファイル.base](<./無題のファイル.base>) | Obsidian Bases | 無題のファイル | Obsidian Bases |
+| [無題のファイル.canvas](<./無題のファイル.canvas>) | Obsidian Canvas | 無題のファイル | Obsidian Canvas |

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,0 +1,16 @@
+# M3E Documents Log
+
+このファイルは `docs/` の LLM Wiki 型運用ログである。ingest / organize / lint / query を時系列で追記する。
+
+## [2026-06-27] ingest | LLM Wiki pattern
+
+- Source: `docs/ideas/260627_llm_wiki_pattern.md`
+- Action: 添付 Markdown を verbatim で stow した。
+- Promoted: `docs/06_Operations/LLM_Wiki_Schema.md`
+
+## [2026-06-27] organize | docs index bootstrap
+
+- Action: `docs/` 全体を content-oriented index で横断できるようにした。
+- Index: `docs/index.md`
+- Check: `node scripts/ops/check-docs-index.mjs --check`
+- Coverage: `docs/.obsidian/` と `.DS_Store` を除く `docs/` 配下のファイル。

--- a/scripts/ops/check-docs-index.mjs
+++ b/scripts/ops/check-docs-index.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const docsRoot = path.join(repoRoot, "docs");
+const indexPath = path.join(docsRoot, "index.md");
+
+const GROUP_LABELS = new Map([
+  ["00_Home", "00_Home - entry and current state"],
+  ["01_Vision", "01_Vision - principles, vision, strategy"],
+  ["03_Spec", "03_Spec - functional specifications"],
+  ["04_Architecture", "04_Architecture - implementation architecture"],
+  ["06_Operations", "06_Operations - operation rules and handoff"],
+  ["09_Decisions", "09_Decisions - ADR"],
+  ["_generated", "_generated - generated projections"],
+  ["competitive_research", "competitive_research - external tool research"],
+  ["daily", "daily - chronological work logs"],
+  ["for-akaghef", "for-akaghef - Akaghef-facing materials"],
+  ["ideas", "ideas - raw ideas and stowed notes"],
+  ["legacy", "legacy - historical designs"],
+  ["research", "research - source research and extracts"],
+  ["tasks", "tasks - handoffs and task notes"],
+  ["root", "root - top-level docs files"],
+]);
+
+const TYPE_LABELS = new Map([
+  [".base", "Obsidian Bases"],
+  [".canvas", "Obsidian Canvas"],
+  [".csv", "CSV"],
+  [".html", "HTML"],
+  [".jpg", "Image"],
+  [".jpeg", "Image"],
+  [".json", "JSON"],
+  [".md", "Markdown"],
+  [".mlx", "MATLAB Live Script"],
+  [".png", "Image"],
+  [".sql", "SQL"],
+  [".txt", "Text"],
+]);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(abs));
+    } else if (entry.isFile()) {
+      files.push(abs);
+    }
+  }
+  return files;
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}
+
+function shouldIgnore(rel) {
+  return rel.startsWith("docs/.obsidian/") || rel.endsWith("/.DS_Store") || rel === "docs/.DS_Store";
+}
+
+function docsFiles() {
+  const rels = walk(docsRoot)
+    .map((abs) => toPosix(path.relative(repoRoot, abs)))
+    .filter((rel) => !shouldIgnore(rel))
+  if (!rels.includes("docs/index.md")) {
+    rels.push("docs/index.md");
+  }
+  return rels.sort((a, b) => a.localeCompare(b, "en"));
+}
+
+function readStart(abs, limit = 65536) {
+  const fd = fs.openSync(abs, "r");
+  try {
+    const size = fs.statSync(abs).size;
+    const buffer = Buffer.alloc(Math.min(size, limit));
+    fs.readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.toString("utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function cleanText(value) {
+  return value
+    .replace(/\r/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\|/g, "\\|")
+    .trim();
+}
+
+function truncate(value, max = 120) {
+  const cleaned = cleanText(value);
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, max - 3)}...`;
+}
+
+function fallbackTitle(rel) {
+  return path.basename(rel, path.extname(rel)).replace(/[_-]+/g, " ");
+}
+
+function markdownTitleAndSummary(abs, rel) {
+  const text = readStart(abs);
+  const lines = text.split(/\n/);
+  const titleLine = lines.find((line) => /^#\s+/.test(line));
+  const title = titleLine ? titleLine.replace(/^#\s+/, "").trim() : fallbackTitle(rel);
+  let inFence = false;
+  let inFrontmatter = false;
+  let seenFrontmatterStart = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line === "---" && !seenFrontmatterStart) {
+      inFrontmatter = true;
+      seenFrontmatterStart = true;
+      continue;
+    }
+    if (line === "---" && inFrontmatter) {
+      inFrontmatter = false;
+      continue;
+    }
+    if (inFrontmatter) continue;
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (!line || line.startsWith("#") || line.startsWith("|") || line.startsWith("![")) continue;
+    if (/^[-*]\s+/.test(line)) continue;
+    return { title, summary: truncate(line) };
+  }
+  return { title, summary: title };
+}
+
+function titleAndSummary(rel) {
+  const abs = path.join(repoRoot, rel);
+  if (path.basename(rel) === "index.md" && groupFor(rel) === "root") {
+    return { title: "M3E Documents Index", summary: "Generated content-oriented index for docs/." };
+  }
+  if (!fs.existsSync(abs)) {
+    return { title: fallbackTitle(rel), summary: "File is expected in docs/." };
+  }
+  const ext = path.extname(rel).toLowerCase();
+  if (ext === ".md") return markdownTitleAndSummary(abs, rel);
+  if (ext === ".sql" || ext === ".txt" || ext === ".csv") {
+    const firstLine = readStart(abs, 8192)
+      .split(/\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return { title: fallbackTitle(rel), summary: truncate(firstLine || fallbackTitle(rel)) };
+  }
+  return { title: fallbackTitle(rel), summary: TYPE_LABELS.get(ext) || "File" };
+}
+
+function groupFor(rel) {
+  const withoutDocs = rel.slice("docs/".length);
+  const first = withoutDocs.split("/")[0];
+  return withoutDocs.includes("/") ? first : "root";
+}
+
+function typeFor(rel) {
+  return TYPE_LABELS.get(path.extname(rel).toLowerCase()) || "File";
+}
+
+function linkFor(rel) {
+  const label = rel.slice("docs/".length);
+  return `[${cleanText(label)}](<./${label}>)`;
+}
+
+function renderIndex() {
+  const files = docsFiles();
+  const groups = new Map();
+  for (const rel of files) {
+    const group = groupFor(rel);
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group).push(rel);
+  }
+
+  const lines = [];
+  lines.push("# M3E Documents Index");
+  lines.push("");
+  lines.push("This file is the content-oriented index for `docs/`. It is generated from the current file tree and maintained as the navigation layer described in `06_Operations/LLM_Wiki_Schema.md`.");
+  lines.push("");
+  lines.push("- Regenerate: `node scripts/ops/check-docs-index.mjs --write`");
+  lines.push("- Check: `node scripts/ops/check-docs-index.mjs --check`");
+  lines.push("- Coverage: all files under `docs/`, excluding `docs/.obsidian/` and `.DS_Store`");
+  lines.push(`- Indexed files: ${files.length}`);
+  lines.push("");
+  lines.push("## Reading Routes");
+  lines.push("");
+  lines.push("- Session bootstrap: `00_Home/Agent_Brief.md`, `00_Home/Current_Status.md`, `00_Home/Glossary.md`");
+  lines.push("- Current product direction: `00_Home/Home.md`, `00_Home/Objective.md`, `01_Vision/Strategy.md`");
+  lines.push("- Feature meaning: `03_Spec/` first, then `04_Architecture/`");
+  lines.push("- Operations and handoff: `06_Operations/`, then `tasks/`");
+  lines.push("- Raw ideas and research: `ideas/`, `research/`, `competitive_research/`, `legacy/`");
+  lines.push("");
+  lines.push("## Directory Catalog");
+  lines.push("");
+
+  const orderedGroups = [...groups.keys()].sort((a, b) => {
+    const ai = [...GROUP_LABELS.keys()].indexOf(a);
+    const bi = [...GROUP_LABELS.keys()].indexOf(b);
+    if (ai !== -1 || bi !== -1) return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    return a.localeCompare(b, "en");
+  });
+
+  for (const group of orderedGroups) {
+    const label = GROUP_LABELS.get(group) || group;
+    const rels = groups.get(group);
+    lines.push(`### ${label}`);
+    lines.push("");
+    lines.push("| File | Type | Title | Summary |");
+    lines.push("|---|---:|---|---|");
+    for (const rel of rels) {
+      const { title, summary } = titleAndSummary(rel);
+      lines.push(`| ${linkFor(rel)} | ${typeFor(rel)} | ${truncate(title, 80)} | ${summary} |`);
+    }
+    lines.push("");
+  }
+
+  while (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+const mode = process.argv[2] || "--check";
+const expected = renderIndex();
+
+if (mode === "--write") {
+  fs.writeFileSync(indexPath, expected);
+  console.log(`wrote ${path.relative(repoRoot, indexPath)}`);
+} else if (mode === "--check") {
+  const actual = fs.existsSync(indexPath) ? fs.readFileSync(indexPath, "utf8") : "";
+  if (actual !== expected) {
+    console.error("docs/index.md is stale. Run: node scripts/ops/check-docs-index.mjs --write");
+    process.exit(1);
+  }
+  console.log("docs/index.md is current");
+} else {
+  console.error("usage: node scripts/ops/check-docs-index.mjs [--check|--write]");
+  process.exit(2);
+}


### PR DESCRIPTION
## Summary
- stow the attached LLM Wiki markdown verbatim under docs/ideas
- add an M3E docs LLM Wiki schema plus docs/index.md and docs/log.md
- update docs README/rules and add a script to regenerate/check index coverage

## Checks
- node scripts/ops/check-docs-index.mjs --check
- node --check scripts/ops/check-docs-index.mjs
- git diff --check
- cmp attachment docs/ideas/260627_llm_wiki_pattern.md