### PR TITLE
feat(beta): run Progressive Navigation through Codex App Server

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -5574,7 +5574,7 @@ async function requestRapidMapifyOracleForSelectedNode(action: RapidGenerateActi
   if (!map || !viewState.selectedNodeId) {
     throw new Error("No node is selected.");
   }
-  const response = await fetch(`/api/maps/${encodeURIComponent(LOCAL_MAP_ID)}/rapid/mapify-oracle`, {
+  const response = await fetch(`/api/maps/${encodeURIComponent(LOCAL_MAP_ID)}/cas/pn-generate`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json; charset=utf-8",
@@ -5582,7 +5582,7 @@ async function requestRapidMapifyOracleForSelectedNode(action: RapidGenerateActi
     },
     body: JSON.stringify({
       workspaceId: WORKSPACE_ID,
-      agentId: "rapid-mapify-oracle",
+      agentId: "cas-pn-generate",
       selectedNodeId: viewState.selectedNodeId,
       opId: RAPID_MAPIFY_OP_BY_ACTION[action],
       action,
@@ -5591,7 +5591,7 @@ async function requestRapidMapifyOracleForSelectedNode(action: RapidGenerateActi
   });
   const result = await response.json().catch(() => ({}));
   if (!response.ok) {
-    throw new Error(String(result.error || "Rapid Mapify Oracle request failed."));
+    throw new Error(String(result.error || "CAS PN generation request failed."));
   }
   return result as RapidMapifyOracleApplyResponse;
 }
@@ -5857,7 +5857,7 @@ async function generateRapidActionForSelectedNode(
     }
     const added = result.added.length;
     const merged = result.merged.length;
-    const sourceLabel = "Mapify Oracle";
+    const sourceLabel = "CAS";
     if (added === 0 && merged === 0) {
       setStatus(`${sourceLabel} generated no new nodes: ${label || action}`);
       return;
@@ -5867,7 +5867,7 @@ async function generateRapidActionForSelectedNode(
     render();
     board.focus();
   } catch (err) {
-    setStatus(`Rapid generation failed: ${(err as Error).message}`, true);
+    setStatus(`CAS generation failed: ${(err as Error).message}`, true);
   }
 }
 

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -5584,6 +5584,7 @@ async function requestRapidMapifyOracleForSelectedNode(action: RapidGenerateActi
       workspaceId: WORKSPACE_ID,
       agentId: "cas-pn-generate",
       selectedNodeId: viewState.selectedNodeId,
+      scopeId: normalizedCurrentScopeId(),
       opId: RAPID_MAPIFY_OP_BY_ACTION[action],
       action,
       baseSavedAt: lastServerSavedAt,

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -5559,7 +5559,7 @@ interface RapidMapifyOracleApplyResponse {
   savedAt?: string;
   opId: string;
   action: RapidGenerateAction;
-  source: "mapify_teacher_fixture" | "m3e_local_mf_h_fallback";
+  source: "mapify_teacher_fixture" | "m3e_local_mf_h_fallback" | "codex_app_server";
   fragment: string;
   added: Array<{ id: string; parentId: string; label: string }>;
   merged: Array<{ id: string; parentId: string; label: string }>;

--- a/beta/src/node/codex_app_server.ts
+++ b/beta/src/node/codex_app_server.ts
@@ -8,27 +8,10 @@ export interface CodexProgressiveGenerationRequest {
   nodeDetails: string;
   ancestorLabels: string[];
   existingChildLabels: string[];
-  context: ProgressiveMapContext;
+  scopeAddress: string;
+  selectedAddress: string;
+  scopeMfH: string;
   cwd: string;
-}
-
-export interface ProgressiveMapContextNode {
-  id: string;
-  text: string;
-  details: string;
-  note: string;
-  attributes: Record<string, string>;
-  address: string;
-}
-
-export interface ProgressiveMapContext {
-  map: { id: string; rootLabel: string; address: string };
-  scope: ProgressiveMapContextNode;
-  selected: ProgressiveMapContextNode;
-  ancestors: ProgressiveMapContextNode[];
-  siblings: ProgressiveMapContextNode[];
-  existingChildren: ProgressiveMapContextNode[];
-  scopeOutline: string[];
 }
 
 export interface CodexProgressiveGenerationResult {
@@ -165,7 +148,14 @@ class JsonRpcProcess {
   }
 }
 
-export function parseCodexChildren(rawText: string): string[] {
+function relationFor(action: CodexProgressiveAction): string {
+  if (action === "examples") return "example_of";
+  if (action === "classify") return "subtype_of";
+  if (action === "related") return "related_to";
+  return "detail_of";
+}
+
+export function parseCodexChildren(rawText: string, action: CodexProgressiveAction): string[] {
   const trimmed = rawText.trim();
   const jsonText = trimmed.replace(/^```json\s*/i, "").replace(/\s*```$/, "");
   let parsed: unknown;
@@ -180,12 +170,13 @@ export function parseCodexChildren(rawText: string): string[] {
   if (!Array.isArray(values)) throw new Error("Codex App Server PN proposal must contain a children array.");
   const seen = new Set<string>();
   const children: string[] = [];
+  const expectedRelation = relationFor(action);
   for (const value of values) {
-    const text = typeof value === "string"
-      ? value.trim()
-      : (typeof value === "object" && value !== null && typeof (value as { text?: unknown }).text === "string"
-        ? (value as { text: string }).text.trim()
-        : "");
+    const item = typeof value === "object" && value !== null
+      ? value as { text?: unknown; relation?: unknown }
+      : null;
+    if (!item || item.relation !== expectedRelation) continue;
+    const text = typeof item.text === "string" ? item.text.trim() : "";
     if (!text || text.length > 160 || seen.has(text.toLocaleLowerCase())) continue;
     seen.add(text.toLocaleLowerCase());
     children.push(text);
@@ -195,27 +186,35 @@ export function parseCodexChildren(rawText: string): string[] {
   return children;
 }
 
+function completionTemplate(nodeText: string): string {
+  return [`# ${nodeText}`, "## ???", "## ???", "## ???", "## ???"].join("\n");
+}
+
 function promptFor(request: CodexProgressiveGenerationRequest): string {
   const actionInstruction: Record<CodexProgressiveAction, string> = {
-    detail: "選択 node を説明として詳細化する。分類・下位分類・構成要素の列挙にはしない。定義、識別できる特徴、理解の手掛かりのような説明 node を追加する。",
-    examples: "選択 node を理解する具体例を追加する。",
-    classify: "選択 node の互いに異なる子分類を追加する。",
-    related: "選択 node と直接関連し、次に検討すべき topic を追加する。",
+    detail: "選択 node の説明的な詳細を追加する。分類、具体例、関連topicへ置き換えない。relation は detail_of。",
+    examples: "選択 node を実例として具体化する固有または具体的なinstance/caseを追加する。特徴、定義、分類、言い換えは禁止。relation は example_of。",
+    classify: "選択 node の互いに異なる子分類を追加する。具体例や特徴は追加しない。relation は subtype_of。",
+    related: "選択 node と直接関連し、次に検討すべきtopicを追加する。分類や具体例にはしない。relation は related_to。",
   };
+  const expectedRelation = relationFor(request.action);
   return [
     "You are the generation runtime behind M3E Progressive Navigation.",
     "Do not use tools, do not inspect files, and do not modify anything.",
-    "Return exactly one JSON object and no markdown: {\"children\":[{\"text\":\"...\"}]}",
-    "Use Japanese. Return 3 to 6 concise child labels, each at most 60 characters.",
+    `Return exactly one JSON object and no markdown: {\"children\":[{\"text\":\"...\",\"relation\":\"${expectedRelation}\"}]}`,
+    "Use Japanese. Fill all four ??? slots with concise noun-phrase node labels, each at most 60 characters.",
     "Do not repeat existing children or ancestors. Do not include explanation.",
-    "Treat the following JSON as authoritative map context. Preserve the selected node's role, scope, and sibling granularity.",
-    "For N3/detail, never substitute N5/classification, N4/examples, or N6/related-topics output.",
+    "The MF-H scope is the authoritative semantic context. Preserve its hierarchy and granularity.",
+    "Only fill the ??? slots in the completion template. Do not rewrite the existing scope.",
     `Operation: ${actionInstruction[request.action]}`,
     `Selected node: ${request.nodeText}`,
+    `Selected address: ${request.selectedAddress}`,
+    `Scope address: ${request.scopeAddress}`,
     request.nodeDetails ? `Selected details: ${request.nodeDetails}` : "",
     request.ancestorLabels.length ? `Ancestors: ${request.ancestorLabels.join(" > ")}` : "",
     request.existingChildLabels.length ? `Existing children (do not repeat): ${request.existingChildLabels.join(", ")}` : "",
-    `Map context: ${JSON.stringify(request.context)}`,
+    `MF-H scope:\n${request.scopeMfH}`,
+    `MF-H completion template:\n${completionTemplate(request.nodeText)}`,
   ].filter(Boolean).join("\n");
 }
 
@@ -249,7 +248,7 @@ export async function generateProgressiveChildrenWithCodex(
         : "Codex App Server PN turn failed.");
     }
     const rawText = rpc.agentMessage(threadId, turnId);
-    return { threadId, turnId, rawText, children: parseCodexChildren(rawText) };
+    return { threadId, turnId, rawText, children: parseCodexChildren(rawText, request.action) };
   } finally {
     rpc.close();
   }

--- a/beta/src/node/codex_app_server.ts
+++ b/beta/src/node/codex_app_server.ts
@@ -8,7 +8,27 @@ export interface CodexProgressiveGenerationRequest {
   nodeDetails: string;
   ancestorLabels: string[];
   existingChildLabels: string[];
+  context: ProgressiveMapContext;
   cwd: string;
+}
+
+export interface ProgressiveMapContextNode {
+  id: string;
+  text: string;
+  details: string;
+  note: string;
+  attributes: Record<string, string>;
+  address: string;
+}
+
+export interface ProgressiveMapContext {
+  map: { id: string; rootLabel: string; address: string };
+  scope: ProgressiveMapContextNode;
+  selected: ProgressiveMapContextNode;
+  ancestors: ProgressiveMapContextNode[];
+  siblings: ProgressiveMapContextNode[];
+  existingChildren: ProgressiveMapContextNode[];
+  scopeOutline: string[];
 }
 
 export interface CodexProgressiveGenerationResult {
@@ -177,7 +197,7 @@ export function parseCodexChildren(rawText: string): string[] {
 
 function promptFor(request: CodexProgressiveGenerationRequest): string {
   const actionInstruction: Record<CodexProgressiveAction, string> = {
-    detail: "選択 node を理解可能な構成要素へ詳細化する。",
+    detail: "選択 node を説明として詳細化する。分類・下位分類・構成要素の列挙にはしない。定義、識別できる特徴、理解の手掛かりのような説明 node を追加する。",
     examples: "選択 node を理解する具体例を追加する。",
     classify: "選択 node の互いに異なる子分類を追加する。",
     related: "選択 node と直接関連し、次に検討すべき topic を追加する。",
@@ -188,11 +208,14 @@ function promptFor(request: CodexProgressiveGenerationRequest): string {
     "Return exactly one JSON object and no markdown: {\"children\":[{\"text\":\"...\"}]}",
     "Use Japanese. Return 3 to 6 concise child labels, each at most 60 characters.",
     "Do not repeat existing children or ancestors. Do not include explanation.",
+    "Treat the following JSON as authoritative map context. Preserve the selected node's role, scope, and sibling granularity.",
+    "For N3/detail, never substitute N5/classification, N4/examples, or N6/related-topics output.",
     `Operation: ${actionInstruction[request.action]}`,
     `Selected node: ${request.nodeText}`,
     request.nodeDetails ? `Selected details: ${request.nodeDetails}` : "",
     request.ancestorLabels.length ? `Ancestors: ${request.ancestorLabels.join(" > ")}` : "",
     request.existingChildLabels.length ? `Existing children (do not repeat): ${request.existingChildLabels.join(", ")}` : "",
+    `Map context: ${JSON.stringify(request.context)}`,
   ].filter(Boolean).join("\n");
 }
 

--- a/beta/src/node/codex_app_server.ts
+++ b/beta/src/node/codex_app_server.ts
@@ -1,0 +1,233 @@
+import { spawn } from "child_process";
+
+export type CodexProgressiveAction = "detail" | "examples" | "classify" | "related";
+
+export interface CodexProgressiveGenerationRequest {
+  action: CodexProgressiveAction;
+  nodeText: string;
+  nodeDetails: string;
+  ancestorLabels: string[];
+  existingChildLabels: string[];
+  cwd: string;
+}
+
+export interface CodexProgressiveGenerationResult {
+  threadId: string;
+  turnId: string;
+  children: string[];
+  rawText: string;
+}
+
+type JsonRpcMessage = {
+  id?: number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { message?: string };
+};
+
+class JsonRpcProcess {
+  private readonly child = spawn(process.env.M3E_CODEX_BIN || "codex", ["app-server", "--stdio"], {
+    cwd: process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  private nextId = 1;
+  private stdoutBuffer = "";
+  private stderr = "";
+  private readonly pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>();
+  private readonly notifications: JsonRpcMessage[] = [];
+  private readonly completedAgentMessages = new Map<string, string>();
+  private closed = false;
+
+  constructor() {
+    this.child.stdout.setEncoding("utf8");
+    this.child.stderr.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk: string) => this.onStdout(chunk));
+    this.child.stderr.on("data", (chunk: string) => { this.stderr += chunk; });
+    this.child.on("error", (error) => this.failAll(error));
+    this.child.on("exit", (code) => {
+      if (!this.closed) this.failAll(new Error(`Codex App Server exited before completion (code ${code ?? "unknown"}). ${this.stderr.trim()}`));
+    });
+  }
+
+  private onStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    let newline = this.stdoutBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (line) this.onLine(line);
+      newline = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  private onLine(line: string): void {
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+    if (typeof message.id === "number") {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || "Codex App Server returned an error."));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+    if (message.method === "item/completed") {
+      const params = message.params as { threadId?: unknown; turnId?: unknown; item?: { type?: unknown; text?: unknown } } | undefined;
+      if (typeof params?.threadId === "string" && typeof params.turnId === "string"
+        && params.item?.type === "agentMessage" && typeof params.item.text === "string") {
+        this.completedAgentMessages.set(`${params.threadId}:${params.turnId}`, params.item.text);
+      }
+    }
+    if (message.method) this.notifications.push(message);
+  }
+
+  request(method: string, params: unknown, timeoutMs = 30_000): Promise<unknown> {
+    if (this.closed) return Promise.reject(new Error("Codex App Server is closed."));
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Codex App Server timed out waiting for ${method}.`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => { clearTimeout(timer); resolve(value); },
+        reject: (error) => { clearTimeout(timer); reject(error); },
+      });
+      this.child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+    });
+  }
+
+  async waitForTurn(threadId: string, turnId: string, timeoutMs = 120_000): Promise<JsonRpcMessage> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const index = this.notifications.findIndex((message) => (
+        message.method === "turn/completed"
+        && typeof message.params === "object"
+        && message.params !== null
+        && (message.params as { threadId?: unknown }).threadId === threadId
+        && ((message.params as { turn?: { id?: unknown } }).turn?.id === turnId)
+      ));
+      if (index >= 0) return this.notifications.splice(index, 1)[0]!;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error("Codex App Server timed out waiting for generation to complete.");
+  }
+
+  agentMessage(threadId: string, turnId: string): string {
+    const text = this.completedAgentMessages.get(`${threadId}:${turnId}`);
+    if (!text) {
+      const methods = this.notifications.map((message) => message.method).filter(Boolean).join(", ");
+      const errors = this.notifications
+        .filter((message) => message.method === "error")
+        .map((message) => JSON.stringify(message.params))
+        .join(" | ");
+      throw new Error(`Codex App Server completed without an agent message. Notifications: ${methods || "none"}. ${errors}`);
+    }
+    return text;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.child.kill();
+  }
+
+  private failAll(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}
+
+export function parseCodexChildren(rawText: string): string[] {
+  const trimmed = rawText.trim();
+  const jsonText = trimmed.replace(/^```json\s*/i, "").replace(/\s*```$/, "");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    throw new Error("Codex App Server returned a non-JSON PN proposal.");
+  }
+  const values = Array.isArray(parsed)
+    ? parsed
+    : (typeof parsed === "object" && parsed !== null ? (parsed as { children?: unknown }).children : undefined);
+  if (!Array.isArray(values)) throw new Error("Codex App Server PN proposal must contain a children array.");
+  const seen = new Set<string>();
+  const children: string[] = [];
+  for (const value of values) {
+    const text = typeof value === "string"
+      ? value.trim()
+      : (typeof value === "object" && value !== null && typeof (value as { text?: unknown }).text === "string"
+        ? (value as { text: string }).text.trim()
+        : "");
+    if (!text || text.length > 160 || seen.has(text.toLocaleLowerCase())) continue;
+    seen.add(text.toLocaleLowerCase());
+    children.push(text);
+    if (children.length === 12) break;
+  }
+  if (children.length === 0) throw new Error("Codex App Server PN proposal contained no usable children.");
+  return children;
+}
+
+function promptFor(request: CodexProgressiveGenerationRequest): string {
+  const actionInstruction: Record<CodexProgressiveAction, string> = {
+    detail: "選択 node を理解可能な構成要素へ詳細化する。",
+    examples: "選択 node を理解する具体例を追加する。",
+    classify: "選択 node の互いに異なる子分類を追加する。",
+    related: "選択 node と直接関連し、次に検討すべき topic を追加する。",
+  };
+  return [
+    "You are the generation runtime behind M3E Progressive Navigation.",
+    "Do not use tools, do not inspect files, and do not modify anything.",
+    "Return exactly one JSON object and no markdown: {\"children\":[{\"text\":\"...\"}]}",
+    "Use Japanese. Return 3 to 6 concise child labels, each at most 60 characters.",
+    "Do not repeat existing children or ancestors. Do not include explanation.",
+    `Operation: ${actionInstruction[request.action]}`,
+    `Selected node: ${request.nodeText}`,
+    request.nodeDetails ? `Selected details: ${request.nodeDetails}` : "",
+    request.ancestorLabels.length ? `Ancestors: ${request.ancestorLabels.join(" > ")}` : "",
+    request.existingChildLabels.length ? `Existing children (do not repeat): ${request.existingChildLabels.join(", ")}` : "",
+  ].filter(Boolean).join("\n");
+}
+
+export async function generateProgressiveChildrenWithCodex(
+  request: CodexProgressiveGenerationRequest,
+): Promise<CodexProgressiveGenerationResult> {
+  const rpc = new JsonRpcProcess();
+  try {
+    await rpc.request("initialize", { clientInfo: { name: "m3e-progressive-navigation", version: "1" } });
+    const threadResponse = await rpc.request("thread/start", {
+      cwd: request.cwd,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+      baseInstructions: "You are a read-only structured proposal generator. Never use tools. Return only the exact format requested by the user.",
+    }) as { thread?: { id?: unknown } };
+    const threadId = typeof threadResponse.thread?.id === "string" ? threadResponse.thread.id : "";
+    if (!threadId) throw new Error("Codex App Server did not return a thread id.");
+    const turnResponse = await rpc.request("turn/start", {
+      threadId,
+      approvalPolicy: "never",
+      sandboxPolicy: { type: "readOnly", networkAccess: false },
+      input: [{ type: "text", text: promptFor(request) }],
+    }) as { turn?: { id?: unknown } };
+    const turnId = typeof turnResponse.turn?.id === "string" ? turnResponse.turn.id : "";
+    if (!turnId) throw new Error("Codex App Server did not return a turn id.");
+    const completed = await rpc.waitForTurn(threadId, turnId);
+    const completedTurn = (completed.params as { turn?: { status?: unknown; error?: { message?: unknown } } } | undefined)?.turn;
+    if (completedTurn?.status === "failed") {
+      throw new Error(typeof completedTurn.error?.message === "string"
+        ? completedTurn.error.message
+        : "Codex App Server PN turn failed.");
+    }
+    const rawText = rpc.agentMessage(threadId, turnId);
+    return { threadId, turnId, rawText, children: parseCodexChildren(rawText) };
+  } finally {
+    rpc.close();
+  }
+}

--- a/beta/src/node/codex_app_server.ts
+++ b/beta/src/node/codex_app_server.ts
@@ -17,9 +17,12 @@ export interface CodexProgressiveGenerationRequest {
 export interface CodexProgressiveGenerationResult {
   threadId: string;
   turnId: string;
+  model: string;
   children: string[];
   rawText: string;
 }
+
+export const CODEX_PN_MODEL = process.env.M3E_CODEX_PN_MODEL || "gpt-5.3-codex-spark";
 
 type JsonRpcMessage = {
   id?: number;
@@ -226,14 +229,21 @@ export async function generateProgressiveChildrenWithCodex(
     await rpc.request("initialize", { clientInfo: { name: "m3e-progressive-navigation", version: "1" } });
     const threadResponse = await rpc.request("thread/start", {
       cwd: request.cwd,
+      model: CODEX_PN_MODEL,
+      allowProviderModelFallback: false,
       approvalPolicy: "never",
       sandbox: "danger-full-access",
       baseInstructions: "You are a read-only structured proposal generator. Never use tools. Return only the exact format requested by the user.",
-    }) as { thread?: { id?: unknown } };
+    }) as { thread?: { id?: unknown }; model?: unknown };
     const threadId = typeof threadResponse.thread?.id === "string" ? threadResponse.thread.id : "";
     if (!threadId) throw new Error("Codex App Server did not return a thread id.");
+    const model = typeof threadResponse.model === "string" ? threadResponse.model : "";
+    if (model !== CODEX_PN_MODEL) {
+      throw new Error(`Codex App Server selected unexpected model: ${model || "unknown"}. Expected ${CODEX_PN_MODEL}.`);
+    }
     const turnResponse = await rpc.request("turn/start", {
       threadId,
+      model: CODEX_PN_MODEL,
       approvalPolicy: "never",
       sandboxPolicy: { type: "readOnly", networkAccess: false },
       input: [{ type: "text", text: promptFor(request) }],
@@ -248,7 +258,7 @@ export async function generateProgressiveChildrenWithCodex(
         : "Codex App Server PN turn failed.");
     }
     const rawText = rpc.agentMessage(threadId, turnId);
-    return { threadId, turnId, rawText, children: parseCodexChildren(rawText, request.action) };
+    return { threadId, turnId, model, rawText, children: parseCodexChildren(rawText, request.action) };
   } finally {
     rpc.close();
   }

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -3290,6 +3290,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
           "m3e:cas.operation": CAS_PN_OPERATION,
           "m3e:cas.thread_id": generation.threadId,
           "m3e:cas.turn_id": generation.turnId,
+          "m3e:cas.model": generation.model,
           "m3e:pn.action": action,
           "m3e:pn.op_id": opId,
           "m3e:pn.source": "codex_app_server",
@@ -3317,6 +3318,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
             operation: CAS_PN_OPERATION,
             threadId: generation.threadId,
             turnId: generation.turnId,
+            model: generation.model,
             committed: false,
           },
         });
@@ -3352,6 +3354,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
           operation: CAS_PN_OPERATION,
           threadId: generation.threadId,
           turnId: generation.turnId,
+          model: generation.model,
           committed: true,
         },
       });

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -23,8 +23,6 @@ import {
 import { getAiStatus, runAiSubagent } from "./ai_subagent";
 import {
   generateProgressiveChildrenWithCodex,
-  type ProgressiveMapContext,
-  type ProgressiveMapContextNode,
 } from "./codex_app_server";
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
 import {
@@ -881,10 +879,6 @@ function parseAgentMapRoute(urlPath: string): AgentMapRoute | null {
   const rapidMapifyMatch = pathname.match(/^\/api\/maps\/([^/]+)\/rapid\/mapify-oracle$/);
   if (rapidMapifyMatch) {
     return { kind: "rapid-mapify-oracle", mapId: decodeURIComponent(rapidMapifyMatch[1]!) };
-  }
-  const casPnGenerateMatch = pathname.match(/^\/api\/maps\/([^/]+)\/cas\/pn-generate$/);
-  if (casPnGenerateMatch) {
-    return { kind: "cas-pn-generate", mapId: decodeURIComponent(casPnGenerateMatch[1]!) };
   }
   return null;
 }
@@ -2801,19 +2795,6 @@ function progressiveNodeAddress(state: AppState, mapId: string, nodeId: string):
   return `M:(${mapId})> ${labels.join(" > ")}`;
 }
 
-function progressiveContextNode(state: AppState, mapId: string, nodeId: string): ProgressiveMapContextNode {
-  const node = state.nodes[nodeId];
-  if (!node) throw new Error(`Selected node not found: ${nodeId}`);
-  return {
-    id: node.id,
-    text: node.text,
-    details: node.details || "",
-    note: node.note || "",
-    attributes: { ...(node.attributes || {}) },
-    address: progressiveNodeAddress(state, mapId, nodeId),
-  };
-}
-
 function isDescendantOf(state: AppState, nodeId: string, ancestorId: string): boolean {
   let currentId: string | null = nodeId;
   while (currentId) {
@@ -2823,51 +2804,36 @@ function isDescendantOf(state: AppState, nodeId: string, ancestorId: string): bo
   return false;
 }
 
-function progressiveScopeOutline(state: AppState, scopeId: string, maxNodes = 120): string[] {
+function progressiveScopeMfH(state: AppState, scopeId: string, maxNodes = 120): string {
   const lines: string[] = [];
   const visit = (nodeId: string, depth: number): void => {
     if (lines.length >= maxNodes) return;
     const node = state.nodes[nodeId];
     if (!node) return;
-    const detail = node.details?.trim() ? ` — ${node.details.trim().slice(0, 240)}` : "";
-    lines.push(`${"  ".repeat(depth)}- ${node.text}${detail}`);
+    const label = node.text.replace(/[\r\n]+/g, " ").trim() || "(untitled)";
+    lines.push(`${"#".repeat(depth + 1)} ${label}`);
     for (const childId of node.children || []) visit(childId, depth + 1);
   };
   visit(scopeId, 0);
-  if (lines.length >= maxNodes) lines.push("… scope outline truncated at 120 nodes");
-  return lines;
+  if (lines.length >= maxNodes) lines.push("<!-- scope truncated at 120 nodes -->");
+  return lines.join("\n");
 }
 
-function progressiveMapContext(
+function progressiveScopeContext(
   state: AppState,
   mapId: string,
   selectedNodeId: string,
   requestedScopeId: string,
-): ProgressiveMapContext {
+): { scopeAddress: string; selectedAddress: string; scopeMfH: string } {
   const selected = state.nodes[selectedNodeId];
   if (!selected) throw new Error(`Selected node not found: ${selectedNodeId}`);
   const scopeId = requestedScopeId && state.nodes[requestedScopeId] && isDescendantOf(state, selectedNodeId, requestedScopeId)
     ? requestedScopeId
     : state.rootId;
-  const ancestorIds: string[] = [];
-  let ancestorId = selected.parentId;
-  while (ancestorId) {
-    ancestorIds.unshift(ancestorId);
-    ancestorId = state.nodes[ancestorId]?.parentId ?? null;
-  }
-  const parent = selected.parentId ? state.nodes[selected.parentId] : undefined;
   return {
-    map: {
-      id: mapId,
-      rootLabel: state.nodes[state.rootId]?.text || "",
-      address: `M:(${mapId})`,
-    },
-    scope: progressiveContextNode(state, mapId, scopeId),
-    selected: progressiveContextNode(state, mapId, selectedNodeId),
-    ancestors: ancestorIds.map((id) => progressiveContextNode(state, mapId, id)),
-    siblings: (parent?.children || []).filter((id) => id !== selectedNodeId).map((id) => progressiveContextNode(state, mapId, id)),
-    existingChildren: (selected.children || []).map((id) => progressiveContextNode(state, mapId, id)),
-    scopeOutline: progressiveScopeOutline(state, scopeId),
+    scopeAddress: progressiveNodeAddress(state, mapId, scopeId),
+    selectedAddress: progressiveNodeAddress(state, mapId, selectedNodeId),
+    scopeMfH: progressiveScopeMfH(state, scopeId),
   };
 }
 
@@ -3300,6 +3266,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
       agentActiveNodes.set(agentActiveNodeKey(workspaceId, route.mapId, agentId), activeNode);
 
       const selected = savedDoc.state.nodes[selectedNodeId]!;
+      const scopeContext = progressiveScopeContext(savedDoc.state, route.mapId, selectedNodeId, requestedScopeId);
       const generation = await generateProgressiveChildrenWithCodex({
         action,
         nodeText: selected.text,
@@ -3308,7 +3275,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
         existingChildLabels: (selected.children || [])
           .map((childId) => savedDoc.state.nodes[childId]?.text)
           .filter((label): label is string => Boolean(label)),
-        context: progressiveMapContext(savedDoc.state, route.mapId, selectedNodeId, requestedScopeId),
+        ...scopeContext,
         cwd: REPO_ROOT,
       });
       const fragment = labelsToMfH(generation.children);

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -856,7 +856,8 @@ type HomeRouteAction =
 type AgentMapRoute =
   | { kind: "agent-active-node"; mapId: string }
   | { kind: "append-mf-h"; mapId: string }
-  | { kind: "rapid-mapify-oracle"; mapId: string };
+  | { kind: "rapid-mapify-oracle"; mapId: string }
+  | { kind: "cas-pn-generate"; mapId: string };
 
 function parseAgentMapRoute(urlPath: string): AgentMapRoute | null {
   const pathname = new URL(urlPath, "http://localhost").pathname;
@@ -871,6 +872,10 @@ function parseAgentMapRoute(urlPath: string): AgentMapRoute | null {
   const rapidMapifyMatch = pathname.match(/^\/api\/maps\/([^/]+)\/rapid\/mapify-oracle$/);
   if (rapidMapifyMatch) {
     return { kind: "rapid-mapify-oracle", mapId: decodeURIComponent(rapidMapifyMatch[1]!) };
+  }
+  const casPnGenerateMatch = pathname.match(/^\/api\/maps\/([^/]+)\/cas\/pn-generate$/);
+  if (casPnGenerateMatch) {
+    return { kind: "cas-pn-generate", mapId: decodeURIComponent(casPnGenerateMatch[1]!) };
   }
   return null;
 }
@@ -2668,6 +2673,7 @@ interface MapifyTeacherDelta {
 }
 
 const RAPID_MAPIFY_ORACLE_AGENT_ID = "rapid-mapify-oracle";
+const CAS_PN_GENERATE_AGENT_ID = "cas-pn-generate";
 const RAPID_MAPIFY_ORACLE_ROOT = path.join(REPO_ROOT, "tools", "rapid_mapify_oracle");
 const BIOLOGY_RF1_TEACHER_DELTA = path.join(
   RAPID_MAPIFY_ORACLE_ROOT,
@@ -3126,6 +3132,153 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
       sendJson(res, err instanceof SyntaxError ? 400 : 400, {
         ok: false,
         error: err instanceof SyntaxError ? "Invalid JSON body." : ((err as Error).message || "Rapid Mapify Oracle failed."),
+      });
+      return true;
+    }
+  }
+
+  if (route.kind === "cas-pn-generate") {
+    if (req.method !== "POST") {
+      sendJson(res, 405, { ok: false, error: "Method not allowed." });
+      return true;
+    }
+    try {
+      const body = JSON.parse(await readRequestBody(req)) as Record<string, unknown>;
+      const workspaceId = requestWorkspaceId(url, body);
+      // Prefer explicit body/query agentId when provided; otherwise default to CAS PN agent.
+      const fromBodyAgentId = typeof body.agentId === "string" ? body.agentId.trim() : "";
+      const fromQueryAgentId = url.searchParams.get("agentId")?.trim() || "";
+      const agentId = fromBodyAgentId || fromQueryAgentId || CAS_PN_GENERATE_AGENT_ID;
+      const requestedOpId = typeof body.opId === "string" ? body.opId.trim() : "";
+      const action = normalizeRapidMapifyAction(body.action);
+      const explicitSelectedNodeId = typeof body.selectedNodeId === "string" ? body.selectedNodeId.trim() : "";
+      const active = agentActiveNodes.get(agentActiveNodeKey(workspaceId, route.mapId, agentId));
+      const selectedNodeId = explicitSelectedNodeId || active?.nodeId || "";
+      if (!selectedNodeId) {
+        sendJson(res, 400, { ok: false, error: "selectedNodeId is required when no agent active node is set." });
+        return true;
+      }
+
+      const savedDoc = RapidMvpModel.loadSavedMapFromSqlite(currentSqliteDbPath(), route.mapId);
+      const baseSavedAt = typeof body.baseSavedAt === "string" ? body.baseSavedAt : null;
+      if (baseSavedAt && savedDoc.savedAt !== baseSavedAt) {
+        sendJson(res, 409, {
+          ok: false,
+          code: "DOC_CONFLICT",
+          error: "Map changed externally. Refresh before running CAS PN generation.",
+          mapId: route.mapId,
+          savedAt: savedDoc.savedAt,
+        });
+        return true;
+      }
+      if (!savedDoc.state.nodes[selectedNodeId]) {
+        sendJson(res, 404, { ok: false, error: `Selected node not found: ${selectedNodeId}` });
+        return true;
+      }
+
+      const activeNode: AgentActiveNodeState = {
+        workspaceId,
+        mapId: route.mapId,
+        agentId,
+        nodeId: selectedNodeId,
+        updatedAt: new Date().toISOString(),
+      };
+      agentActiveNodes.set(agentActiveNodeKey(workspaceId, route.mapId, agentId), activeNode);
+
+      const fragment = resolveRapidMapifyFragment(savedDoc.state, selectedNodeId, action, requestedOpId);
+      const result = appendMfHNodesToParent(savedDoc.state, selectedNodeId, fragment.fragment);
+      const runId = `cas_pn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+      const generatedAt = new Date().toISOString();
+      for (const added of result.added) {
+        const node = savedDoc.state.nodes[added.id];
+        if (!node) continue;
+        node.attributes = {
+          ...(node.attributes ?? {}),
+          "m3e:generated_by": "cas",
+          "m3e:cas.operation": "pn-generate",
+          "m3e:cas.run_id": runId,
+          "m3e:pn.action": action,
+          "m3e:pn.op_id": fragment.opId,
+          "m3e:pn.source": fragment.source,
+          "m3e:generated_at": generatedAt,
+        };
+      }
+
+      const allResultLabels = [...result.added, ...result.merged].map((node) => node.label);
+      const teacherLabelSet = new Set(fragment.teacherLabels);
+      const teacherProximity = fragment.teacherLabels.length === 0
+        ? null
+        : allResultLabels.filter((label) => teacherLabelSet.has(label)).length / fragment.teacherLabels.length;
+
+      if (Boolean(body.dryRun)) {
+        sendJson(res, 200, {
+          ok: true,
+          dryRun: true,
+          kind: "cas-pn-generate",
+          mapId: route.mapId,
+          workspaceId,
+          activeNode,
+          opId: fragment.opId,
+          action: fragment.action,
+          source: fragment.source,
+          fragment: fragment.fragment,
+          added: result.added,
+          merged: result.merged,
+          diagnostics: fragment.diagnostics,
+          cas: {
+            service: "m3e-cas",
+            operation: "pn-generate",
+            runId,
+            committed: false,
+          },
+          oracle: {
+            teacherLabels: fragment.teacherLabels,
+            teacherProximity,
+          },
+        });
+        return true;
+      }
+
+      const model = RapidMvpModel.fromJSON(savedDoc.state);
+      const errors = model.validate();
+      if (errors.length > 0) {
+        sendJson(res, 400, { ok: false, error: `Invalid model before save: ${errors.join(" | ")}` });
+        return true;
+      }
+      model.saveToSqlite(currentSqliteDbPath(), route.mapId);
+      const savedAt = RapidMvpModel.loadSavedMapFromSqlite(currentSqliteDbPath(), route.mapId).savedAt;
+      broadcastMapUpdate(route.mapId, savedAt, sourceTabId);
+      handleMapSavedForVaultWatch(currentSqliteDbPath(), route.mapId);
+      sendJson(res, 200, {
+        ok: true,
+        kind: "cas-pn-generate",
+        mapId: route.mapId,
+        workspaceId,
+        activeNode,
+        savedAt,
+        opId: fragment.opId,
+        action: fragment.action,
+        source: fragment.source,
+        fragment: fragment.fragment,
+        added: result.added,
+        merged: result.merged,
+        diagnostics: fragment.diagnostics,
+        cas: {
+          service: "m3e-cas",
+          operation: "pn-generate",
+          runId,
+          committed: true,
+        },
+        oracle: {
+          teacherLabels: fragment.teacherLabels,
+          teacherProximity,
+        },
+      });
+      return true;
+    } catch (err) {
+      sendJson(res, err instanceof SyntaxError ? 400 : 400, {
+        ok: false,
+        error: err instanceof SyntaxError ? "Invalid JSON body." : ((err as Error).message || "CAS PN generation failed."),
       });
       return true;
     }

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -21,6 +21,7 @@ import {
   deleteConflictBackup,
 } from "./conflict_backup";
 import { getAiStatus, runAiSubagent } from "./ai_subagent";
+import { generateProgressiveChildrenWithCodex } from "./codex_app_server";
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
 import {
   COLLAB_ENABLED,
@@ -2674,6 +2675,7 @@ interface MapifyTeacherDelta {
 
 const RAPID_MAPIFY_ORACLE_AGENT_ID = "rapid-mapify-oracle";
 const CAS_PN_GENERATE_AGENT_ID = "cas-pn-generate";
+const CAS_PN_OPERATION = "pn-generate";
 const RAPID_MAPIFY_ORACLE_ROOT = path.join(REPO_ROOT, "tools", "rapid_mapify_oracle");
 const BIOLOGY_RF1_TEACHER_DELTA = path.join(
   RAPID_MAPIFY_ORACLE_ROOT,
@@ -2688,6 +2690,14 @@ function normalizeRapidMapifyAction(raw: unknown): RapidMapifyAction {
     return value;
   }
   return "detail";
+}
+
+function progressiveOperationId(action: RapidMapifyAction, requested: unknown): string {
+  if (typeof requested === "string" && requested.trim()) return requested.trim();
+  if (action === "examples") return "RF2.addExamples";
+  if (action === "classify") return "RF3.addSubtypes";
+  if (action === "related") return "RF6.addRelatedTopics";
+  return "RF1.expandSelectedNode";
 }
 
 function readJsonFile<T>(filePath: string): T {
@@ -2757,6 +2767,18 @@ function hasChildLabels(state: AppState, nodeId: string, labels: string[]): bool
       .filter((value): value is string => Boolean(value)),
   );
   return labels.every((label) => childLabels.has(label));
+}
+
+function ancestorLabels(state: AppState, nodeId: string): string[] {
+  const labels: string[] = [];
+  let currentId = state.nodes[nodeId]?.parentId ?? null;
+  while (currentId) {
+    const current = state.nodes[currentId];
+    if (!current) break;
+    labels.unshift(current.text);
+    currentId = current.parentId;
+  }
+  return labels;
 }
 
 function resolveRapidMapifyFragment(
@@ -3151,6 +3173,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
       const agentId = fromBodyAgentId || fromQueryAgentId || CAS_PN_GENERATE_AGENT_ID;
       const requestedOpId = typeof body.opId === "string" ? body.opId.trim() : "";
       const action = normalizeRapidMapifyAction(body.action);
+      const opId = progressiveOperationId(action, requestedOpId);
       const explicitSelectedNodeId = typeof body.selectedNodeId === "string" ? body.selectedNodeId.trim() : "";
       const active = agentActiveNodes.get(agentActiveNodeKey(workspaceId, route.mapId, agentId));
       const selectedNodeId = explicitSelectedNodeId || active?.nodeId || "";
@@ -3185,30 +3208,35 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
       };
       agentActiveNodes.set(agentActiveNodeKey(workspaceId, route.mapId, agentId), activeNode);
 
-      const fragment = resolveRapidMapifyFragment(savedDoc.state, selectedNodeId, action, requestedOpId);
-      const result = appendMfHNodesToParent(savedDoc.state, selectedNodeId, fragment.fragment);
-      const runId = `cas_pn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+      const selected = savedDoc.state.nodes[selectedNodeId]!;
+      const generation = await generateProgressiveChildrenWithCodex({
+        action,
+        nodeText: selected.text,
+        nodeDetails: selected.details || "",
+        ancestorLabels: ancestorLabels(savedDoc.state, selectedNodeId),
+        existingChildLabels: (selected.children || [])
+          .map((childId) => savedDoc.state.nodes[childId]?.text)
+          .filter((label): label is string => Boolean(label)),
+        cwd: REPO_ROOT,
+      });
+      const fragment = labelsToMfH(generation.children);
+      const result = appendMfHNodesToParent(savedDoc.state, selectedNodeId, fragment);
       const generatedAt = new Date().toISOString();
       for (const added of result.added) {
         const node = savedDoc.state.nodes[added.id];
         if (!node) continue;
         node.attributes = {
           ...(node.attributes ?? {}),
-          "m3e:generated_by": "cas",
-          "m3e:cas.operation": "pn-generate",
-          "m3e:cas.run_id": runId,
+          "m3e:generated_by": "codex-app-server",
+          "m3e:cas.operation": CAS_PN_OPERATION,
+          "m3e:cas.thread_id": generation.threadId,
+          "m3e:cas.turn_id": generation.turnId,
           "m3e:pn.action": action,
-          "m3e:pn.op_id": fragment.opId,
-          "m3e:pn.source": fragment.source,
+          "m3e:pn.op_id": opId,
+          "m3e:pn.source": "codex_app_server",
           "m3e:generated_at": generatedAt,
         };
       }
-
-      const allResultLabels = [...result.added, ...result.merged].map((node) => node.label);
-      const teacherLabelSet = new Set(fragment.teacherLabels);
-      const teacherProximity = fragment.teacherLabels.length === 0
-        ? null
-        : allResultLabels.filter((label) => teacherLabelSet.has(label)).length / fragment.teacherLabels.length;
 
       if (Boolean(body.dryRun)) {
         sendJson(res, 200, {
@@ -3218,22 +3246,19 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
           mapId: route.mapId,
           workspaceId,
           activeNode,
-          opId: fragment.opId,
-          action: fragment.action,
-          source: fragment.source,
-          fragment: fragment.fragment,
+          opId,
+          action,
+          source: "codex_app_server",
+          fragment,
           added: result.added,
           merged: result.merged,
-          diagnostics: fragment.diagnostics,
+          diagnostics: ["Generated by Codex App Server in read-only proposal mode."],
           cas: {
-            service: "m3e-cas",
-            operation: "pn-generate",
-            runId,
+            service: "codex-app-server",
+            operation: CAS_PN_OPERATION,
+            threadId: generation.threadId,
+            turnId: generation.turnId,
             committed: false,
-          },
-          oracle: {
-            teacherLabels: fragment.teacherLabels,
-            teacherProximity,
           },
         });
         return true;
@@ -3256,22 +3281,19 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
         workspaceId,
         activeNode,
         savedAt,
-        opId: fragment.opId,
-        action: fragment.action,
-        source: fragment.source,
-        fragment: fragment.fragment,
+        opId,
+        action,
+        source: "codex_app_server",
+        fragment,
         added: result.added,
         merged: result.merged,
-        diagnostics: fragment.diagnostics,
+        diagnostics: ["Generated by Codex App Server in read-only proposal mode."],
         cas: {
-          service: "m3e-cas",
-          operation: "pn-generate",
-          runId,
+          service: "codex-app-server",
+          operation: CAS_PN_OPERATION,
+          threadId: generation.threadId,
+          turnId: generation.turnId,
           committed: true,
-        },
-        oracle: {
-          teacherLabels: fragment.teacherLabels,
-          teacherProximity,
         },
       });
       return true;

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -21,7 +21,11 @@ import {
   deleteConflictBackup,
 } from "./conflict_backup";
 import { getAiStatus, runAiSubagent } from "./ai_subagent";
-import { generateProgressiveChildrenWithCodex } from "./codex_app_server";
+import {
+  generateProgressiveChildrenWithCodex,
+  type ProgressiveMapContext,
+  type ProgressiveMapContextNode,
+} from "./codex_app_server";
 import { getLinearTransformStatus, runLinearTransform } from "./linear_agent";
 import {
   COLLAB_ENABLED,
@@ -2773,12 +2777,94 @@ function ancestorLabels(state: AppState, nodeId: string): string[] {
   const labels: string[] = [];
   let currentId = state.nodes[nodeId]?.parentId ?? null;
   while (currentId) {
-    const current = state.nodes[currentId];
+    const current: TreeNode | undefined = state.nodes[currentId];
     if (!current) break;
     labels.unshift(current.text);
     currentId = current.parentId;
   }
   return labels;
+}
+
+function progressiveNodeAddress(state: AppState, mapId: string, nodeId: string): string {
+  const labels: string[] = [];
+  let currentId: string | null = nodeId;
+  while (currentId) {
+    const current: TreeNode | undefined = state.nodes[currentId];
+    if (!current) break;
+    labels.unshift(current.text);
+    currentId = current.parentId;
+  }
+  return `M:(${mapId})> ${labels.join(" > ")}`;
+}
+
+function progressiveContextNode(state: AppState, mapId: string, nodeId: string): ProgressiveMapContextNode {
+  const node = state.nodes[nodeId];
+  if (!node) throw new Error(`Selected node not found: ${nodeId}`);
+  return {
+    id: node.id,
+    text: node.text,
+    details: node.details || "",
+    note: node.note || "",
+    attributes: { ...(node.attributes || {}) },
+    address: progressiveNodeAddress(state, mapId, nodeId),
+  };
+}
+
+function isDescendantOf(state: AppState, nodeId: string, ancestorId: string): boolean {
+  let currentId: string | null = nodeId;
+  while (currentId) {
+    if (currentId === ancestorId) return true;
+    currentId = state.nodes[currentId]?.parentId ?? null;
+  }
+  return false;
+}
+
+function progressiveScopeOutline(state: AppState, scopeId: string, maxNodes = 120): string[] {
+  const lines: string[] = [];
+  const visit = (nodeId: string, depth: number): void => {
+    if (lines.length >= maxNodes) return;
+    const node = state.nodes[nodeId];
+    if (!node) return;
+    const detail = node.details?.trim() ? ` — ${node.details.trim().slice(0, 240)}` : "";
+    lines.push(`${"  ".repeat(depth)}- ${node.text}${detail}`);
+    for (const childId of node.children || []) visit(childId, depth + 1);
+  };
+  visit(scopeId, 0);
+  if (lines.length >= maxNodes) lines.push("… scope outline truncated at 120 nodes");
+  return lines;
+}
+
+function progressiveMapContext(
+  state: AppState,
+  mapId: string,
+  selectedNodeId: string,
+  requestedScopeId: string,
+): ProgressiveMapContext {
+  const selected = state.nodes[selectedNodeId];
+  if (!selected) throw new Error(`Selected node not found: ${selectedNodeId}`);
+  const scopeId = requestedScopeId && state.nodes[requestedScopeId] && isDescendantOf(state, selectedNodeId, requestedScopeId)
+    ? requestedScopeId
+    : state.rootId;
+  const ancestorIds: string[] = [];
+  let ancestorId = selected.parentId;
+  while (ancestorId) {
+    ancestorIds.unshift(ancestorId);
+    ancestorId = state.nodes[ancestorId]?.parentId ?? null;
+  }
+  const parent = selected.parentId ? state.nodes[selected.parentId] : undefined;
+  return {
+    map: {
+      id: mapId,
+      rootLabel: state.nodes[state.rootId]?.text || "",
+      address: `M:(${mapId})`,
+    },
+    scope: progressiveContextNode(state, mapId, scopeId),
+    selected: progressiveContextNode(state, mapId, selectedNodeId),
+    ancestors: ancestorIds.map((id) => progressiveContextNode(state, mapId, id)),
+    siblings: (parent?.children || []).filter((id) => id !== selectedNodeId).map((id) => progressiveContextNode(state, mapId, id)),
+    existingChildren: (selected.children || []).map((id) => progressiveContextNode(state, mapId, id)),
+    scopeOutline: progressiveScopeOutline(state, scopeId),
+  };
 }
 
 function resolveRapidMapifyFragment(
@@ -3174,6 +3260,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
       const requestedOpId = typeof body.opId === "string" ? body.opId.trim() : "";
       const action = normalizeRapidMapifyAction(body.action);
       const opId = progressiveOperationId(action, requestedOpId);
+      const requestedScopeId = typeof body.scopeId === "string" ? body.scopeId.trim() : "";
       const explicitSelectedNodeId = typeof body.selectedNodeId === "string" ? body.selectedNodeId.trim() : "";
       const active = agentActiveNodes.get(agentActiveNodeKey(workspaceId, route.mapId, agentId));
       const selectedNodeId = explicitSelectedNodeId || active?.nodeId || "";
@@ -3217,6 +3304,7 @@ async function handleAgentMapApi(req: http.IncomingMessage, res: http.ServerResp
         existingChildLabels: (selected.children || [])
           .map((childId) => savedDoc.state.nodes[childId]?.text)
           .filter((label): label is string => Boolean(label)),
+        context: progressiveMapContext(savedDoc.state, route.mapId, selectedNodeId, requestedScopeId),
         cwd: REPO_ROOT,
       });
       const fragment = labelsToMfH(generation.children);

--- a/beta/tests/unit/cas_pn_generate_api.test.js
+++ b/beta/tests/unit/cas_pn_generate_api.test.js
@@ -1,0 +1,105 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+let server;
+let baseUrl;
+let dataDir;
+let RapidMvpModel;
+
+async function requestJson(url, init) {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => ({}));
+  return { response, payload };
+}
+
+beforeAll(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-cas-pn-generate-"));
+  process.env.M3E_DATA_DIR = dataDir;
+  process.env.M3E_DB_FILE = "cas-pn-generate.sqlite";
+
+  const startViewerPath = require.resolve("../../dist/node/start_viewer.js");
+  delete require.cache[startViewerPath];
+  const { createAppServer } = require(startViewerPath);
+  ({ RapidMvpModel } = require("../../dist/node/rapid_mvp.js"));
+
+  server = createAppServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  delete process.env.M3E_DATA_DIR;
+  delete process.env.M3E_DB_FILE;
+  if (server) {
+    await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+  }
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+async function seedBiologyMap(mapId) {
+  const model = new RapidMvpModel("Root");
+  const fungusId = model.addNode(model.state.rootId, "菌類");
+  const animalId = model.addNode(model.state.rootId, "動物");
+  const first = await requestJson(`${baseUrl}/api/maps/${mapId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ state: model.toJSON() }),
+  });
+  expect(first.response.status).toBe(200);
+  expect(first.payload.savedAt).toEqual(expect.any(String));
+  return { rootId: model.state.rootId, fungusId, animalId, savedAt: first.payload.savedAt };
+}
+
+test("CAS PN generation appends selected-node children through CAS and persists CAS metadata", async () => {
+  const mapId = "cas-pn-generate-detail";
+  const seeded = await seedBiologyMap(mapId);
+
+  const cas = await requestJson(`${baseUrl}/api/maps/${mapId}/cas/pn-generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({
+      workspaceId: "ws-test",
+      selectedNodeId: seeded.fungusId,
+      action: "detail",
+      baseSavedAt: seeded.savedAt,
+    }),
+  });
+
+  expect(cas.response.status).toBe(200);
+  expect(cas.payload.ok).toBe(true);
+  expect(cas.payload.kind).toBe("cas-pn-generate");
+  expect(cas.payload.cas).toMatchObject({
+    service: "m3e-cas",
+    operation: "pn-generate",
+    committed: true,
+  });
+  expect(cas.payload.cas.runId).toEqual(expect.stringMatching(/^cas_pn_/));
+  expect(cas.payload.added.map((node) => node.label)).toEqual([
+    "光合成をしない",
+    "胞子で増える",
+    "菌糸を伸ばす",
+  ]);
+  expect(cas.payload.merged).toEqual([]);
+
+  const after = await requestJson(`${baseUrl}/api/maps/${mapId}`);
+  expect(after.response.status).toBe(200);
+  const fungus = after.payload.state.nodes[seeded.fungusId];
+  const childLabels = fungus.children.map((childId) => after.payload.state.nodes[childId].text);
+  expect(childLabels).toEqual(cas.payload.added.map((node) => node.label));
+
+  for (const added of cas.payload.added) {
+    const node = after.payload.state.nodes[added.id];
+    expect(node.attributes).toMatchObject({
+      "m3e:generated_by": "cas",
+      "m3e:cas.operation": "pn-generate",
+      "m3e:cas.run_id": cas.payload.cas.runId,
+      "m3e:pn.action": "detail",
+      "m3e:pn.op_id": "RF1.expandSelectedNode",
+      "m3e:pn.source": "m3e_local_mf_h_fallback",
+    });
+    expect(node.attributes["m3e:generated_at"]).toEqual(expect.any(String));
+  }
+});

--- a/beta/tests/unit/cas_pn_generate_api.test.js
+++ b/beta/tests/unit/cas_pn_generate_api.test.js
@@ -25,7 +25,7 @@ process.stdin.on("data", (chunk) => {
     if (line) {
       const request = JSON.parse(line);
       if (request.method === "initialize") process.stdout.write(JSON.stringify({ id: request.id, result: { ok: true } }) + "\\n");
-      if (request.method === "thread/start") process.stdout.write(JSON.stringify({ id: request.id, result: { thread: { id: "thread-cas-test" } } }) + "\\n");
+      if (request.method === "thread/start") process.stdout.write(JSON.stringify({ id: request.id, result: { thread: { id: "thread-cas-test" }, model: "gpt-5.3-codex-spark" } }) + "\\n");
       if (request.method === "turn/start") {
         if (process.env.M3E_CAS_CAPTURE_FILE) {
           require("node:fs").writeFileSync(process.env.M3E_CAS_CAPTURE_FILE, JSON.stringify(request.params));
@@ -131,6 +131,7 @@ test("CAS PN generation calls Codex App Server and persists its returned proposa
   });
   expect(cas.payload.cas.threadId).toBe("thread-cas-test");
   expect(cas.payload.cas.turnId).toBe("turn-cas-test");
+  expect(cas.payload.cas.model).toBe("gpt-5.3-codex-spark");
   expect(cas.payload.added.map((node) => node.label)).toEqual([
     "身体的特徴",
     "知能と社会性",
@@ -141,6 +142,7 @@ test("CAS PN generation calls Codex App Server and persists its returned proposa
 
   const capturedTurn = JSON.parse(fs.readFileSync(capturePath, "utf8"));
   const prompt = capturedTurn.input[0].text;
+  expect(capturedTurn.model).toBe("gpt-5.3-codex-spark");
   expect(prompt).toContain("MF-H scope:");
   expect(prompt).toContain("# Root");
   expect(prompt).toContain("## 菌類");
@@ -164,6 +166,7 @@ test("CAS PN generation calls Codex App Server and persists its returned proposa
       "m3e:cas.operation": "pn-generate",
       "m3e:cas.thread_id": "thread-cas-test",
       "m3e:cas.turn_id": "turn-cas-test",
+      "m3e:cas.model": "gpt-5.3-codex-spark",
       "m3e:pn.action": "detail",
       "m3e:pn.op_id": "RF1.expandSelectedNode",
       "m3e:pn.source": "codex_app_server",

--- a/beta/tests/unit/cas_pn_generate_api.test.js
+++ b/beta/tests/unit/cas_pn_generate_api.test.js
@@ -7,6 +7,7 @@ let server;
 let baseUrl;
 let dataDir;
 let RapidMvpModel;
+let parseCodexChildren;
 let fakeCodexPath;
 let capturePath;
 
@@ -30,8 +31,9 @@ process.stdin.on("data", (chunk) => {
           require("node:fs").writeFileSync(process.env.M3E_CAS_CAPTURE_FILE, JSON.stringify(request.params));
         }
         process.stdout.write(JSON.stringify({ id: request.id, result: { turn: { id: "turn-cas-test" } } }) + "\\n");
-        process.stdout.write(JSON.stringify({ method: "item/completed", params: { threadId: "thread-cas-test", turnId: "turn-cas-test", item: { type: "agentMessage", id: "item-cas-test", text: "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\"},{\\\"text\\\":\\\"知能と社会性\\\"},{\\\"text\\\":\\\"文化と技術\\\"}]}" } } }) + "\\n");
-        process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: "thread-cas-test", turn: { id: "turn-cas-test", status: "completed", items: [{ type: "agentMessage", id: "item-cas-test", text: "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\"},{\\\"text\\\":\\\"知能と社会性\\\"},{\\\"text\\\":\\\"文化と技術\\\"}]}" }] } } }) + "\\n");
+        const proposal = "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\",\\\"relation\\\":\\\"detail_of\\\"},{\\\"text\\\":\\\"知能と社会性\\\",\\\"relation\\\":\\\"detail_of\\\"},{\\\"text\\\":\\\"文化と技術\\\",\\\"relation\\\":\\\"detail_of\\\"},{\\\"text\\\":\\\"発達と生活\\\",\\\"relation\\\":\\\"detail_of\\\"}]}";
+        process.stdout.write(JSON.stringify({ method: "item/completed", params: { threadId: "thread-cas-test", turnId: "turn-cas-test", item: { type: "agentMessage", id: "item-cas-test", text: proposal } } }) + "\\n");
+        process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: "thread-cas-test", turn: { id: "turn-cas-test", status: "completed", items: [{ type: "agentMessage", id: "item-cas-test", text: proposal }] } } }) + "\\n");
       }
     }
     newline = buffer.indexOf("\\n");
@@ -60,11 +62,19 @@ beforeAll(async () => {
   delete require.cache[startViewerPath];
   const { createAppServer } = require(startViewerPath);
   ({ RapidMvpModel } = require("../../dist/node/rapid_mvp.js"));
+  ({ parseCodexChildren } = require("../../dist/node/codex_app_server.js"));
 
   server = createAppServer();
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
   baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test("CAS PN rejects a proposal whose relation does not match the action", () => {
+  expect(() => parseCodexChildren(
+    JSON.stringify({ children: [{ text: "言語を使う動物", relation: "detail_of" }] }),
+    "examples",
+  )).toThrow(/no usable children/);
 });
 
 afterAll(async () => {
@@ -125,18 +135,21 @@ test("CAS PN generation calls Codex App Server and persists its returned proposa
     "身体的特徴",
     "知能と社会性",
     "文化と技術",
+    "発達と生活",
   ]);
   expect(cas.payload.merged).toEqual([]);
 
   const capturedTurn = JSON.parse(fs.readFileSync(capturePath, "utf8"));
   const prompt = capturedTurn.input[0].text;
-  expect(prompt).toContain("Map context:");
-  expect(prompt).toContain('"scope"');
+  expect(prompt).toContain("MF-H scope:");
+  expect(prompt).toContain("# Root");
+  expect(prompt).toContain("## 菌類");
+  expect(prompt).toContain("## 動物");
+  expect(prompt).not.toContain('"attributes"');
   expect(prompt).toContain("M:(cas-pn-generate-detail)> Root");
-  expect(prompt).toContain("生物分類の検証 scope。");
+  expect(prompt).toContain("MF-H completion template:\n# 菌類\n## ???");
   expect(prompt).toContain("胞子で増える生物群。");
-  expect(prompt).toContain("動物");
-  expect(prompt).toContain("never substitute N5/classification");
+  expect(prompt).toContain('"relation":"detail_of"');
 
   const after = await requestJson(`${baseUrl}/api/maps/${mapId}`);
   expect(after.response.status).toBe(200);

--- a/beta/tests/unit/cas_pn_generate_api.test.js
+++ b/beta/tests/unit/cas_pn_generate_api.test.js
@@ -8,6 +8,7 @@ let baseUrl;
 let dataDir;
 let RapidMvpModel;
 let fakeCodexPath;
+let capturePath;
 
 function writeFakeCodex() {
   fakeCodexPath = path.join(dataDir, "fake-codex.js");
@@ -25,6 +26,9 @@ process.stdin.on("data", (chunk) => {
       if (request.method === "initialize") process.stdout.write(JSON.stringify({ id: request.id, result: { ok: true } }) + "\\n");
       if (request.method === "thread/start") process.stdout.write(JSON.stringify({ id: request.id, result: { thread: { id: "thread-cas-test" } } }) + "\\n");
       if (request.method === "turn/start") {
+        if (process.env.M3E_CAS_CAPTURE_FILE) {
+          require("node:fs").writeFileSync(process.env.M3E_CAS_CAPTURE_FILE, JSON.stringify(request.params));
+        }
         process.stdout.write(JSON.stringify({ id: request.id, result: { turn: { id: "turn-cas-test" } } }) + "\\n");
         process.stdout.write(JSON.stringify({ method: "item/completed", params: { threadId: "thread-cas-test", turnId: "turn-cas-test", item: { type: "agentMessage", id: "item-cas-test", text: "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\"},{\\\"text\\\":\\\"知能と社会性\\\"},{\\\"text\\\":\\\"文化と技術\\\"}]}" } } }) + "\\n");
         process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: "thread-cas-test", turn: { id: "turn-cas-test", status: "completed", items: [{ type: "agentMessage", id: "item-cas-test", text: "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\"},{\\\"text\\\":\\\"知能と社会性\\\"},{\\\"text\\\":\\\"文化と技術\\\"}]}" }] } } }) + "\\n");
@@ -49,6 +53,8 @@ beforeAll(async () => {
   process.env.M3E_DATA_DIR = dataDir;
   process.env.M3E_DB_FILE = "cas-pn-generate.sqlite";
   process.env.M3E_CODEX_BIN = fakeCodexPath;
+  capturePath = path.join(dataDir, "codex-turn.json");
+  process.env.M3E_CAS_CAPTURE_FILE = capturePath;
 
   const startViewerPath = require.resolve("../../dist/node/start_viewer.js");
   delete require.cache[startViewerPath];
@@ -65,6 +71,7 @@ afterAll(async () => {
   delete process.env.M3E_DATA_DIR;
   delete process.env.M3E_DB_FILE;
   delete process.env.M3E_CODEX_BIN;
+  delete process.env.M3E_CAS_CAPTURE_FILE;
   if (server) {
     await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
   }
@@ -73,8 +80,11 @@ afterAll(async () => {
 
 async function seedBiologyMap(mapId) {
   const model = new RapidMvpModel("Root");
+  model.state.nodes[model.state.rootId].details = "生物分類の検証 scope。";
+  model.state.nodes[model.state.rootId].attributes = { "m3e:display-role": "experiment-scope" };
   const fungusId = model.addNode(model.state.rootId, "菌類");
   const animalId = model.addNode(model.state.rootId, "動物");
+  model.state.nodes[fungusId].details = "胞子で増える生物群。";
   const first = await requestJson(`${baseUrl}/api/maps/${mapId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8" },
@@ -95,6 +105,7 @@ test("CAS PN generation calls Codex App Server and persists its returned proposa
     body: JSON.stringify({
       workspaceId: "ws-test",
       selectedNodeId: seeded.fungusId,
+      scopeId: seeded.rootId,
       action: "detail",
       baseSavedAt: seeded.savedAt,
     }),
@@ -116,6 +127,16 @@ test("CAS PN generation calls Codex App Server and persists its returned proposa
     "文化と技術",
   ]);
   expect(cas.payload.merged).toEqual([]);
+
+  const capturedTurn = JSON.parse(fs.readFileSync(capturePath, "utf8"));
+  const prompt = capturedTurn.input[0].text;
+  expect(prompt).toContain("Map context:");
+  expect(prompt).toContain('"scope"');
+  expect(prompt).toContain("M:(cas-pn-generate-detail)> Root");
+  expect(prompt).toContain("生物分類の検証 scope。");
+  expect(prompt).toContain("胞子で増える生物群。");
+  expect(prompt).toContain("動物");
+  expect(prompt).toContain("never substitute N5/classification");
 
   const after = await requestJson(`${baseUrl}/api/maps/${mapId}`);
   expect(after.response.status).toBe(200);

--- a/beta/tests/unit/cas_pn_generate_api.test.js
+++ b/beta/tests/unit/cas_pn_generate_api.test.js
@@ -7,6 +7,35 @@ let server;
 let baseUrl;
 let dataDir;
 let RapidMvpModel;
+let fakeCodexPath;
+
+function writeFakeCodex() {
+  fakeCodexPath = path.join(dataDir, "fake-codex.js");
+  fs.writeFileSync(fakeCodexPath, `#!${process.execPath}
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline = buffer.indexOf("\\n");
+  while (newline >= 0) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (line) {
+      const request = JSON.parse(line);
+      if (request.method === "initialize") process.stdout.write(JSON.stringify({ id: request.id, result: { ok: true } }) + "\\n");
+      if (request.method === "thread/start") process.stdout.write(JSON.stringify({ id: request.id, result: { thread: { id: "thread-cas-test" } } }) + "\\n");
+      if (request.method === "turn/start") {
+        process.stdout.write(JSON.stringify({ id: request.id, result: { turn: { id: "turn-cas-test" } } }) + "\\n");
+        process.stdout.write(JSON.stringify({ method: "item/completed", params: { threadId: "thread-cas-test", turnId: "turn-cas-test", item: { type: "agentMessage", id: "item-cas-test", text: "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\"},{\\\"text\\\":\\\"知能と社会性\\\"},{\\\"text\\\":\\\"文化と技術\\\"}]}" } } }) + "\\n");
+        process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: "thread-cas-test", turn: { id: "turn-cas-test", status: "completed", items: [{ type: "agentMessage", id: "item-cas-test", text: "{\\\"children\\\":[{\\\"text\\\":\\\"身体的特徴\\\"},{\\\"text\\\":\\\"知能と社会性\\\"},{\\\"text\\\":\\\"文化と技術\\\"}]}" }] } } }) + "\\n");
+      }
+    }
+    newline = buffer.indexOf("\\n");
+  }
+});
+`);
+  fs.chmodSync(fakeCodexPath, 0o755);
+}
 
 async function requestJson(url, init) {
   const response = await fetch(url, init);
@@ -16,8 +45,10 @@ async function requestJson(url, init) {
 
 beforeAll(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-cas-pn-generate-"));
+  writeFakeCodex();
   process.env.M3E_DATA_DIR = dataDir;
   process.env.M3E_DB_FILE = "cas-pn-generate.sqlite";
+  process.env.M3E_CODEX_BIN = fakeCodexPath;
 
   const startViewerPath = require.resolve("../../dist/node/start_viewer.js");
   delete require.cache[startViewerPath];
@@ -33,6 +64,7 @@ beforeAll(async () => {
 afterAll(async () => {
   delete process.env.M3E_DATA_DIR;
   delete process.env.M3E_DB_FILE;
+  delete process.env.M3E_CODEX_BIN;
   if (server) {
     await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
   }
@@ -53,7 +85,7 @@ async function seedBiologyMap(mapId) {
   return { rootId: model.state.rootId, fungusId, animalId, savedAt: first.payload.savedAt };
 }
 
-test("CAS PN generation appends selected-node children through CAS and persists CAS metadata", async () => {
+test("CAS PN generation calls Codex App Server and persists its returned proposal", async () => {
   const mapId = "cas-pn-generate-detail";
   const seeded = await seedBiologyMap(mapId);
 
@@ -72,15 +104,16 @@ test("CAS PN generation appends selected-node children through CAS and persists 
   expect(cas.payload.ok).toBe(true);
   expect(cas.payload.kind).toBe("cas-pn-generate");
   expect(cas.payload.cas).toMatchObject({
-    service: "m3e-cas",
+    service: "codex-app-server",
     operation: "pn-generate",
     committed: true,
   });
-  expect(cas.payload.cas.runId).toEqual(expect.stringMatching(/^cas_pn_/));
+  expect(cas.payload.cas.threadId).toBe("thread-cas-test");
+  expect(cas.payload.cas.turnId).toBe("turn-cas-test");
   expect(cas.payload.added.map((node) => node.label)).toEqual([
-    "光合成をしない",
-    "胞子で増える",
-    "菌糸を伸ばす",
+    "身体的特徴",
+    "知能と社会性",
+    "文化と技術",
   ]);
   expect(cas.payload.merged).toEqual([]);
 
@@ -93,12 +126,13 @@ test("CAS PN generation appends selected-node children through CAS and persists 
   for (const added of cas.payload.added) {
     const node = after.payload.state.nodes[added.id];
     expect(node.attributes).toMatchObject({
-      "m3e:generated_by": "cas",
+      "m3e:generated_by": "codex-app-server",
       "m3e:cas.operation": "pn-generate",
-      "m3e:cas.run_id": cas.payload.cas.runId,
+      "m3e:cas.thread_id": "thread-cas-test",
+      "m3e:cas.turn_id": "turn-cas-test",
       "m3e:pn.action": "detail",
       "m3e:pn.op_id": "RF1.expandSelectedNode",
-      "m3e:pn.source": "m3e_local_mf_h_fallback",
+      "m3e:pn.source": "codex_app_server",
     });
     expect(node.attributes["m3e:generated_at"]).toEqual(expect.any(String));
   }

--- a/idea/20_ai/cas_m3e_copilot/README.md
+++ b/idea/20_ai/cas_m3e_copilot/README.md
@@ -1,0 +1,171 @@
+# M3E × Codex App Server — Scope-aware Copilot
+
+更新: 2026-07-12  
+状態: 会話ログからの設計整理。確定事項と将来案を分離する。
+
+## 目的
+
+M3E の map を操作面かつ正本として維持し、その背後で Codex App Server（CAS）が scope-aware な常駐知能として働く状態を作る。Progressive Navigation（PN）は、この知能を呼び出す操作面の一つである。
+
+## 今回確認できたこと
+
+- M3E の PN 操作から `codex app-server --stdio` の `thread/start` / `turn/start` を実行し、提案を map へ反映できる。
+- CAS の `threadId` / `turnId` を生成 node の provenance として保存できる。
+- Mapify fixture や固定ローカル生成を使わず、CAS の実 turn で生成できる。
+- 現在の PR #72 は、操作ごとに CAS process と thread を作って終了する on-demand 実装であり、常駐化はまだ行っていない。
+
+## 確定した設計判断
+
+### Host と正本
+
+- M3E が host であり、map / scope / viewer / SQLite / operation command を所有する。
+- CAS は M3E の子 server（常駐 sidecar）として扱う。
+- CAS thread は cache であり、正本ではない。map が唯一の正本である。
+- CAS が停止しても、M3E は通常の map editor として利用できる。
+
+### AI Mode
+
+```text
+AI Mode OFF
+└─ CAS停止。通常のmap編集のみ。
+
+AI Mode ON
+└─ M3E host
+   └─ 常駐CAS子server
+      └─ userが開いているscopeを追跡
+         ├─ contextをprewarm/cache
+         ├─変更差分を監視
+         ├─操作候補をBGで検討
+         └─user操作時に提案
+```
+
+- 「常に考えるが、勝手に書かない」を基本境界とする。
+- scope 移動時に context を prewarm する。
+- node 選択時に PN 候補を background で準備する。
+- map 更新時は debounce し、revision が古い候補を破棄する。
+- map への commit は user の選択または明示 approval 後だけ行う。
+- thread の基本 key は `workspaceId + mapId + scopeId` とする。
+- 複数 tab では focused tab の scope を active context とする。
+
+想定状態:
+
+```text
+OFF / WARMING / WATCHING / THINKING / READY / STALE / ERROR
+```
+
+## Context 表現
+
+### 今回の PN
+
+単純な scope の階層・粒度・局所派生には MF-H を使う。AppState JSON を丸ごと prompt へ渡さない。
+
+```text
+# test1
+## 動物
+### 哺乳類
+#### ヒト
+#### イヌ
+#### クジラ
+```
+
+理由:
+
+- MF-H は階層の token 効率がよい。
+- JSON の反復 key、空 field、ID、style attribute は、局所的な意味生成にはノイズが多い。
+- map API の正本レスポンスは JSON のまま維持し、CAS 入力時に deterministic に MF-H へ射影する。
+
+### JSON へ昇格する条件
+
+次を正確に扱う場合は JSON または同等の構造表現へ昇格する。
+
+- node ID による厳密な書き戻し
+- alias / GraphLink / 非木構造
+- 複数 scope
+- metadata を判断材料として使う操作
+- field-level mutation
+- 複雑な validation
+
+## PN 生成パターン
+
+CAS に自由な木生成をさせず、現在 scope から MF-H completion template を機械生成し、生成対象だけを `???` にする。
+
+```text
+# ヒト
+## ???
+## ???
+## ???
+## ???
+```
+
+CAS は既存 scope を書き換えず、slot だけを埋める。response は小さい構造化 JSON とし、操作ごとの relation を検証してから map へ適用する。
+
+```json
+{
+  "children": [
+    { "text": "...", "relation": "example_of" }
+  ]
+}
+```
+
+## 操作契約
+
+今回の PR では prompt 内の最小契約と relation 検証まで行う。将来は N3〜N6 を YAML 正本へ分離する。
+
+```yaml
+operation: N4.examples
+target: selected_node
+input_projection: mf-h
+slots:
+  count: 4
+  relation: example_of
+constraints:
+  fill_slots_only: true
+  preserve_existing: true
+  forbid:
+    - property
+    - definition
+    - classification
+    - paraphrase
+```
+
+YAML は意味契約、MF-H は構造 template、CAS は穴埋め、M3E は validation と commit を担当する。
+
+## 失敗から得たこと
+
+`ヒト` に N3 / N4 を実行した際、次のような不整合が発生した。
+
+- `身体の構造 / 生命維持機能 / 感覚と運動` のように、N3 と分類・構成要素が混ざった。
+- N4 で `二足歩行する霊長類 / 言語を使う動物` のように、具体例ではなく特徴・言い換えが生成された。
+- context JSON を増やしても、操作の意味契約が弱ければ品質は上がらなかった。
+- `preserve sibling granularity` のような一般指示だけでは、親子 edge の意味を決められなかった。
+
+結論: context の量ではなく、操作ごとの relation、禁止事項、slot、validation が必要である。
+
+## 未決事項
+
+- `N4.examples` で抽象概念の instance を何とみなすか。曖昧時に clarification を返す契約。
+- `N6.related` を tree child として保存するか、GraphLink にするか。
+- YAML contract の配置、schema、versioning。
+- background turn の費用・頻度・cancel policy。
+- thread 再利用時の compaction、TTL、最大 cache 数。
+- MF-H から JSON へ昇格する complexity threshold。
+
+## PR #72 の境界
+
+含む:
+
+- M3E PN から実 CAS turn を実行する経路
+- CAS provenance の保存
+- scope の MF-H 射影
+- `???` completion template
+- N3〜N6 の最小 action contract と relation 検証
+- API / build / 実 CAS dry-run の検証
+
+含まない:
+
+- AI Mode UI
+- CAS process の常駐化
+- scope watcher / background generation
+- YAML contract runtime
+- thread cache
+


### PR DESCRIPTION
## Summary
- Run N3-N6 Progressive Navigation generation through a real `codex app-server --stdio` thread/turn.
- Keep M3E as the host and map as the source of truth; CAS currently runs on-demand as a child process.
- Project the active scope to token-efficient MF-H instead of sending AppState/metadata JSON.
- Provide a deterministic MF-H `???` completion template and require action-specific relations (`detail_of`, `example_of`, `subtype_of`, `related_to`).
- Persist CAS thread/turn provenance on generated nodes and retain conflict-safe `baseSavedAt` handling.
- Stow the conversation decisions, ideas, failure evidence, and future resident AI Mode design under `idea/20_ai/cas_m3e_copilot/README.md`.

## Scope boundary
Included: on-demand CAS PN path, MF-H context/template, minimal action contract, relation validation, provenance, tests.

Deferred: resident CAS child server, AI Mode UI, scope watcher/background generation, thread cache, YAML contract runtime.

## Verification
- [x] `npm --prefix beta run build:test`
- [x] `npm --prefix beta exec vitest run tests/unit/cas_pn_generate_api.test.js` (2 tests)
- [x] `npm --prefix beta run build`
- [x] `git diff --check`
- [x] Real CAS dry-run for `ヒト -> N4 例を追加` returned named instances: `織田信長`, `紫式部`, `マリー・キュリー`, `アインシュタイン`
- [x] Verified the real CAS prompt contains MF-H scope plus the `???` template and no attributes JSON
