### PR TITLE
feat(beta): add runtime board video reproduction

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -15,6 +15,8 @@
     "lab:edge-port": "vite --host 127.0.0.1 --config vite.config.mjs",
     "lab:node": "vite --host 127.0.0.1 --port 14274 --config vite.config.mjs",
     "lab:pn": "vite --host 127.0.0.1 --port 14275 --config vite.config.mjs",
+    "lab:runtime-board": "vite --host 127.0.0.1 --port 14276 --config vite.config.mjs",
+    "test:runtime-board": "playwright test --config playwright.runtime-board.config.js",
     "test:node": "npm run build:test && npx vitest run tests/unit/node_draw_*.test.* && playwright test --config playwright.node-lab.config.js",
     "test:layout": "npm run build:test && npx vitest run tests/unit/layout_*.test.*",
     "layout:capture": "npm run build:node && node dist/node/layout_capture.js",

--- a/beta/playwright.runtime-board.config.js
+++ b/beta/playwright.runtime-board.config.js
@@ -1,0 +1,34 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+const PORT = process.env.M3E_RUNTIME_BOARD_PORT || "14276";
+if (PORT === "4173" && process.env.M3E_ALLOW_VISUAL_TEST_ON_4173 !== "1") {
+  throw new Error("Refusing to run runtime-board tests on beta port 4173. Use a dedicated test port.");
+}
+
+module.exports = defineConfig({
+  testDir: "./tests/visual",
+  testMatch: /runtime_board\.spec\.js/,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    viewport: { width: 1440, height: 900 },
+  },
+  webServer: {
+    command: `npx vite --host 127.0.0.1 --port ${PORT} --config vite.config.mjs`,
+    url: `http://127.0.0.1:${PORT}/src/labs/runtime-board/runtime-board.html`,
+    reuseExistingServer: false,
+    cwd: __dirname,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
+    },
+  ],
+});

--- a/beta/src/labs/runtime-board/graph_data.ts
+++ b/beta/src/labs/runtime-board/graph_data.ts
@@ -1,0 +1,579 @@
+/** Static demo data for the conditional-probability pipeline runtime board. */
+
+export type NodeCategory =
+  | "source"
+  | "etl"
+  | "table"
+  | "independent"
+  | "hub"
+  | "process"
+  | "service"
+  | "api"
+  | "api-new"
+  | "output";
+
+export type GraphNode = {
+  id: string;
+  label: string;
+  sublabel?: string;
+  category: NodeCategory;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  method?: string;
+  path?: string;
+  overview?: string;
+  code?: string;
+  sourceLink?: string;
+};
+
+export type GraphEdge = {
+  id: string;
+  from: string;
+  to: string;
+  label?: string;
+  /** optional control point offset for elbow routing */
+  via?: { x: number; y: number }[];
+};
+
+export type StepDef = {
+  index: number;
+  title: string;
+  detail: string;
+  activeNodeIds: string[];
+  activeEdgeIds: string[];
+  completedNodeIds?: string[];
+};
+
+export const CATEGORY_META: Record<
+  NodeCategory,
+  { label: string; fill: string; stroke: string; text: string }
+> = {
+  source: { label: "原典データ", fill: "#1e3a5f", stroke: "#3b82f6", text: "#bfdbfe" },
+  etl: { label: "ETL / Phase", fill: "#7c2d12", stroke: "#ea580c", text: "#fed7aa" },
+  table: { label: "テーブル (条件付き分布)", fill: "#14532d", stroke: "#22c55e", text: "#bbf7d0" },
+  independent: { label: "独立テーブル (marginal)", fill: "#166534", stroke: "#4ade80", text: "#dcfce7" },
+  hub: { label: "ハブ (T_municipal_stats)", fill: "#5b21b6", stroke: "#a78bfa", text: "#ede9fe" },
+  process: { label: "加工手法", fill: "#9a3412", stroke: "#f97316", text: "#ffedd5" },
+  service: { label: "サービス", fill: "#9d174d", stroke: "#ec4899", text: "#fce7f3" },
+  api: { label: "API エンドポイント", fill: "#7f1d1d", stroke: "#ef4444", text: "#fecaca" },
+  "api-new": { label: "■ 新規 API", fill: "#991b1b", stroke: "#f87171", text: "#fee2e2" },
+  output: { label: "出力", fill: "#713f12", stroke: "#eab308", text: "#fef9c3" },
+};
+
+const N = (
+  partial: GraphNode
+): GraphNode => ({
+  ...partial,
+  w: partial.w ?? 148,
+  h: partial.h ?? 44,
+  overview: partial.overview ?? `${partial.label} ノード`,
+  code:
+    partial.code ??
+    `// ${partial.id}\nfunction handle() {\n  return load("${partial.id}");\n}`,
+  sourceLink: partial.sourceLink ?? `lambda/api/src/handlers/${partial.id}.ts`,
+});
+
+/** Multi-column pipeline layout (world coords). */
+export const NODES: GraphNode[] = [
+  // Col 0 — source
+  N({ id: "src-census-2020", label: "国勢調査 2020", sublabel: "e-Stat API", category: "source", x: 40, y: 40, w: 150, h: 48 }),
+  N({ id: "src-estat-api", label: "e-Stat API", sublabel: "統計表取得", category: "source", x: 40, y: 110, w: 150, h: 48 }),
+  N({ id: "src-school-basic", label: "学校基本調査", sublabel: "文部科学省", category: "source", x: 40, y: 180, w: 150, h: 48 }),
+  N({ id: "src-economic-2021", label: "経済センサス 2021", sublabel: "事業所統計", category: "source", x: 40, y: 250, w: 150, h: 48 }),
+  N({ id: "src-labor-2023", label: "労働力調査 2023", sublabel: "就業構造", category: "source", x: 40, y: 320, w: 150, h: 48 }),
+  N({ id: "src-housing", label: "住宅・土地統計", sublabel: "総務省", category: "source", x: 40, y: 390, w: 150, h: 48 }),
+  N({ id: "src-kaken", label: "共創研 Kaken", sublabel: "研究データ", category: "source", x: 40, y: 460, w: 150, h: 48 }),
+
+  // Col 1 — ETL intermediate
+  N({ id: "etl-census", label: "node-census", sublabel: "正規化・結合", category: "etl", x: 240, y: 50, w: 140, h: 48 }),
+  N({ id: "etl-employment", label: "node-employment_structure", sublabel: "産業×就業", category: "etl", x: 240, y: 140, w: 160, h: 48 }),
+  N({ id: "etl-economic", label: "node-economic_census", sublabel: "地域経済", category: "etl", x: 240, y: 230, w: 150, h: 48 }),
+  N({ id: "etl-tax", label: "node-tax", sublabel: "税務統計", category: "etl", x: 240, y: 320, w: 140, h: 48 }),
+  N({ id: "etl-university", label: "node-university", sublabel: "高等教育", category: "etl", x: 240, y: 410, w: 140, h: 48 }),
+
+  // Col 2 — independent / hub tables
+  N({ id: "t-age", label: "T1_age", sublabel: "年齢分布", category: "independent", x: 460, y: 30, w: 120, h: 42 }),
+  N({ id: "t-sex", label: "T2_sex", sublabel: "性別分布", category: "independent", x: 460, y: 90, w: 120, h: 42 }),
+  N({ id: "t-prefecture", label: "T3_prefecture", sublabel: "都道府県", category: "independent", x: 460, y: 150, w: 130, h: 42 }),
+  N({
+    id: "t-municipal",
+    label: "T_municipal_stats",
+    sublabel: "市区町村ハブ",
+    category: "hub",
+    x: 450,
+    y: 220,
+    w: 150,
+    h: 48,
+    overview: "市区町村単位の統計ハブ。条件付き分布の結合キー。",
+    code: "const hub = joinMunicipal(T3, census, economic);\nreturn hub.byPrefecture(pref);",
+    sourceLink: "lambda/api/src/tables/municipal_stats.ts",
+  }),
+  N({ id: "t-marital", label: "T4_marital", sublabel: "配偶者関係", category: "table", x: 460, y: 300, w: 120, h: 42 }),
+  N({ id: "t-education", label: "T5_education", sublabel: "学歴分布", category: "table", x: 460, y: 360, w: 120, h: 42 }),
+  N({ id: "t-employment", label: "T6_employment", sublabel: "就業状態", category: "independent", x: 460, y: 420, w: 130, h: 42 }),
+  N({ id: "t-income", label: "T8_income", sublabel: "所得分布", category: "independent", x: 460, y: 480, w: 120, h: 42 }),
+  N({ id: "t-occupation", label: "T11_occupation", sublabel: "職業分類", category: "independent", x: 460, y: 540, w: 130, h: 42 }),
+  N({ id: "t7b-employment-pref", label: "T7B_employment_pref", sublabel: "就業×地域", category: "table", x: 460, y: 600, w: 150, h: 42 }),
+  N({ id: "m5-universities", label: "M5_universities", sublabel: "大学マスタ", category: "etl", x: 460, y: 660, w: 130, h: 42 }),
+
+  // Col 3 — Phases
+  N({
+    id: "phase1",
+    label: "Phase 1 基盤",
+    sublabel: "年齢・性別・地域",
+    category: "etl",
+    x: 680,
+    y: 40,
+    w: 150,
+    h: 48,
+    overview: "基盤属性の独立抽選: 年齢 / 性別 / 都道府県 / 市区町村。",
+    code: "P(age) ← T1\nP(sex|age) ← T2_by_age\nP(pref) ← T3\nP(muni|pref) ← T_municipal_stats",
+  }),
+  N({
+    id: "phase2",
+    label: "Phase 2 デモグラフィック",
+    sublabel: "婚姻・学歴",
+    category: "etl",
+    x: 680,
+    y: 120,
+    w: 170,
+    h: 48,
+  }),
+  N({
+    id: "phase3",
+    label: "Phase 3 経済",
+    sublabel: "就業・所得・職業",
+    category: "process",
+    x: 680,
+    y: 220,
+    w: 150,
+    h: 48,
+    overview: "Municipal Blend とフォールバック階層で経済属性を推定。",
+    code:
+      "P(employment | sex, age) ← T7 + T7B fallback → Municipal Blend\nP(occupation | emp, sex, edu) ← T11 × Municipal Blend\nP(income | hh, age) ← T8 × Municipal Blend",
+  }),
+  N({ id: "phase4", label: "Phase 4 地理", sublabel: "移動・居住", category: "etl", x: 680, y: 320, w: 140, h: 48 }),
+  N({ id: "phase5", label: "Phase 5 心理", sublabel: "嗜好・行動", category: "etl", x: 680, y: 400, w: 140, h: 48 }),
+  N({
+    id: "phase6",
+    label: "Phase 6 検証",
+    sublabel: "HARD / COND / SOFT",
+    category: "etl",
+    x: 680,
+    y: 500,
+    w: 150,
+    h: 48,
+    overview: "ルール検証と再生成。HARD 棄却、COND 再サンプル、SOFT ペナルティ。",
+    code:
+      "HARD 57 ルール検査 (違反 → 棄却 + 再生成)\nCOND 49 ルール (違反 → 該当属性 resample)\nSOFT 51 + S-R20 6 ルール (penalty スコア)\n(オプション) apply_lpf でキャリブレーション",
+  }),
+
+  // Col 4 — process techniques
+  N({
+    id: "cond-sampling",
+    label: "Conditional Sampling",
+    sublabel: "条件付き抽選",
+    category: "process",
+    x: 900,
+    y: 40,
+    w: 170,
+    h: 48,
+  }),
+  N({
+    id: "municipal-blend",
+    label: "Municipal Blend",
+    sublabel: "市区町村混合",
+    category: "process",
+    x: 900,
+    y: 140,
+    w: 150,
+    h: 48,
+  }),
+  N({
+    id: "fallback-hierarchy",
+    label: "Fallback Hierarchy",
+    sublabel: "階層フォールバック",
+    category: "process",
+    x: 900,
+    y: 230,
+    w: 160,
+    h: 48,
+  }),
+  N({
+    id: "apply-lpf",
+    label: "apply_lpf",
+    sublabel: "LPF キャリブレーション",
+    category: "process",
+    x: 900,
+    y: 340,
+    w: 140,
+    h: 48,
+  }),
+  N({
+    id: "hardcond-rules",
+    label: "HARD/COND Rules",
+    sublabel: "57+49 ルール",
+    category: "process",
+    x: 900,
+    y: 440,
+    w: 150,
+    h: 48,
+  }),
+
+  // Col 5 — services
+  N({
+    id: "gen-lambda",
+    label: "Gen Lambda",
+    sublabel: "生成エントリ",
+    category: "service",
+    x: 1120,
+    y: 100,
+    w: 140,
+    h: 48,
+    overview: "ペルソナ生成 Lambda。Phase 1〜6 をオーケストレーション。",
+    code: "export async function generatePersona(req) {\n  const base = samplePhase1(req);\n  return runPhases(base, req.conditions);\n}",
+    sourceLink: "lambda/api/src/handlers/generate.ts",
+  }),
+  N({
+    id: "condition-rate-service",
+    label: "condition-rate-service",
+    sublabel: "条件付き確率",
+    category: "service",
+    x: 1100,
+    y: 320,
+    w: 170,
+    h: 48,
+    overview: "条件付き確率と信頼区間・推定人口を返すコアサービス。",
+    code:
+      "stderr = √(p(1-p)/N)\nCI95 = [rate ± 1.96·stderr]\nestimated_population = round(rate × base_pop)",
+    sourceLink: "lambda/api/src/services/condition_rate.ts",
+  }),
+
+  // Col 6 — APIs
+  N({
+    id: "api-personas-generate",
+    label: "POST /v1/personas/generate",
+    sublabel: "ペルソナ生成",
+    category: "api",
+    x: 1340,
+    y: 80,
+    w: 190,
+    h: 48,
+    method: "POST",
+    path: "/v1/personas/generate",
+    overview: "条件付きペルソナを生成する API。",
+    code: "POST /v1/personas/generate\n→ Gen Lambda\n→ JSON persona",
+    sourceLink: "lambda/api/src/handlers/personas_generate.ts",
+  }),
+  N({
+    id: "api-tables-id",
+    label: "GET /v1/tables/:id",
+    sublabel: "テーブル直接取得",
+    category: "api",
+    x: 1340,
+    y: 160,
+    w: 170,
+    h: 48,
+    method: "GET",
+    path: "/v1/tables/:id",
+    overview: "テーブル直接取得 API",
+    code: "GET /v1/tables/{table_id}\n→ loadTable(table_id) (Lambda Layer から JSON 読み込み)\n→ JSON そのまま返却",
+    sourceLink: "lambda/api/src/handlers/index.ts#handleGetTable",
+  }),
+  N({
+    id: "api-condition-rate",
+    label: "POST /v1/personas/condition-rate",
+    sublabel: "条件付き確率 API",
+    category: "api-new",
+    x: 1320,
+    y: 300,
+    w: 210,
+    h: 52,
+    method: "POST",
+    path: "/v1/personas/condition-rate",
+    overview: "条件付き確率・信頼区間・推定人口を返す新規 API。",
+    code: `POST /v1/personas/condition-rate に下記が到着:
+{
+  "conditions": {
+    "age_range": {"min": 25, "max": 45},
+    "sex": "female",
+    "prefecture": ["東京都"],
+    "big5": {"O": {"min": 0.0}}
+  },
+  "method": "auto",
+  "include_absolute": true
+}`,
+    sourceLink: "lambda/api/src/handlers/condition_rate.ts",
+  }),
+  N({
+    id: "api-health",
+    label: "GET /health",
+    sublabel: "ヘルスチェック",
+    category: "api",
+    x: 1340,
+    y: 400,
+    w: 130,
+    h: 42,
+    method: "GET",
+    path: "/health",
+  }),
+
+  // Col 7 — outputs
+  N({
+    id: "out-condition-rate",
+    label: "条件付き確率 (%)",
+    sublabel: "rate / CI / pop",
+    category: "output",
+    x: 1580,
+    y: 280,
+    w: 160,
+    h: 52,
+    overview: "最終出力: 条件付き確率、95% CI、推定人口。",
+    code: "{\n  \"rate\": 0.0042,\n  \"ci95\": [0.0030, 0.0054],\n  \"estimated_population\": 525000\n}",
+  }),
+  N({
+    id: "out-persona",
+    label: "生成ペルソナ",
+    sublabel: "JSON persona",
+    category: "output",
+    x: 1580,
+    y: 100,
+    w: 140,
+    h: 48,
+  }),
+  N({
+    id: "out-table",
+    label: "生テーブル",
+    sublabel: "JSON rows",
+    category: "output",
+    x: 1580,
+    y: 180,
+    w: 130,
+    h: 48,
+  }),
+];
+
+export const EDGES: GraphEdge[] = [
+  { id: "e-src-census", from: "src-census-2020", to: "etl-census" },
+  { id: "e-src-estat", from: "src-estat-api", to: "etl-census" },
+  { id: "e-src-school", from: "src-school-basic", to: "etl-university" },
+  { id: "e-src-economic", from: "src-economic-2021", to: "etl-economic" },
+  { id: "e-src-labor", from: "src-labor-2023", to: "etl-employment" },
+  { id: "e-src-housing", from: "src-housing", to: "etl-tax" },
+  { id: "e-src-kaken", from: "src-kaken", to: "etl-university" },
+
+  { id: "e-etl-age", from: "etl-census", to: "t-age", label: "age" },
+  { id: "e-etl-sex", from: "etl-census", to: "t-sex", label: "sex" },
+  { id: "e-etl-pref", from: "etl-census", to: "t-prefecture", label: "pref" },
+  { id: "e-etl-muni", from: "etl-census", to: "t-municipal", label: "muni" },
+  { id: "e-emp-t6", from: "etl-employment", to: "t-employment" },
+  { id: "e-emp-t7b", from: "etl-employment", to: "t7b-employment-pref" },
+  { id: "e-econ-hub", from: "etl-economic", to: "t-municipal" },
+  { id: "e-tax-income", from: "etl-tax", to: "t-income" },
+  { id: "e-uni-m5", from: "etl-university", to: "m5-universities" },
+  { id: "e-uni-edu", from: "etl-university", to: "t-education" },
+
+  { id: "e-t1-p1", from: "t-age", to: "phase1", label: "P(age)" },
+  { id: "e-t2-p1", from: "t-sex", to: "phase1", label: "P(sex)" },
+  { id: "e-t3-p1", from: "t-prefecture", to: "phase1", label: "P(pref)" },
+  { id: "e-hub-p1", from: "t-municipal", to: "phase1", label: "muni" },
+  { id: "e-t4-p2", from: "t-marital", to: "phase2" },
+  { id: "e-t5-p2", from: "t-education", to: "phase2" },
+  { id: "e-t6-p3", from: "t-employment", to: "phase3" },
+  { id: "e-t8-p3", from: "t-income", to: "phase3" },
+  { id: "e-t11-p3", from: "t-occupation", to: "phase3" },
+  { id: "e-t7b-p3", from: "t7b-employment-pref", to: "phase3" },
+  { id: "e-hub-p3", from: "t-municipal", to: "phase3", label: "blend" },
+
+  { id: "e-p1-cs", from: "phase1", to: "cond-sampling" },
+  { id: "e-p2-mb", from: "phase2", to: "municipal-blend" },
+  { id: "e-p3-mb", from: "phase3", to: "municipal-blend" },
+  { id: "e-p3-fb", from: "phase3", to: "fallback-hierarchy" },
+  { id: "e-p6-lpf", from: "phase6", to: "apply-lpf" },
+  { id: "e-p6-rules", from: "phase6", to: "hardcond-rules" },
+  { id: "e-rules-p6", from: "hardcond-rules", to: "phase6" },
+
+  { id: "e-cs-gen", from: "cond-sampling", to: "gen-lambda" },
+  { id: "e-mb-gen", from: "municipal-blend", to: "gen-lambda" },
+  { id: "e-fb-crs", from: "fallback-hierarchy", to: "condition-rate-service" },
+  { id: "e-lpf-crs", from: "apply-lpf", to: "condition-rate-service" },
+  { id: "e-rules-crs", from: "hardcond-rules", to: "condition-rate-service" },
+
+  { id: "e-gen-api", from: "gen-lambda", to: "api-personas-generate" },
+  { id: "e-gen-table", from: "gen-lambda", to: "api-tables-id" },
+  { id: "e-crs-api", from: "condition-rate-service", to: "api-condition-rate" },
+  { id: "e-api-gen-out", from: "api-personas-generate", to: "out-persona" },
+  { id: "e-api-table-out", from: "api-tables-id", to: "out-table" },
+  { id: "e-api-cr-out", from: "api-condition-rate", to: "out-condition-rate" },
+];
+
+/** 15-step API processing flow matching the reference video narrative. */
+export const STEPS: StepDef[] = [
+  {
+    index: 1,
+    title: "API リクエスト受信",
+    detail: `POST /v1/personas/condition-rate に下記が到着:
+{
+  "conditions": {
+    "age_range": {"min": 25, "max": 45},
+    "sex": "female",
+    "prefecture": ["東京都"],
+    "big5": {"O": {"min": 0.0}}
+  },
+  "method": "auto",
+  "include_absolute": true
+}`,
+    activeNodeIds: ["api-condition-rate"],
+    activeEdgeIds: [],
+  },
+  {
+    index: 2,
+    title: "ルーティング → condition-rate-service",
+    detail: "API Gateway → Lambda ハンドラ → condition-rate-service へ委譲。\nmethod: auto のとき内部で推定経路を選択。",
+    activeNodeIds: ["api-condition-rate", "condition-rate-service"],
+    activeEdgeIds: ["e-crs-api"],
+    completedNodeIds: ["api-condition-rate"],
+  },
+  {
+    index: 3,
+    title: "原典データ参照",
+    detail: "条件に必要な統計表の原典 (国勢調査 / e-Stat / 労働力調査 等) を解決。",
+    activeNodeIds: [
+      "src-census-2020",
+      "src-estat-api",
+      "src-labor-2023",
+      "etl-census",
+      "etl-employment",
+    ],
+    activeEdgeIds: ["e-src-census", "e-src-estat", "e-src-labor"],
+    completedNodeIds: ["api-condition-rate", "condition-rate-service"],
+  },
+  {
+    index: 4,
+    title: "独立テーブル準備",
+    detail: "T1_age / T2_sex / T3_prefecture / T_municipal_stats をメモリにロード。",
+    activeNodeIds: ["t-age", "t-sex", "t-prefecture", "t-municipal"],
+    activeEdgeIds: ["e-etl-age", "e-etl-sex", "e-etl-pref", "e-etl-muni"],
+    completedNodeIds: ["api-condition-rate", "condition-rate-service", "etl-census"],
+  },
+  {
+    index: 5,
+    title: "Phase 1 基盤抽選",
+    detail: `P(age) ← T1 (独立分布)
+P(sex | age) ← T2_by_age
+P(prefecture) ← T3 (独立分布)
+P(municipality | prefecture) ← T_municipal_stats`,
+    activeNodeIds: ["t-age", "t-sex", "t-prefecture", "t-municipal", "phase1", "cond-sampling"],
+    activeEdgeIds: ["e-t1-p1", "e-t2-p1", "e-t3-p1", "e-hub-p1", "e-p1-cs"],
+    completedNodeIds: ["api-condition-rate", "condition-rate-service"],
+  },
+  {
+    index: 6,
+    title: "Phase 2 デモグラフィック",
+    detail: "婚姻・学歴を Conditional Sampling と Municipal Blend で推定。",
+    activeNodeIds: ["t-marital", "t-education", "phase2", "municipal-blend"],
+    activeEdgeIds: ["e-t4-p2", "e-t5-p2", "e-p2-mb"],
+    completedNodeIds: ["phase1", "t-age", "t-sex", "t-prefecture", "cond-sampling"],
+  },
+  {
+    index: 7,
+    title: "Phase 3 経済",
+    detail: `P(employment | sex, age) ← T7 + T7B fallback → Municipal Blend
+P(occupation | emp, sex, edu) ← T11 × Municipal Blend
+P(income | hh, age) ← T8 × Municipal Blend`,
+    activeNodeIds: [
+      "t-employment",
+      "t-income",
+      "t-occupation",
+      "t-municipal",
+      "phase3",
+      "municipal-blend",
+      "fallback-hierarchy",
+    ],
+    activeEdgeIds: ["e-t6-p3", "e-t8-p3", "e-t11-p3", "e-hub-p3", "e-p3-mb", "e-p3-fb"],
+    completedNodeIds: ["phase1", "phase2", "cond-sampling"],
+  },
+  {
+    index: 8,
+    title: "Phase 4–5 地理・心理",
+    detail: "居住・移動 (Phase 4) と Big5 制約 (Phase 5) を適用。\nbig5.O min 制約で再抽選。",
+    activeNodeIds: ["phase4", "phase5"],
+    activeEdgeIds: [],
+    completedNodeIds: ["phase1", "phase2", "phase3", "municipal-blend"],
+  },
+  {
+    index: 9,
+    title: "Fallback Hierarchy",
+    detail: "セル件数が閾値未満のとき、市区町村 → 都道府県 → 全国へ階層フォールバック。",
+    activeNodeIds: ["fallback-hierarchy", "phase3", "condition-rate-service"],
+    activeEdgeIds: ["e-p3-fb", "e-fb-crs"],
+    completedNodeIds: ["phase1", "phase2", "phase3"],
+  },
+  {
+    index: 10,
+    title: "Phase 6 検証",
+    detail: `HARD 57 ルール検査 (違反 → 棄却 + 再生成)
+COND 49 ルール (違反 → 該当属性 resample)
+SOFT 51 + S-R20 6 ルール (penalty スコア)
+(オプション) apply_lpf でキャリブレーション`,
+    activeNodeIds: ["phase6", "apply-lpf", "hardcond-rules"],
+    activeEdgeIds: ["e-p6-lpf", "e-p6-rules", "e-rules-p6"],
+    completedNodeIds: ["phase1", "phase2", "phase3", "phase4", "phase5"],
+  },
+  {
+    index: 11,
+    title: "Gen Lambda オーケストレーション",
+    detail: "生成経路では Gen Lambda が Phase 結果を束ね JSON persona を組み立てる。\n本フロー (condition-rate) は確率集計パスを優先。",
+    activeNodeIds: ["gen-lambda", "cond-sampling", "municipal-blend"],
+    activeEdgeIds: ["e-cs-gen", "e-mb-gen"],
+    completedNodeIds: ["phase1", "phase2", "phase3", "phase6"],
+  },
+  {
+    index: 12,
+    title: "信頼区間 + 推定人口",
+    detail: `stderr = √(p(1-p)/N) = √(0.0042×0.9958/10000) ≈ 0.00065
+CI95 = [rate ± 1.96·stderr] = [0.30%, 0.54%]
+estimated_population = round(0.0042 × 125,000,000) = 525,000 人`,
+    activeNodeIds: ["condition-rate-service"],
+    activeEdgeIds: ["e-fb-crs", "e-lpf-crs", "e-rules-crs"],
+    completedNodeIds: ["phase6", "apply-lpf", "hardcond-rules"],
+  },
+  {
+    index: 13,
+    title: "レスポンス組み立て",
+    detail: "rate / ci95 / estimated_population / method_used を JSON 化。\ninclude_absolute=true なら絶対人数を同梱。",
+    activeNodeIds: ["condition-rate-service", "api-condition-rate"],
+    activeEdgeIds: ["e-crs-api"],
+    completedNodeIds: ["condition-rate-service"],
+  },
+  {
+    index: 14,
+    title: "出力ノードへ配送",
+    detail: "条件付き確率 (%) ノードへ結果を書き出し、クライアントへ 200 OK。",
+    activeNodeIds: ["api-condition-rate", "out-condition-rate"],
+    activeEdgeIds: ["e-api-cr-out"],
+    completedNodeIds: ["condition-rate-service", "api-condition-rate"],
+  },
+  {
+    index: 15,
+    title: "フロー完了",
+    detail: "全 Phase と API パスが完了。再生ボタンで最初から再実行可能。",
+    activeNodeIds: [
+      "api-condition-rate",
+      "condition-rate-service",
+      "phase1",
+      "phase3",
+      "phase6",
+      "out-condition-rate",
+    ],
+    activeEdgeIds: ["e-crs-api", "e-api-cr-out", "e-p1-cs", "e-p3-mb"],
+    completedNodeIds: NODES.map((n) => n.id),
+  },
+];
+
+export const WORLD = { width: 1780, height: 740 };
+export const STEP_INTERVAL_MS = 2200;
+export const TITLE = "条件付き確率 生成パイプライン";
+export const SUBTITLE = "原典データ → ETL → 確率テーブル → サンプリング → API → 条件付き確率 (%)";

--- a/beta/src/labs/runtime-board/runtime-board.css
+++ b/beta/src/labs/runtime-board/runtime-board.css
@@ -1,0 +1,560 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1020;
+  --bg-elevated: #121a2e;
+  --panel: rgba(12, 18, 36, 0.92);
+  --panel-border: rgba(148, 163, 184, 0.22);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #facc15;
+  --accent-soft: rgba(250, 204, 21, 0.18);
+  --glow: rgba(250, 204, 21, 0.55);
+  --done: rgba(74, 222, 128, 0.55);
+  --inactive-opacity: 0.28;
+  font-family: "Inter", "Hiragino Sans", "Noto Sans JP", ui-sans-serif, system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#runtime-board-root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.board {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 40%, #152038 0%, var(--bg) 70%),
+    var(--bg);
+}
+
+.board-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 20px 0;
+  pointer-events: none;
+}
+
+.board-header > * {
+  pointer-events: auto;
+}
+
+.title-block h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.title-block p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.help-chip {
+  font-size: 11px;
+  color: var(--muted);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  padding: 6px 12px;
+  white-space: nowrap;
+}
+
+.playback {
+  position: absolute;
+  top: 56px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(10, 16, 32, 0.88);
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+}
+
+.playback button {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #1e293b;
+  color: var(--text);
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.15s, border-color 0.15s, transform 0.1s;
+}
+
+.playback button:hover {
+  background: #334155;
+  border-color: rgba(226, 232, 240, 0.45);
+}
+
+.playback button:active {
+  transform: scale(0.96);
+}
+
+.playback button.primary {
+  width: auto;
+  min-width: 108px;
+  padding: 0 16px;
+  background: var(--accent);
+  color: #111827;
+  border-color: #fde047;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.playback button.primary:hover {
+  background: #fde047;
+}
+
+.playback .step-counter {
+  min-width: 64px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--muted);
+  padding: 0 4px;
+}
+
+.playback .step-counter strong {
+  color: var(--accent);
+  font-size: 13px;
+}
+
+.pan-hint {
+  position: absolute;
+  top: 62px;
+  left: calc(50% + 180px);
+  z-index: 25;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: rgba(15, 23, 42, 0.8);
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: 16px;
+  pointer-events: none;
+}
+
+.viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+}
+
+.viewport.panning {
+  cursor: grabbing;
+}
+
+.viewport svg.world {
+  display: block;
+  width: 100%;
+  height: 100%;
+  user-select: none;
+}
+
+.edge {
+  fill: none;
+  stroke: #475569;
+  stroke-width: 1.4;
+  opacity: var(--inactive-opacity);
+  transition: opacity 0.25s, stroke 0.25s, stroke-width 0.25s, filter 0.25s;
+}
+
+.edge.active {
+  opacity: 1;
+  stroke: var(--accent);
+  stroke-width: 2.2;
+  filter: drop-shadow(0 0 4px var(--glow));
+  stroke-dasharray: 6 4;
+  animation: dash-flow 0.9s linear infinite;
+}
+
+.edge.completed {
+  opacity: 0.55;
+  stroke: #86efac;
+}
+
+.edge-label {
+  font-size: 9px;
+  fill: #64748b;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.edge-label.active {
+  fill: #fde68a;
+  opacity: 1;
+}
+
+@keyframes dash-flow {
+  to {
+    stroke-dashoffset: -20;
+  }
+}
+
+.node {
+  cursor: pointer;
+  opacity: var(--inactive-opacity);
+  transition: opacity 0.25s, filter 0.25s;
+}
+
+.node .node-body {
+  rx: 8;
+  ry: 8;
+  stroke-width: 1.5;
+  transition: stroke-width 0.2s, filter 0.2s;
+}
+
+.node .node-label {
+  font-size: 11px;
+  font-weight: 650;
+  pointer-events: none;
+}
+
+.node .node-sub {
+  font-size: 9px;
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.node.active {
+  opacity: 1;
+  filter: drop-shadow(0 0 10px var(--glow));
+}
+
+.node.active .node-body {
+  stroke-width: 2.5;
+  filter: drop-shadow(0 0 6px var(--glow));
+}
+
+.node.completed {
+  opacity: 0.82;
+  filter: drop-shadow(0 0 4px var(--done));
+}
+
+.node.completed .node-body {
+  stroke-width: 2;
+}
+
+.node.selected {
+  opacity: 1;
+}
+
+.node.selected .node-body {
+  stroke: #f8fafc;
+  stroke-width: 2.5;
+  filter: drop-shadow(0 0 8px rgba(248, 250, 252, 0.45));
+}
+
+.node:hover {
+  opacity: 1;
+}
+
+.legend {
+  position: absolute;
+  left: 14px;
+  bottom: 14px;
+  z-index: 30;
+  width: 200px;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  backdrop-filter: blur(8px);
+}
+
+.legend h2 {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.legend ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.legend .swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid;
+  flex: 0 0 auto;
+}
+
+.step-overlay {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  z-index: 35;
+  width: min(720px, calc(100vw - 280px));
+  padding: 14px 18px 12px;
+  background: rgba(10, 14, 28, 0.94);
+  border: 1.5px solid var(--accent);
+  border-radius: 14px;
+  box-shadow:
+    0 0 0 1px rgba(250, 204, 21, 0.12),
+    0 12px 40px rgba(0, 0, 0, 0.45),
+    0 0 24px var(--accent-soft);
+}
+
+.step-overlay .step-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.step-overlay .step-badge {
+  color: var(--accent);
+  font-weight: 800;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.step-overlay .step-title {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.step-overlay .step-detail {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #cbd5e1;
+  white-space: pre-wrap;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  max-height: 120px;
+  overflow: auto;
+}
+
+.step-overlay .progress {
+  margin-top: 10px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.step-overlay .progress > span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #eab308, #facc15);
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.minimap {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  z-index: 30;
+  width: 168px;
+  height: 96px;
+  padding: 6px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.minimap svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.minimap .mm-node {
+  opacity: 0.85;
+}
+
+.minimap .mm-viewport {
+  fill: rgba(250, 204, 21, 0.08);
+  stroke: var(--accent);
+  stroke-width: 8;
+}
+
+.drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 40;
+  width: min(380px, 92vw);
+  background: rgba(11, 16, 32, 0.97);
+  border-left: 1px solid var(--panel-border);
+  box-shadow: -12px 0 40px rgba(0, 0, 0, 0.4);
+  transform: translateX(100%);
+  transition: transform 0.22s ease;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 18px 24px;
+  overflow: hidden;
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.drawer-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.drawer-head h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  word-break: break-all;
+}
+
+.drawer-head .api-type {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.drawer-close {
+  appearance: none;
+  border: 1px solid var(--panel-border);
+  background: #1e293b;
+  color: var(--text);
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.drawer-body {
+  overflow: auto;
+  display: grid;
+  gap: 14px;
+  min-height: 0;
+}
+
+.drawer section h3 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.drawer section p,
+.drawer section pre {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #e2e8f0;
+}
+
+.drawer pre {
+  background: #0f172a;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  padding: 12px;
+  white-space: pre-wrap;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  overflow: auto;
+}
+
+.drawer .method-path {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.drawer .method-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: #7f1d1d;
+  color: #fecaca;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.drawer .source-link {
+  color: #93c5fd;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 38;
+  background: rgba(2, 6, 23, 0.35);
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+@media (max-width: 1100px) {
+  .step-overlay {
+    width: calc(100vw - 40px);
+    left: 20px;
+    transform: none;
+  }
+
+  .legend {
+    display: none;
+  }
+
+  .minimap {
+    width: 120px;
+    height: 72px;
+  }
+}

--- a/beta/src/labs/runtime-board/runtime-board.html
+++ b/beta/src/labs/runtime-board/runtime-board.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>条件付き確率 生成パイプライン — Runtime Board</title>
+  </head>
+  <body>
+    <div id="runtime-board-root"></div>
+    <script type="module" src="./runtime-board.tsx"></script>
+  </body>
+</html>

--- a/beta/src/labs/runtime-board/runtime-board.tsx
+++ b/beta/src/labs/runtime-board/runtime-board.tsx
@@ -1,0 +1,443 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  CATEGORY_META,
+  EDGES,
+  NODES,
+  STEP_INTERVAL_MS,
+  STEPS,
+  SUBTITLE,
+  TITLE,
+  WORLD,
+  type GraphEdge,
+  type GraphNode,
+  type NodeCategory,
+} from "./graph_data";
+import "./runtime-board.css";
+
+type Camera = { x: number; y: number; scale: number };
+
+function nodeCenter(node: GraphNode): { x: number; y: number } {
+  return { x: node.x + node.w / 2, y: node.y + node.h / 2 };
+}
+
+function edgePath(edge: GraphEdge, byId: Map<string, GraphNode>): string {
+  const from = byId.get(edge.from);
+  const to = byId.get(edge.to);
+  if (!from || !to) return "";
+  const a = nodeCenter(from);
+  const b = nodeCenter(to);
+  // exit/enter at box edges toward target
+  const dx = b.x - a.x;
+  const startX = a.x + Math.sign(dx || 1) * (from.w / 2);
+  const endX = b.x - Math.sign(dx || 1) * (to.w / 2);
+  const startY = a.y;
+  const endY = b.y;
+  const midX = (startX + endX) / 2;
+  if (edge.via && edge.via.length > 0) {
+    const pts = edge.via.map((p) => `${p.x},${p.y}`).join(" ");
+    return `M ${startX} ${startY} L ${pts} L ${endX} ${endY}`;
+  }
+  // smooth horizontal elbow
+  return `M ${startX} ${startY} C ${midX} ${startY}, ${midX} ${endY}, ${endX} ${endY}`;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function App(): React.ReactElement {
+  const [stepIndex, setStepIndex] = useState(0); // 0-based
+  const [playing, setPlaying] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [camera, setCamera] = useState<Camera>({ x: 40, y: 20, scale: 0.78 });
+  const [panning, setPanning] = useState(false);
+  const panRef = useRef<{ sx: number; sy: number; cx: number; cy: number } | null>(null);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+
+  const byId = useMemo(() => new Map(NODES.map((n) => [n.id, n])), []);
+  const step = STEPS[stepIndex]!;
+  const totalSteps = STEPS.length;
+
+  const activeNodes = useMemo(() => new Set(step.activeNodeIds), [step]);
+  const activeEdges = useMemo(() => new Set(step.activeEdgeIds), [step]);
+  const completedNodes = useMemo(() => {
+    const set = new Set<string>();
+    for (let i = 0; i < stepIndex; i += 1) {
+      for (const id of STEPS[i]!.activeNodeIds) set.add(id);
+      for (const id of STEPS[i]!.completedNodeIds ?? []) set.add(id);
+    }
+    for (const id of step.completedNodeIds ?? []) set.add(id);
+    // current actives are not "completed" for styling priority
+    for (const id of step.activeNodeIds) set.delete(id);
+    return set;
+  }, [step, stepIndex]);
+
+  const goPrev = useCallback(() => {
+    setPlaying(false);
+    setStepIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const goNext = useCallback(() => {
+    setStepIndex((i) => {
+      if (i >= totalSteps - 1) {
+        setPlaying(false);
+        return i;
+      }
+      return i + 1;
+    });
+  }, [totalSteps]);
+
+  const togglePlay = useCallback(() => {
+    setPlaying((p) => !p);
+  }, []);
+
+  useEffect(() => {
+    if (!playing) return;
+    const timer = window.setInterval(() => {
+      setStepIndex((i) => {
+        if (i >= totalSteps - 1) {
+          setPlaying(false);
+          return i;
+        }
+        return i + 1;
+      });
+    }, STEP_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [playing, totalSteps]);
+
+  // keyboard
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight" || e.key === " ") {
+        e.preventDefault();
+        if (e.key === " ") togglePlay();
+        else goNext();
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === "Escape") {
+        setSelectedId(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [goNext, goPrev, togglePlay]);
+
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const rect = viewportRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    setCamera((cam) => {
+      const nextScale = clamp(cam.scale * (e.deltaY > 0 ? 0.92 : 1.08), 0.35, 1.8);
+      const wx = (mx - cam.x) / cam.scale;
+      const wy = (my - cam.y) / cam.scale;
+      return {
+        scale: nextScale,
+        x: mx - wx * nextScale,
+        y: my - wy * nextScale,
+      };
+    });
+  }, []);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    const target = e.target as Element;
+    if (target.closest(".node")) return;
+    panRef.current = { sx: e.clientX, sy: e.clientY, cx: camera.x, cy: camera.y };
+    setPanning(true);
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, [camera.x, camera.y]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!panRef.current) return;
+    const dx = e.clientX - panRef.current.sx;
+    const dy = e.clientY - panRef.current.sy;
+    setCamera((cam) => ({
+      ...cam,
+      x: panRef.current!.cx + dx,
+      y: panRef.current!.cy + dy,
+    }));
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    panRef.current = null;
+    setPanning(false);
+  }, []);
+
+  const selected = selectedId ? byId.get(selectedId) ?? null : null;
+  const progressPct = ((stepIndex + 1) / totalSteps) * 100;
+
+  const transform = `translate(${camera.x} ${camera.y}) scale(${camera.scale})`;
+
+  return (
+    <div className="board" data-testid="runtime-board">
+      <header className="board-header">
+        <div className="title-block">
+          <h1>{TITLE}</h1>
+          <p>{SUBTITLE}</p>
+        </div>
+        <div className="help-chip" data-testid="help-chip">
+          ホイール: 拡大縮小 / ドラッグ: 移動 / クリック: 詳細 / ▶ ボタン: API 処理フロー再生
+        </div>
+      </header>
+
+      <div className="playback" data-testid="playback-controls" role="group" aria-label="再生コントロール">
+        <button type="button" aria-label="最初へ" data-testid="btn-reset" onClick={() => { setPlaying(false); setStepIndex(0); }}>
+          ⏮
+        </button>
+        <button type="button" aria-label="前のステップ" data-testid="btn-prev" onClick={goPrev}>
+          ⏪
+        </button>
+        <button
+          type="button"
+          className="primary"
+          aria-label={playing ? "一時停止" : "再生"}
+          data-testid="btn-play"
+          onClick={togglePlay}
+        >
+          {playing ? "⏸ 一時停止" : "▶ API処理フローを再生"}
+        </button>
+        <button type="button" aria-label="次のステップ" data-testid="btn-next" onClick={goNext}>
+          ⏩
+        </button>
+        <div className="step-counter" data-testid="step-counter">
+          <strong>{stepIndex + 1}</strong> / {totalSteps}
+        </div>
+      </div>
+      <div className="pan-hint" aria-hidden="true">✋</div>
+
+      <div
+        ref={viewportRef}
+        className={`viewport${panning ? " panning" : ""}`}
+        data-testid="graph-viewport"
+        onWheel={onWheel}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      >
+        <svg className="world" data-testid="graph-svg">
+          <g transform={transform}>
+            {EDGES.map((edge) => {
+              const d = edgePath(edge, byId);
+              const isActive = activeEdges.has(edge.id);
+              const isCompleted =
+                !isActive &&
+                completedNodes.has(edge.from) &&
+                completedNodes.has(edge.to);
+              const cls = ["edge", isActive ? "active" : "", isCompleted ? "completed" : ""]
+                .filter(Boolean)
+                .join(" ");
+              return (
+                <g key={edge.id}>
+                  <path
+                    className={cls}
+                    d={d}
+                    data-edge-id={edge.id}
+                    data-active={isActive ? "true" : "false"}
+                  />
+                  {edge.label ? (
+                    <text
+                      className={`edge-label${isActive ? " active" : ""}`}
+                      x={(byId.get(edge.from)!.x + byId.get(edge.to)!.x) / 2 + 40}
+                      y={(byId.get(edge.from)!.y + byId.get(edge.to)!.y) / 2 + 12}
+                    >
+                      {edge.label}
+                    </text>
+                  ) : null}
+                </g>
+              );
+            })}
+
+            {NODES.map((node) => {
+              const meta = CATEGORY_META[node.category];
+              const isActive = activeNodes.has(node.id);
+              const isCompleted = completedNodes.has(node.id);
+              const isSelected = selectedId === node.id;
+              const cls = [
+                "node",
+                isActive ? "active" : "",
+                isCompleted ? "completed" : "",
+                isSelected ? "selected" : "",
+              ]
+                .filter(Boolean)
+                .join(" ");
+              return (
+                <g
+                  key={node.id}
+                  className={cls}
+                  data-node-id={node.id}
+                  data-active={isActive ? "true" : "false"}
+                  data-completed={isCompleted ? "true" : "false"}
+                  data-testid={`node-${node.id}`}
+                  transform={`translate(${node.x} ${node.y})`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedId(node.id);
+                  }}
+                >
+                  <rect
+                    className="node-body"
+                    width={node.w}
+                    height={node.h}
+                    fill={meta.fill}
+                    stroke={meta.stroke}
+                  />
+                  <text
+                    className="node-label"
+                    x={10}
+                    y={node.sublabel ? 18 : node.h / 2 + 4}
+                    fill={meta.text}
+                  >
+                    {node.label.length > 22 ? `${node.label.slice(0, 20)}…` : node.label}
+                  </text>
+                  {node.sublabel ? (
+                    <text className="node-sub" x={10} y={34} fill={meta.text}>
+                      {node.sublabel}
+                    </text>
+                  ) : null}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+
+      <aside className="legend" data-testid="legend" aria-label="凡例">
+        <h2>凡例</h2>
+        <ul>
+          {(Object.keys(CATEGORY_META) as NodeCategory[]).map((key) => {
+            const m = CATEGORY_META[key];
+            return (
+              <li key={key}>
+                <span className="swatch" style={{ background: m.fill, borderColor: m.stroke }} />
+                {m.label}
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <div className="step-overlay" data-testid="step-overlay" aria-live="polite">
+        <div className="step-head">
+          <span className="step-badge" data-testid="step-badge">
+            {stepIndex + 1}/{totalSteps} STEP {step.index}:
+          </span>
+          <span className="step-title" data-testid="step-title">
+            {step.title}
+          </span>
+        </div>
+        <pre className="step-detail" data-testid="step-detail">
+          {step.detail}
+        </pre>
+        <div className="progress" data-testid="step-progress">
+          <span style={{ width: `${progressPct}%` }} />
+        </div>
+      </div>
+
+      <div className="minimap" data-testid="minimap" aria-label="ミニマップ">
+        <svg viewBox={`0 0 ${WORLD.width} ${WORLD.height}`} preserveAspectRatio="xMidYMid meet">
+          {NODES.map((node) => {
+            const m = CATEGORY_META[node.category];
+            const isActive = activeNodes.has(node.id);
+            return (
+              <rect
+                key={node.id}
+                className="mm-node"
+                x={node.x}
+                y={node.y}
+                width={node.w}
+                height={node.h}
+                rx={4}
+                fill={m.fill}
+                stroke={isActive ? m.stroke : "transparent"}
+                strokeWidth={isActive ? 6 : 0}
+                opacity={isActive ? 1 : 0.55}
+              />
+            );
+          })}
+          {/* rough viewport indicator */}
+          <rect
+            className="mm-viewport"
+            x={(-camera.x / camera.scale)}
+            y={(-camera.y / camera.scale)}
+            width={(viewportRef.current?.clientWidth ?? 1200) / camera.scale}
+            height={(viewportRef.current?.clientHeight ?? 700) / camera.scale}
+          />
+        </svg>
+      </div>
+
+      {selected ? (
+        <button
+          type="button"
+          className="drawer-backdrop"
+          aria-label="詳細を閉じる"
+          data-testid="drawer-backdrop"
+          onClick={() => setSelectedId(null)}
+        />
+      ) : null}
+
+      <aside
+        className={`drawer${selected ? " open" : ""}`}
+        data-testid="node-drawer"
+        data-open={selected ? "true" : "false"}
+        aria-hidden={selected ? "false" : "true"}
+      >
+        {selected ? (
+          <>
+            <div className="drawer-head">
+              <div>
+                <h2 data-testid="drawer-title">{selected.method && selected.path ? `${selected.method} ${selected.path}` : selected.label}</h2>
+                <div className="api-type">
+                  {CATEGORY_META[selected.category].label}
+                  {selected.method ? " · API" : ""}
+                </div>
+              </div>
+              <button
+                type="button"
+                className="drawer-close"
+                aria-label="閉じる"
+                data-testid="drawer-close"
+                onClick={() => setSelectedId(null)}
+              >
+                ✕
+              </button>
+            </div>
+            <div className="drawer-body">
+              {(selected.method || selected.path) && (
+                <section>
+                  <h3>エンドポイント</h3>
+                  <div className="method-path">
+                    {selected.method ? <span className="method-badge">{selected.method}</span> : null}
+                    <span data-testid="drawer-path">{selected.path ?? selected.label}</span>
+                  </div>
+                </section>
+              )}
+              <section>
+                <h3>概要</h3>
+                <p data-testid="drawer-overview">{selected.overview}</p>
+              </section>
+              <section>
+                <h3>実装コード</h3>
+                <pre data-testid="drawer-code">{selected.code}</pre>
+              </section>
+              <section>
+                <h3>ソース</h3>
+                <div className="source-link" data-testid="drawer-source">
+                  {selected.sourceLink}
+                </div>
+              </section>
+            </div>
+          </>
+        ) : null}
+      </aside>
+    </div>
+  );
+}
+
+const root = document.getElementById("runtime-board-root");
+if (!root) throw new Error("runtime-board-root not found");
+createRoot(root).render(<App />);

--- a/beta/tests/visual/runtime_board.spec.js
+++ b/beta/tests/visual/runtime_board.spec.js
@@ -1,0 +1,102 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+const ENTRY = "/src/labs/runtime-board/runtime-board.html";
+
+async function openBoard(page) {
+  await page.goto(ENTRY);
+  await expect(page.getByTestId("runtime-board")).toBeVisible();
+  await expect(page.getByTestId("graph-svg")).toBeVisible();
+  await expect(page.getByTestId("playback-controls")).toBeVisible();
+}
+
+test.describe("runtime-board video repro", () => {
+  test("loads dark board with graph, legend, minimap, and step overlay", async ({ page }) => {
+    await openBoard(page);
+
+    await expect(page.getByRole("heading", { name: /条件付き確率 生成パイプライン/ })).toBeVisible();
+    await expect(page.getByTestId("legend")).toBeVisible();
+    await expect(page.getByTestId("minimap")).toBeVisible();
+    await expect(page.getByTestId("step-overlay")).toBeVisible();
+    await expect(page.getByTestId("step-counter")).toContainText("1");
+    await expect(page.getByTestId("step-title")).toHaveText("API リクエスト受信");
+
+    // Dense graph: multiple category nodes present
+    await expect(page.getByTestId("node-api-condition-rate")).toBeVisible();
+    await expect(page.getByTestId("node-phase1")).toBeVisible();
+    await expect(page.getByTestId("node-t-municipal")).toBeVisible();
+    await expect(page.getByTestId("node-out-condition-rate")).toBeVisible();
+
+    // Step 1: API endpoint is active
+    await expect(page.getByTestId("node-api-condition-rate")).toHaveAttribute("data-active", "true");
+  });
+
+  test("manual step progression updates counter, title, and active states", async ({ page }) => {
+    await openBoard(page);
+
+    const activeBefore = await page.locator('[data-testid^="node-"][data-active="true"]').evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-testid"))
+    );
+    expect(activeBefore).toContain("node-api-condition-rate");
+
+    await page.getByTestId("btn-next").click();
+    await expect(page.getByTestId("step-counter")).toContainText("2");
+    await expect(page.getByTestId("step-badge")).toContainText("2/");
+    await expect(page.getByTestId("step-title")).not.toHaveText("API リクエスト受信");
+
+    const activeAfter = await page.locator('[data-testid^="node-"][data-active="true"]').evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-testid"))
+    );
+    expect(activeAfter).not.toEqual(activeBefore);
+    // Step 2 activates service + API
+    await expect(page.getByTestId("node-condition-rate-service")).toHaveAttribute("data-active", "true");
+
+    // Progress further to Phase 1 (step 5)
+    await page.getByTestId("btn-next").click();
+    await page.getByTestId("btn-next").click();
+    await page.getByTestId("btn-next").click();
+    await expect(page.getByTestId("step-counter")).toContainText("5");
+    await expect(page.getByTestId("step-title")).toHaveText("Phase 1 基盤抽選");
+    await expect(page.getByTestId("node-phase1")).toHaveAttribute("data-active", "true");
+    await expect(page.getByTestId("node-t-age")).toHaveAttribute("data-active", "true");
+
+    // Completed nodes remain marked after advancing past them
+    await page.getByTestId("btn-next").click();
+    await expect(page.getByTestId("step-counter")).toContainText("6");
+    await expect(page.getByTestId("node-phase1")).toHaveAttribute("data-completed", "true");
+
+    // Previous steps back
+    await page.getByTestId("btn-prev").click();
+    await expect(page.getByTestId("step-counter")).toContainText("5");
+  });
+
+  test("node click opens detail drawer with API-like content", async ({ page }) => {
+    await openBoard(page);
+
+    await expect(page.getByTestId("node-drawer")).toHaveAttribute("data-open", "false");
+
+    await page.getByTestId("node-api-tables-id").click();
+    await expect(page.getByTestId("node-drawer")).toHaveAttribute("data-open", "true");
+    await expect(page.getByTestId("drawer-title")).toContainText("/v1/tables");
+    await expect(page.getByTestId("drawer-overview")).toBeVisible();
+    await expect(page.getByTestId("drawer-code")).toContainText("loadTable");
+    await expect(page.getByTestId("drawer-source")).toContainText("handlers");
+
+    await page.getByTestId("drawer-close").click();
+    await expect(page.getByTestId("node-drawer")).toHaveAttribute("data-open", "false");
+
+    // Second node: condition-rate API
+    await page.getByTestId("node-api-condition-rate").click();
+    await expect(page.getByTestId("node-drawer")).toHaveAttribute("data-open", "true");
+    await expect(page.getByTestId("drawer-path")).toContainText("condition-rate");
+    await expect(page.getByTestId("drawer-code")).toContainText("conditions");
+  });
+
+  test("play button advances steps over time", async ({ page }) => {
+    await openBoard(page);
+    await expect(page.getByTestId("step-counter")).toContainText("1");
+    await page.getByTestId("btn-play").click();
+    await expect(page.getByTestId("step-counter")).toContainText("2", { timeout: 4000 });
+    await page.getByTestId("btn-play").click(); // pause
+  });
+});

--- a/beta/vite.config.mjs
+++ b/beta/vite.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
         "edge-port-lab": "src/labs/edge-port/edge-port-lab.html",
         "node-lab": "src/labs/node/node-lab.html",
         "pn-lab": "src/labs/pn/pn-lab.html",
+        "runtime-board": "src/labs/runtime-board/runtime-board.html",
       },
       output: {
         entryFileNames: "[name].js",
@@ -35,6 +36,7 @@ export default defineConfig({
           if (name.includes("edge-port-lab")) return "edge-port-lab.css";
           if (name.includes("node-lab")) return "node-lab.css";
           if (name.includes("pn-lab")) return "pn-lab.css";
+          if (name.includes("runtime-board")) return "runtime-board.css";
           return name.includes("layout-lab") ? "layout-lab.css" : "workbench-ui.css";
         },
       },


### PR DESCRIPTION
## Summary
- add an isolated Beta Runtime Board lab reproducing the supplied X video experience
- render a dense color-coded pipeline with animated step playback, active/completed paths, bottom step overlay, node detail drawer, legend, minimap, pan, and zoom
- add dedicated Vite wiring and focused Playwright coverage

## Verification
- `npm --prefix beta run build`
- `cd beta && npx tsc --noEmit -p tsconfig.labs.json`
- `npm --prefix beta run test:runtime-board` (4 passed)

## Scope
- `beta/` only
- no map data/schema, collaboration, sync, or `final/` changes

## Residual differences
- graph labels and placement are approximated from extracted video frames
- playback does not auto-pan the camera to the active path