### PR TITLE
fix(beta): make scope path copy reliable

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -9152,13 +9152,16 @@ function buildMapPath(nodeId: string): string | null {
 }
 
 function formatMapPath(pathNodes: TreeNode[]): string {
+  const configuredLabel = MAP_META[LOCAL_MAP_ID]?.label;
+  const rootLabel = map?.state.nodes[map.state.rootId]?.text?.trim();
+  const mapLabel = configuredLabel || rootLabel || MAP_LABEL;
   const parts = pathNodes
     .filter((node) => node.id !== map?.state.rootId)
     .map((node) => ({ label: uiLabel(node), isScopeRoot: isFolderNode(node) }));
   if (parts.length === 0) {
-    return `M:(${MAP_LABEL})> root`;
+    return `M:(${mapLabel})> root`;
   }
-  let path = `M:(${MAP_LABEL})> ${parts[0].label}`;
+  let path = `M:(${mapLabel})> ${parts[0].label}`;
   for (let i = 1; i < parts.length; i++) {
     path += parts[i].isScopeRoot ? " >> " : " > ";
     path += parts[i].label;
@@ -9168,19 +9171,15 @@ function formatMapPath(pathNodes: TreeNode[]): string {
 
 async function copyMapPathToClipboard(nodeId: string): Promise<void> {
   const path = buildMapPath(nodeId);
-  if (!path) return;
-  try {
-    await navigator.clipboard.writeText(path);
-  } catch {
-    // Fallback: textarea + execCommand for older contexts
-    const ta = document.createElement("textarea");
-    ta.value = path;
-    ta.style.position = "fixed";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.select();
-    try { document.execCommand("copy"); } finally { ta.remove(); }
+  if (!path) {
+    setStatus("Failed to copy node path: node not found.", true);
+    return;
   }
+  if (await copyTextToSystemClipboard(path)) {
+    setStatus(`Path copied: ${path}`);
+    return;
+  }
+  setStatus("Failed to copy node path to system clipboard.", true);
 }
 
 function showScopeLockContextMenu(x: number, y: number, scopeId: string): void {
@@ -13570,27 +13569,9 @@ async function readTextFromSystemClipboard(): Promise<string | null> {
   return (await readTextViaLocalClipboardApi()) || (await readTextViaBrowserClipboard());
 }
 
-function buildNodePath(nodeId: string): string {
-  if (!map) return "";
-  const pathNodes: TreeNode[] = [];
-  let cursor: string | null = nodeId;
-  while (cursor) {
-    const n: TreeNode | undefined = map.state.nodes[cursor];
-    if (!n) break;
-    pathNodes.unshift(n);
-    cursor = n.parentId ?? null;
-  }
-  return formatMapPath(pathNodes);
-}
-
 async function copyNodePath(): Promise<void> {
   if (!map) return;
-  const path = buildNodePath(viewState.selectedNodeId);
-  if (await copyTextToSystemClipboard(path)) {
-    setStatus(`Path copied: ${path}`);
-    return;
-  }
-  setStatus("Failed to copy path to system clipboard.", true);
+  await copyMapPathToClipboard(viewState.selectedNodeId);
 }
 
 async function copyScopeId(): Promise<void> {

--- a/beta/src/node/start_viewer.ts
+++ b/beta/src/node/start_viewer.ts
@@ -585,7 +585,10 @@ function redirectLoopbackHost(req: http.IncomingMessage, res: http.ServerRespons
 function writeSystemClipboard(text: string): { ok: true; method: string } | { ok: false; error: string } {
   const input = Buffer.from(text, "utf8");
   const run = (command: string, args: string[], method: string) => {
-    const result = spawnSync(command, args, { input, encoding: "utf8" });
+    const env = process.platform === "darwin"
+      ? { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", LC_CTYPE: "UTF-8" }
+      : process.env;
+    const result = spawnSync(command, args, { input, encoding: "utf8", env });
     if (result.status === 0) {
       return { ok: true as const, method };
     }
@@ -611,7 +614,10 @@ function writeSystemClipboard(text: string): { ok: true; method: string } | { ok
 
 function readSystemClipboard(): { ok: true; method: string; text: string } | { ok: false; error: string } {
   const run = (command: string, args: string[], method: string) => {
-    const result = spawnSync(command, args, { encoding: "utf8" });
+    const env = process.platform === "darwin"
+      ? { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", LC_CTYPE: "UTF-8" }
+      : process.env;
+    const result = spawnSync(command, args, { encoding: "utf8", env });
     if (result.status === 0) {
       return { ok: true as const, method, text: result.stdout || "" };
     }

--- a/beta/test_server.js
+++ b/beta/test_server.js
@@ -92,7 +92,10 @@ function readRequestBody(req, maxBytes = 1_000_000) {
 function writeSystemClipboard(text) {
   const input = Buffer.from(text, "utf8");
   const run = (command, args, method) => {
-    const result = spawnSync(command, args, { input, encoding: "utf8" });
+    const env = process.platform === "darwin"
+      ? { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", LC_CTYPE: "UTF-8" }
+      : process.env;
+    const result = spawnSync(command, args, { input, encoding: "utf8", env });
     if (result.status === 0) return { ok: true, method };
     const detail = result.stderr || (result.error && result.error.message) || `${command} exited with status ${result.status}`;
     return { ok: false, error: detail };
@@ -111,7 +114,10 @@ function writeSystemClipboard(text) {
 
 function readSystemClipboard() {
   const run = (command, args, method) => {
-    const result = spawnSync(command, args, { encoding: "utf8" });
+    const env = process.platform === "darwin"
+      ? { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", LC_CTYPE: "UTF-8" }
+      : process.env;
+    const result = spawnSync(command, args, { encoding: "utf8", env });
     if (result.status === 0) return { ok: true, method, text: result.stdout || "" };
     const detail = result.stderr || (result.error && result.error.message) || `${command} exited with status ${result.status}`;
     return { ok: false, error: detail };

--- a/beta/tests/e2e/node_path_copy.spec.js
+++ b/beta/tests/e2e/node_path_copy.spec.js
@@ -1,0 +1,100 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { spawnSync } = require("node:child_process");
+
+const TARGET_SCOPE_ID = "n_1785589333513_xiueid";
+
+function mapPayload() {
+  return {
+    version: 1,
+    savedAt: new Date().toISOString(),
+    state: {
+      rootId: "n_1775394076217_d83f66",
+      nodes: {
+        n_1775394076217_d83f66: {
+          id: "n_1775394076217_d83f66",
+          parentId: null,
+          children: [TARGET_SCOPE_ID],
+          nodeType: "folder",
+          text: "定例会",
+          collapsed: false,
+          details: "",
+          note: "",
+          attributes: {},
+          link: "",
+        },
+        [TARGET_SCOPE_ID]: {
+          id: TARGET_SCOPE_ID,
+          parentId: "n_1775394076217_d83f66",
+          children: [],
+          nodeType: "folder",
+          text: "8月",
+          collapsed: false,
+          details: "",
+          note: "",
+          attributes: {},
+          link: "",
+        },
+      },
+    },
+  };
+}
+
+function readMacClipboard() {
+  if (process.platform !== "darwin") return null;
+  const env = { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", LC_CTYPE: "UTF-8" };
+  const result = spawnSync("pbpaste", [], { encoding: "utf8", env });
+  if (result.status !== 0) throw new Error(result.stderr || "pbpaste failed");
+  return result.stdout;
+}
+
+async function createAndOpenMap(page, request) {
+  const mapId = `map-node-path-copy-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+  const response = await request.post(`/api/maps/${encodeURIComponent(mapId)}`, { data: mapPayload() });
+  expect(response.status()).toBe(200);
+  await page.goto(`/viewer.html?localMapId=${encodeURIComponent(mapId)}`);
+  await expect(page.locator("#meta")).toContainText("nodes: 2", { timeout: 15_000 });
+  await page.getByRole("button", { name: "Hide inspector" }).click();
+  await page.locator("#board").click({ position: { x: 500, y: 500 } });
+  await page.keyboard.press("Alt+v");
+  await page.waitForTimeout(300);
+}
+
+async function invokeContextMenuCopy(page) {
+  const scopeHit = page.locator(`rect.node-hit[data-node-id="${TARGET_SCOPE_ID}"]`);
+  await expect(scopeHit).toBeVisible();
+  await scopeHit.click({ button: "right", force: true });
+  const copyItem = page.locator(".scope-context-menu-item", { hasText: "Copy path" });
+  await expect(copyItem).toBeVisible();
+  await copyItem.click();
+}
+
+test("scope context menu copies the reported node path through the system clipboard route", async ({ page, request }, testInfo) => {
+  await createAndOpenMap(page, request);
+  await invokeContextMenuCopy(page);
+
+  const expected = "M:(定例会)> 8月";
+  await expect(page.locator("#status")).toContainText(`Path copied: ${expected}`);
+  if (process.platform === "darwin") expect(readMacClipboard()).toBe(expected);
+  await page.screenshot({ path: testInfo.outputPath("node-path-copy-success.png") });
+});
+
+test("scope context menu reports failure when every clipboard route is unavailable", async ({ page, request }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: () => Promise.reject(new Error("clipboard disabled for test")) },
+    });
+  });
+  await page.route("**/api/system-clipboard/write", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: false, error: "clipboard disabled for test" }),
+    });
+  });
+  await createAndOpenMap(page, request);
+  await invokeContextMenuCopy(page);
+
+  await expect(page.locator("#status")).toContainText("Failed to copy node path to system clipboard.");
+});

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -51,7 +51,8 @@ function shortcutFixtureWithGraphLink() {
 
 function readMacClipboard() {
   if (process.platform !== "darwin") return null;
-  const result = spawnSync("pbpaste", [], { encoding: "utf8" });
+  const env = { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", LC_CTYPE: "UTF-8" };
+  const result = spawnSync("pbpaste", [], { encoding: "utf8", env });
   if (result.status !== 0) {
     throw new Error(result.stderr || "pbpaste failed");
   }


### PR DESCRIPTION
## Summary
- route scope context-menu copy and keyboard copy through the same verified system clipboard path
- report copy success and failure instead of silently swallowing Clipboard API failures
- resolve unknown map labels from the loaded map root, producing M:(定例会)> 8月 for the reported Swingby scope
- force a valid UTF-8 locale for macOS pbcopy/pbpaste so Japanese paths are not empty or corrupted

## Verification
- npm run build
- npm run test:unit (563 passed, 12 skipped)
- npm run lint:deps
- Playwright E2E with scope n_1785589333513_xiueid: success copy and forced failure reporting (2 passed)
- existing Ctrl+Alt+C Playwright test (1 passed)
- screenshot visually inspected with Path copied: M:(定例会)> 8月