### PR TITLE
fix(beta): widen inline node editor

### DIFF
--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -4497,7 +4497,7 @@ function syncInlineEditorPosition(): void {
   inlineEditor.input.style.left = `${left}px`;
   inlineEditor.input.style.top = `${top}px`;
   inlineEditor.input.style.width = `${width}px`;
-  inlineEditor.input.style.minWidth = `${width}px`;
+  inlineEditor.input.style.minWidth = "40ch";
   inlineEditor.input.style.minHeight = `${height}px`;
   inlineEditor.input.style.fontSize = `${fontSize}px`;
   inlineEditor.input.style.lineHeight = `${lineHeight}px`;

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -210,6 +210,13 @@ test.describe("Tab: add child node", () => {
     expect(editorMetrics.configuredMinWidth).toBe("40ch");
     expect(editorMetrics.unscaledEditorWidth).toBeGreaterThanOrEqual(editorMetrics.computedMinWidth - 1);
 
+    await editor.fill("あ".repeat(80));
+    const wrappedLineCount = await editor.evaluate((element) => {
+      const lineHeight = Number.parseFloat(getComputedStyle(element).lineHeight);
+      return Math.round(element.scrollHeight / lineHeight);
+    });
+    expect(wrappedLineCount).toBeLessThanOrEqual(4);
+
     // Escape to finish editing.
     await pressKey(page, "Escape");
     await waitForRender(page);

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -195,8 +195,20 @@ test.describe("Tab: add child node", () => {
     await pressKey(page, "Tab");
     await waitForRender(page);
 
-    // An inline editor should appear (input element).
-    await expect(page.locator("textarea.inline-node-editor")).toBeVisible();
+    // An inline editor should appear and keep enough width for sentence entry.
+    const editor = page.locator("textarea.inline-node-editor");
+    await expect(editor).toBeVisible();
+    const editorMetrics = await editor.evaluate((element) => {
+      const style = getComputedStyle(element);
+      const transform = new DOMMatrixReadOnly(style.transform);
+      return {
+        configuredMinWidth: element.style.minWidth,
+        computedMinWidth: Number.parseFloat(style.minWidth),
+        unscaledEditorWidth: element.getBoundingClientRect().width / transform.a,
+      };
+    });
+    expect(editorMetrics.configuredMinWidth).toBe("40ch");
+    expect(editorMetrics.unscaledEditorWidth).toBeGreaterThanOrEqual(editorMetrics.computedMinWidth - 1);
 
     // Escape to finish editing.
     await pressKey(page, "Escape");


### PR DESCRIPTION
## Summary
- set inline node editor minimum width to 40ch
- keep wider existing node widths unchanged
- add a Playwright regression assertion for new-node editing

## Verification
- npm run typecheck
- npm run build:browser
- npm run test:shortcuts -- --grep "Inline editing|Tab creates a child node" (3 passed)