### PR TITLE
feat(beta): preview linked Markdown on node hover

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -22,6 +22,7 @@ import { renderNode as renderNodeSvg } from "../shared/node_draw_svg";
 import { routeParentChildEdge, type ParentChildSurfaceMode } from "../shared/parent_child_edge_adapter";
 import type { EdgeRouteStyle } from "../shared/edge_route";
 import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, isMarkdownLinkSubtype, localPathLinkToOpen, safeExternalLinkToOpen } from "../shared/markdown_link_node";
+import { resolveMarkdownFilePreviewTarget, type MarkdownFilePreviewTarget } from "../shared/markdown_file_preview";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
 
 type PublicLayoutOptions = Pick<LayoutOptions, "spacing" | "direction" | "depthAlign" | "edge" | "link">;
@@ -269,12 +270,55 @@ let routingScopeHoldDown = false;
 let routingWheelCarryX = 0;
 let routingWheelCarryY = 0;
 
+type MarkdownPreviewMode = "manual" | "hover" | "pinned";
+const MARKDOWN_HOVER_OPEN_DELAY_MS = 400;
+const MARKDOWN_HOVER_CLOSE_DELAY_MS = 300;
+const MARKDOWN_PREVIEW_CACHE_TTL_MS = 10_000;
+let markdownPreviewMode: MarkdownPreviewMode | null = null;
+let markdownPreviewNodeId: string | null = null;
+let markdownHoverOpenTimer: ReturnType<typeof setTimeout> | null = null;
+let markdownHoverCloseTimer: ReturnType<typeof setTimeout> | null = null;
+let markdownPreviewRequestId = 0;
+let markdownPreviewAbortController: AbortController | null = null;
+const markdownPreviewCache = new Map<string, { cachedAt: number; payload: LocalFsReadResponse }>();
+
+function cancelMarkdownHoverOpen(): void {
+  if (markdownHoverOpenTimer !== null) {
+    clearTimeout(markdownHoverOpenTimer);
+    markdownHoverOpenTimer = null;
+  }
+}
+
+function cancelMarkdownHoverClose(): void {
+  if (markdownHoverCloseTimer !== null) {
+    clearTimeout(markdownHoverCloseTimer);
+    markdownHoverCloseTimer = null;
+  }
+}
+
+function syncMarkdownPreviewMode(mode: MarkdownPreviewMode | null, nodeId: string | null): void {
+  markdownPreviewMode = mode;
+  markdownPreviewNodeId = nodeId;
+  if (!markdownPreviewPanelEl) return;
+  if (mode) markdownPreviewPanelEl.dataset["previewMode"] = mode;
+  else delete markdownPreviewPanelEl.dataset["previewMode"];
+  if (nodeId) markdownPreviewPanelEl.dataset["previewNodeId"] = nodeId;
+  else delete markdownPreviewPanelEl.dataset["previewNodeId"];
+}
+
 function hideMarkdownPreview(): void {
+  cancelMarkdownHoverOpen();
+  cancelMarkdownHoverClose();
+  markdownPreviewRequestId += 1;
+  markdownPreviewAbortController?.abort();
+  markdownPreviewAbortController = null;
+  syncMarkdownPreviewMode(null, null);
   if (markdownPreviewPanelEl) markdownPreviewPanelEl.hidden = true;
 }
 
-function showMarkdownPreview(src: string, title: string): void {
+function showMarkdownPreview(src: string, title: string, mode: MarkdownPreviewMode, nodeId: string): void {
   if (!markdownPreviewPanelEl || !markdownPreviewBodyEl) return;
+  syncMarkdownPreviewMode(mode, nodeId);
   markdownPreviewPanelEl.hidden = false;
   const titleEl = markdownPreviewPanelEl.querySelector(".markdown-preview-title") as HTMLElement | null;
   if (titleEl) titleEl.textContent = title;
@@ -304,12 +348,22 @@ function toggleMarkdownPreviewForSelectedNode(): void {
     setStatus("Selected node has no details or note.");
     return;
   }
-  showMarkdownPreview(body, `Markdown: ${node.text || "(untitled)"}`);
+  showMarkdownPreview(body, `Markdown: ${node.text || "(untitled)"}`, "manual", node.id);
 }
 
 if (markdownPreviewCloseBtn) {
   markdownPreviewCloseBtn.addEventListener("click", () => hideMarkdownPreview());
 }
+
+markdownPreviewPanelEl?.addEventListener("pointerenter", () => {
+  cancelMarkdownHoverClose();
+});
+
+markdownPreviewPanelEl?.addEventListener("pointerleave", () => {
+  if (markdownPreviewMode === "hover") {
+    scheduleMarkdownHoverClose();
+  }
+});
 
 function normalizeDocId(raw: string | null, fallback: string): string {
   const trimmed = (raw || "").trim();
@@ -1252,12 +1306,12 @@ function resetLocalFsTree(): void {
   setLocalFsPreview("Preview", "");
 }
 
-async function fetchLocalFsJson<T>(action: "list" | "read", params: Record<string, string>): Promise<T> {
+async function fetchLocalFsJson<T>(action: "list" | "read", params: Record<string, string>, init?: RequestInit): Promise<T> {
   const url = new URL(`/api/local-fs/${action}`, window.location.origin);
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }
-  const response = await fetch(url.toString());
+  const response = await fetch(url.toString(), init);
   const payload = await response.json().catch(() => null) as T | { error?: { message?: string } } | null;
   if (!response.ok) {
     const errorPayload = payload && typeof payload === "object" && "error" in payload ? payload : null;
@@ -1319,6 +1373,105 @@ async function readLocalFsFile(relativePath: string, title: string): Promise<voi
     setLocalFsPreview(title, "");
     setLocalFsStatus((err as Error).message, true);
   }
+}
+
+function markdownPreviewAllowedRoots(): string[] {
+  if (LOCAL_FS_VIEW_MODE) {
+    return [LOCAL_FS_VIEW_ROOT, vaultUiPrefs.vaultPath, localFsPrefs.rootPath];
+  }
+  return [vaultUiPrefs.vaultPath, localFsPrefs.rootPath];
+}
+
+function markdownPreviewTargetForNode(nodeId: string): MarkdownFilePreviewTarget | null {
+  const node = map?.state.nodes[nodeId];
+  if (!node || isAliasNode(node)) return null;
+  return resolveMarkdownFilePreviewTarget(node, {
+    allowedRootPaths: markdownPreviewAllowedRoots(),
+  });
+}
+
+function markdownPreviewCacheKey(target: MarkdownFilePreviewTarget): string {
+  return `${target.rootPath}\u0000${target.relativePath}`;
+}
+
+async function showMarkdownFilePreviewForNode(nodeId: string, mode: "hover" | "pinned"): Promise<void> {
+  const target = markdownPreviewTargetForNode(nodeId);
+  if (!target) return;
+
+  cancelMarkdownHoverOpen();
+  cancelMarkdownHoverClose();
+  markdownPreviewRequestId += 1;
+  const requestId = markdownPreviewRequestId;
+  markdownPreviewAbortController?.abort();
+  markdownPreviewAbortController = null;
+
+  const title = `Markdown: ${target.relativePath}`;
+  const key = markdownPreviewCacheKey(target);
+  const cached = markdownPreviewCache.get(key);
+  if (cached && Date.now() - cached.cachedAt <= MARKDOWN_PREVIEW_CACHE_TTL_MS) {
+    showMarkdownPreview(cached.payload.content, title, mode, nodeId);
+    return;
+  }
+
+  showMarkdownPreview("Loading…", title, mode, nodeId);
+  const controller = new AbortController();
+  markdownPreviewAbortController = controller;
+  try {
+    const payload = await fetchLocalFsJson<LocalFsReadResponse>("read", {
+      rootPath: target.rootPath,
+      relativePath: target.relativePath,
+      maxBytes: String(256 * 1024),
+    }, { signal: controller.signal });
+    if (requestId !== markdownPreviewRequestId || markdownPreviewNodeId !== nodeId) return;
+    markdownPreviewCache.set(key, { cachedAt: Date.now(), payload });
+    const renderedTitle = `${title}${payload.truncated ? " (truncated)" : ""}`;
+    showMarkdownPreview(payload.content, renderedTitle, mode, nodeId);
+  } catch (err) {
+    if (controller.signal.aborted || requestId !== markdownPreviewRequestId) return;
+    showMarkdownPreview(`Preview unavailable.\n\n${(err as Error).message}`, title, mode, nodeId);
+  } finally {
+    if (markdownPreviewAbortController === controller) {
+      markdownPreviewAbortController = null;
+    }
+  }
+}
+
+function scheduleMarkdownHoverOpen(nodeId: string): void {
+  if (markdownPreviewMode === "manual" || markdownPreviewMode === "pinned") return;
+  const target = markdownPreviewTargetForNode(nodeId);
+  if (!target) {
+    if (markdownPreviewMode === "hover") scheduleMarkdownHoverClose();
+    return;
+  }
+  cancelMarkdownHoverOpen();
+  cancelMarkdownHoverClose();
+  if (markdownPreviewMode === "hover" && markdownPreviewNodeId === nodeId) return;
+  markdownHoverOpenTimer = setTimeout(() => {
+    markdownHoverOpenTimer = null;
+    void showMarkdownFilePreviewForNode(nodeId, "hover");
+  }, MARKDOWN_HOVER_OPEN_DELAY_MS);
+}
+
+function scheduleMarkdownHoverClose(): void {
+  cancelMarkdownHoverOpen();
+  cancelMarkdownHoverClose();
+  if (markdownPreviewMode !== "hover") return;
+  markdownHoverCloseTimer = setTimeout(() => {
+    markdownHoverCloseTimer = null;
+    if (markdownPreviewMode === "hover") hideMarkdownPreview();
+  }, MARKDOWN_HOVER_CLOSE_DELAY_MS);
+}
+
+function pinMarkdownHoverPreviewForNode(nodeId: string): void {
+  if (markdownPreviewMode !== "hover" || markdownPreviewNodeId !== nodeId) return;
+  cancelMarkdownHoverClose();
+  syncMarkdownPreviewMode("pinned", nodeId);
+}
+
+function eventNodeId(target: EventTarget | null): string | null {
+  return target instanceof Element
+    ? target.closest("[data-node-id]")?.getAttribute("data-node-id") || null
+    : null;
 }
 
 function renderLocalFsRow(entry: LocalFsEntry, depth: number, container: HTMLElement): void {
@@ -14295,6 +14448,24 @@ document.addEventListener("click", () => {
   closeToolbarMenus();
 });
 
+canvas.addEventListener("pointerover", (event: PointerEvent) => {
+  if (event.pointerType && event.pointerType !== "mouse") return;
+  const nodeId = eventNodeId(event.target);
+  if (!nodeId) return;
+  if (eventNodeId(event.relatedTarget) === nodeId) return;
+  scheduleMarkdownHoverOpen(nodeId);
+});
+
+canvas.addEventListener("pointerout", (event: PointerEvent) => {
+  if (event.pointerType && event.pointerType !== "mouse") return;
+  const nodeId = eventNodeId(event.target);
+  if (!nodeId || eventNodeId(event.relatedTarget) === nodeId) return;
+  cancelMarkdownHoverOpen();
+  if (markdownPreviewMode === "hover" && markdownPreviewNodeId === nodeId) {
+    scheduleMarkdownHoverClose();
+  }
+});
+
 canvas.addEventListener("pointerdown", (event: PointerEvent) => {
   if (annotationTool !== "select") {
     return;
@@ -14442,6 +14613,7 @@ canvas.addEventListener("pointerdown", (event: PointerEvent) => {
   if (isReadOnlyLink()) {
     event.preventDefault();
     setSingleSelection(nodeId, event.shiftKey);
+    pinMarkdownHoverPreviewForNode(nodeId);
     board.focus();
     scheduleRender();
     return;
@@ -14538,6 +14710,7 @@ function finishNodeDrag(event: PointerEvent): void {
       toggle: toggleKey,
       range: shiftKey,
     });
+    pinMarkdownHoverPreviewForNode(sourceNodeId);
     board.focus();
     return;
   }
@@ -14885,6 +15058,13 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
   }
 
   if (document.activeElement === linearTextEl) {
+    return;
+  }
+
+  if (markdownPreviewMode && event.key === "Escape") {
+    event.preventDefault();
+    hideMarkdownPreview();
+    board.focus();
     return;
   }
 

--- a/beta/src/shared/markdown_file_preview.ts
+++ b/beta/src/shared/markdown_file_preview.ts
@@ -1,0 +1,139 @@
+export interface MarkdownFilePreviewNodeFields {
+  link?: string;
+  attributes?: Record<string, string>;
+}
+
+export interface MarkdownFilePreviewTarget {
+  rootPath: string;
+  relativePath: string;
+}
+
+export interface MarkdownFilePreviewContext {
+  allowedRootPaths: string[];
+}
+
+function normalizeSeparators(value: string): string {
+  return value.trim().replace(/\\/g, "/").replace(/\/+$/g, "");
+}
+
+function decodedPath(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function pathWithoutFragment(value: string): string {
+  return decodedPath(value.trim().split("#", 1)[0] || "");
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith("/") || isWindowsAbsolutePath(value);
+}
+
+function isMarkdownPath(value: string): boolean {
+  return /\.(?:md|markdown)$/i.test(pathWithoutFragment(value));
+}
+
+function normalizedRootKey(value: string): string {
+  const normalized = normalizeSeparators(value);
+  return isWindowsAbsolutePath(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function normalizedAbsoluteKey(value: string): string {
+  const normalized = normalizeSeparators(value);
+  return isWindowsAbsolutePath(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function relativePathWithinRoot(absolutePath: string, rootPath: string): string | null {
+  const rootKey = normalizedRootKey(rootPath);
+  const absoluteKey = normalizedAbsoluteKey(absolutePath);
+  if (!rootKey || !absoluteKey || absoluteKey === rootKey) {
+    return null;
+  }
+  if (!absoluteKey.startsWith(`${rootKey}/`)) {
+    return null;
+  }
+  const normalizedAbsolute = normalizeSeparators(absolutePath);
+  const normalizedRoot = normalizeSeparators(rootPath);
+  return normalizedAbsolute.slice(normalizedRoot.length + 1);
+}
+
+function safeRelativePath(value: string): string | null {
+  const normalized = normalizeSeparators(pathWithoutFragment(value)).replace(/^\.\//, "");
+  if (!normalized || isAbsolutePath(normalized)) {
+    return null;
+  }
+  const segments = normalized.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    return null;
+  }
+  return normalized;
+}
+
+function uniqueAllowedRoots(context: MarkdownFilePreviewContext): string[] {
+  const seen = new Set<string>();
+  const roots: string[] = [];
+  for (const rawRoot of context.allowedRootPaths) {
+    const root = normalizeSeparators(String(rawRoot || ""));
+    const key = normalizedRootKey(root);
+    if (!root || !isAbsolutePath(root) || seen.has(key)) continue;
+    seen.add(key);
+    roots.push(root);
+  }
+  return roots;
+}
+
+function matchingAllowedRoot(rawRoot: string, allowedRoots: string[]): string | null {
+  const key = normalizedRootKey(rawRoot);
+  return allowedRoots.find((root) => normalizedRootKey(root) === key) || null;
+}
+
+export function resolveMarkdownFilePreviewTarget(
+  node: MarkdownFilePreviewNodeFields,
+  context: MarkdownFilePreviewContext,
+): MarkdownFilePreviewTarget | null {
+  const attributes = node.attributes || {};
+  const allowedRoots = uniqueAllowedRoots(context);
+  if (allowedRoots.length === 0) return null;
+
+  const localFsRelativePath = attributes["local-fs:relative-path"] || "";
+  const localFsRootPath = attributes["local-fs:root-path"] || "";
+  if (isMarkdownPath(localFsRelativePath)) {
+    const rootPath = matchingAllowedRoot(localFsRootPath, allowedRoots);
+    const relativePath = safeRelativePath(localFsRelativePath);
+    if (rootPath && relativePath) {
+      return { rootPath, relativePath };
+    }
+  }
+
+  const vaultRelativePath = attributes["vault:path"] || "";
+  if (attributes["vault:kind"] === "file" && isMarkdownPath(vaultRelativePath)) {
+    const relativePath = safeRelativePath(vaultRelativePath);
+    if (relativePath) {
+      return { rootPath: allowedRoots[0]!, relativePath };
+    }
+  }
+
+  const linkPath = pathWithoutFragment(String(node.link || ""));
+  if (!isMarkdownPath(linkPath)) return null;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(linkPath) && !isWindowsAbsolutePath(linkPath)) {
+    return null;
+  }
+
+  if (isAbsolutePath(linkPath)) {
+    for (const rootPath of allowedRoots.sort((a, b) => b.length - a.length)) {
+      const relativePath = relativePathWithinRoot(linkPath, rootPath);
+      if (relativePath) return { rootPath, relativePath };
+    }
+    return null;
+  }
+
+  const relativePath = safeRelativePath(linkPath);
+  return relativePath ? { rootPath: allowedRoots[0]!, relativePath } : null;
+}

--- a/beta/tests/e2e/markdown_hover_preview.spec.js
+++ b/beta/tests/e2e/markdown_hover_preview.spec.js
@@ -1,0 +1,59 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+let previewRoot;
+
+test.beforeAll(() => {
+  previewRoot = fs.mkdtempSync(path.join(os.tmpdir(), "m3e-markdown-hover-"));
+  fs.writeFileSync(
+    path.join(previewRoot, "preview.md"),
+    "# Hover Preview\n\nRead-only Markdown content.\n\n- first\n- second\n",
+    "utf8",
+  );
+});
+
+test.afterAll(() => {
+  if (previewRoot) fs.rmSync(previewRoot, { recursive: true, force: true });
+});
+
+test("Markdown file node hover previews, panel hover preserves, click pins, and Escape closes", async ({ page }, testInfo) => {
+  await page.goto(`/viewer.html?localFsRoot=${encodeURIComponent(previewRoot)}`);
+  await expect(page.locator("#meta")).toContainText("nodes: 2", { timeout: 15_000 });
+  await page.locator("#board").click({ position: { x: 500, y: 500 } });
+  await page.keyboard.press("Alt+v");
+  await page.waitForTimeout(300);
+
+  const fileNode = page.locator('rect.node-hit[data-node-id="localfs:preview.md"]');
+  const panel = page.locator("#markdown-preview-panel");
+  await expect(fileNode).toBeVisible();
+
+  await fileNode.hover();
+  await expect(panel).toBeVisible({ timeout: 2_000 });
+  await expect(panel).toHaveAttribute("data-preview-mode", "hover");
+  await expect(panel.locator("h1")).toHaveText("Hover Preview");
+  await expect(panel).toContainText("Read-only Markdown content.");
+
+  await page.mouse.move(40, 700);
+  await expect(panel).toBeHidden({ timeout: 2_000 });
+
+  await fileNode.hover();
+  await expect(panel).toBeVisible({ timeout: 2_000 });
+  await panel.hover();
+  await page.waitForTimeout(250);
+  await expect(panel).toBeVisible();
+
+  await fileNode.click({ force: true });
+  await expect(panel).toHaveAttribute("data-preview-mode", "pinned");
+  await expect(panel.locator(".markdown-preview-title")).toContainText("preview.md");
+
+  await page.mouse.move(40, 700);
+  await page.waitForTimeout(250);
+  await expect(panel).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("markdown-hover-preview.png") });
+
+  await page.keyboard.press("Escape");
+  await expect(panel).toBeHidden();
+});

--- a/beta/tests/unit/markdown_file_preview.test.ts
+++ b/beta/tests/unit/markdown_file_preview.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { resolveMarkdownFilePreviewTarget } from "../../src/shared/markdown_file_preview";
+
+const root = "/Users/example/vault";
+
+describe("Markdown file preview target resolution", () => {
+  test("resolves a relative Markdown link under the preferred allowed root", () => {
+    expect(resolveMarkdownFilePreviewTarget(
+      { link: "notes/alpha.md" },
+      { allowedRootPaths: [root] },
+    )).toEqual({ rootPath: root, relativePath: "notes/alpha.md" });
+  });
+
+  test("resolves an absolute Markdown link only when it is inside an allowed root", () => {
+    expect(resolveMarkdownFilePreviewTarget(
+      { link: "/Users/example/vault/notes/alpha.markdown#section" },
+      { allowedRootPaths: [root] },
+    )).toEqual({ rootPath: root, relativePath: "notes/alpha.markdown" });
+    expect(resolveMarkdownFilePreviewTarget(
+      { link: "/Users/example/private/secret.md" },
+      { allowedRootPaths: [root] },
+    )).toBeNull();
+  });
+
+  test("uses local filesystem node metadata when its root is allowed", () => {
+    expect(resolveMarkdownFilePreviewTarget({
+      attributes: {
+        "local-fs:root-path": root,
+        "local-fs:relative-path": "docs/design.md",
+      },
+    }, { allowedRootPaths: [root] })).toEqual({
+      rootPath: root,
+      relativePath: "docs/design.md",
+    });
+  });
+
+  test("uses vault file metadata under the active vault root", () => {
+    expect(resolveMarkdownFilePreviewTarget({
+      attributes: {
+        "vault:kind": "file",
+        "vault:path": "daily/2026-08-02.md",
+      },
+    }, { allowedRootPaths: [root] })).toEqual({
+      rootPath: root,
+      relativePath: "daily/2026-08-02.md",
+    });
+  });
+
+  test("rejects traversal, non-Markdown files, and URL schemes", () => {
+    expect(resolveMarkdownFilePreviewTarget({ link: "../secret.md" }, { allowedRootPaths: [root] })).toBeNull();
+    expect(resolveMarkdownFilePreviewTarget({ link: "notes/image.png" }, { allowedRootPaths: [root] })).toBeNull();
+    expect(resolveMarkdownFilePreviewTarget({ link: "https://example.com/readme.md" }, { allowedRootPaths: [root] })).toBeNull();
+  });
+});

--- a/beta/viewer.css
+++ b/beta/viewer.css
@@ -3154,7 +3154,7 @@
       .markdown-preview-panel {
         position: absolute;
         top: 60px;
-        right: 14px;
+        right: 326px;
         z-index: 13;
         width: 420px;
         max-width: calc(100vw - 40px);
@@ -3192,6 +3192,19 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+
+      .markdown-preview-panel[data-preview-mode="pinned"] .markdown-preview-title::after {
+        content: "PINNED";
+        display: inline-block;
+        margin-left: 8px;
+        padding: 2px 5px;
+        border: 1px solid currentColor;
+        border-radius: 999px;
+        font-size: 9px;
+        line-height: 1;
+        letter-spacing: 0.08em;
+        vertical-align: 1px;
       }
 
       .markdown-preview-close {
@@ -3293,6 +3306,12 @@
       .markdown-mermaid svg {
         max-width: 100%;
         height: auto;
+      }
+
+      @media (max-width: 980px) {
+        .markdown-preview-panel {
+          right: 14px;
+        }
       }
 
       .markdown-mermaid-fallback,

--- a/beta/viewer.html
+++ b/beta/viewer.html
@@ -250,7 +250,7 @@
           </div>
         </div>
       </div>
-      <div id="markdown-preview-panel" class="markdown-preview-panel" hidden>
+      <div id="markdown-preview-panel" class="markdown-preview-panel" hidden aria-live="polite">
         <div class="markdown-preview-header">
           <span class="markdown-preview-title">Markdown Preview</span>
           <button id="markdown-preview-close" class="markdown-preview-close" type="button" aria-label="Close markdown preview">&times;</button>


### PR DESCRIPTION
## Summary
- show linked local Markdown in the existing read-only preview panel after a 400 ms node hover
- close transient previews after leaving, preserve them while hovering the panel, pin on node click, and close with Escape
- constrain preview resolution to configured local filesystem or vault roots and keep the panel clear of the Workbench inspector

## Verification
- npm run build
- npm run test:unit (568 passed, 12 skipped)
- npm run lint:deps
- npx playwright test tests/e2e/markdown_hover_preview.spec.js --config playwright.e2e.config.js (1 passed)
- screenshot visually inspected: rendered heading, body, list, pinned badge, and inspector-safe placement