### PR TITLE
add: edit tree parent-edge label with Alt+Enter

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -14984,6 +14984,27 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     return;
   }
 
+  if (event.altKey && event.key === "Enter") {
+    if (isTextEntryElement(event.target)) {
+      return;
+    }
+    const selected = getNode(viewState.selectedNodeId);
+    if (
+      !inlineEditor &&
+      !inlineEdgeLabelEditor &&
+      selected?.parentId &&
+      lastLayout &&
+      incomingTreeEdgeLabelLayout(selected.id)
+    ) {
+      event.preventDefault();
+      startIncomingEdgeLabelEdit(selected.id);
+      return;
+    }
+    event.preventDefault();
+    EnterScopeCommand();
+    return;
+  }
+
   if (event.key === "Enter") {
     event.preventDefault();
     startInlineEdit(viewState.selectedNodeId, { selectAll: event.shiftKey });
@@ -15111,12 +15132,6 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     return;
   }
 
-      if (event.altKey && event.key === "Enter") {
-        event.preventDefault();
-        EnterScopeCommand();
-        return;
-      }
-
   if (event.altKey && event.key.toLowerCase() === "e") {
     event.preventDefault();
     toggleEntityListPanel();
@@ -15171,7 +15186,7 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
 
   if (event.altKey && event.key.toLowerCase() === "l") {
     event.preventDefault();
-    editEdgeLabelForSelectedNode();
+    startIncomingEdgeLabelEdit();
     return;
   }
 
@@ -15283,12 +15298,6 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
   if (!event.ctrlKey && !event.metaKey && !event.altKey && event.shiftKey && event.key.toLowerCase() === "l") {
     event.preventDefault();
     applyMarkedLink();
-    return;
-  }
-
-  if (!event.ctrlKey && !event.metaKey && event.altKey && !event.shiftKey && event.key.toLowerCase() === "l") {
-    event.preventDefault();
-    startIncomingEdgeLabelEdit();
     return;
   }
 

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -676,10 +676,10 @@ test.describe("GraphLink via L / Shift+L", () => {
 });
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-// Alt+L: Incoming edge label editing
+// Alt+L / Alt+Enter: Incoming edge label editing
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-test.describe("Incoming edge label via Alt+L", () => {
+test.describe("Incoming edge label shortcuts", () => {
   test("Alt+L edits the selected node parent edge label", async ({ page }) => {
     await launchViewer(page);
     await focusBoard(page);
@@ -697,6 +697,26 @@ test.describe("Incoming edge label via Alt+L", () => {
     await waitForRender(page);
 
     await expect(page.locator("text.edge-label", { hasText: "blocks" })).toBeVisible();
+    await expectStatusContains(page, "Edge label updated.");
+  });
+
+  test("Alt+Enter edits the selected node parent edge label", async ({ page }) => {
+    await launchViewer(page);
+    await focusBoard(page);
+
+    await pressKey(page, "ArrowRight");
+    await pressKey(page, "ArrowDown");
+    await expectMetaContains(page, "selected: Child B");
+
+    await pressKey(page, "Alt+Enter");
+    const editor = page.locator("textarea.inline-edge-label-editor");
+    await expect(editor).toBeVisible();
+
+    await editor.fill("depends on");
+    await editor.press("Enter");
+    await waitForRender(page);
+
+    await expect(page.locator("text.edge-label", { hasText: "depends on" })).toBeVisible();
     await expectStatusContains(page, "Edge label updated.");
   });
 });

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -335,6 +335,7 @@
               <div class="cheatsheet-row"><kbd>Tab</kbd><span>Add child</span></div>
               <div class="cheatsheet-row"><kbd>Delete</kbd><span>Delete node</span></div>
               <div class="cheatsheet-row"><kbd>Ctrl+Enter</kbd><span>Next &amp; edit</span></div>
+              <div class="cheatsheet-row"><kbd>Alt+Enter</kbd> / <kbd>Alt+L</kbd><span>Edit edge label</span></div>
             </div>
             <div class="cheatsheet-group">
               <div class="cheatsheet-group-title">View</div>


### PR DESCRIPTION
## 概要
選択中ノードのツリー親エッジのラベル（`m3e:edge-label`）を **Alt+Enter** で編集できるようにする。Alt+L が使うのと同じインラインエディタを起動する。

## 変更内容
- `beta/src/browser/viewer.ts` — グローバル keydown ハンドラに Alt+Enter を追加。親を持つノードでは `startIncomingEdgeLabelEdit()` を起動（新規作成・編集の両対応）、ルート/未レイアウト時は既存の scope-entry にフォールスルー。あわせて Alt+L をインラインエディタへ統一し、到達不能だった重複 Alt+Enter / Alt+L ブロックを削除。
- `beta/viewer.html` — チートシートに `Alt+Enter / Alt+L → Edit edge label` を追加。
- `beta/tests/visual/shortcuts.spec.js` — Alt+Enter のテストを追加（describe を「Incoming edge label shortcuts」に改名）。

## テスト
- [x] `npm run typecheck`（全5 tsconfig）通過（exit 0）
- [x] `npm run build:browser` 成功
- [x] Playwright `shortcuts.spec.js -g "edge label"` → 2 passed（Alt+L + Alt+Enter）

🤖 Generated with [Claude Code](https://claude.com/claude-code)