### PR TITLE
Fix Progressive Navigation ancestor jitter

### DIFF
--- a/beta/src/shared/pn_layout.ts
+++ b/beta/src/shared/pn_layout.ts
@@ -294,7 +294,7 @@ function placeNodes(
   visibleReason: Map<PnId, PnPlacedNode["visibleReason"]>,
   overlayRect: PnRect,
   mode: InternalMode,
-): { nodes: PnPlacedNode[]; nodeRectsById: Record<PnId, PnRect>; overflow: PnLayoutOutput["overflow"] } {
+): { overlayRect: PnRect; nodes: PnPlacedNode[]; nodeRectsById: Record<PnId, PnRect>; overflow: PnLayoutOutput["overflow"] } {
   const { nodeById, childrenByParent } = buildIndexes(input.nodes);
   const size = estimateSize(input, visibleNodeIds, mode);
   const direction: Direction = "right";
@@ -329,18 +329,24 @@ function placeNodes(
 
   const renderedIds = visibleNodeIds.filter((id) => id !== input.rootId && byId[id]);
   const minTop = Math.min(0, ...renderedIds.map((id) => byId[id]!.y));
-  const maxBottom = Math.max(overlayRect.h, ...renderedIds.map((id) => rectBottom(byId[id]!)));
+  let effectiveOverlayRect = overlayRect;
   if (minTop < 0) {
-    renderedIds.forEach((id) => {
+    // Rebase the overlay, rather than moving the rendered cards. A newly
+    // visible descendant can extend above the candidate rect; shifting only
+    // cards down makes the already-selected ancestor chain jump on screen.
+    const rebaseY = minTop - 12;
+    Object.keys(byId).forEach((id) => {
       const current = byId[id]!;
-      byId[id] = rect(current.x, current.y - minTop + 12, current.w, current.h);
+      byId[id] = rect(current.x, current.y - rebaseY, current.w, current.h);
     });
+    effectiveOverlayRect = rect(overlayRect.x, overlayRect.y + rebaseY, overlayRect.w, overlayRect.h - rebaseY);
   }
+  const maxBottom = Math.max(effectiveOverlayRect.h, ...renderedIds.map((id) => rectBottom(byId[id]!)));
   const clippedIds = renderedIds.filter((id) => {
     const item = byId[id]!;
-    return item.x < 0 || item.y < 0 || rectRight(item) > overlayRect.w || rectBottom(item) > overlayRect.h;
+    return item.x < 0 || item.y < 0 || rectRight(item) > effectiveOverlayRect.w || rectBottom(item) > effectiveOverlayRect.h;
   });
-  const overflowMode: PnOverflowMode = clippedIds.length > 0 || maxBottom > overlayRect.h
+  const overflowMode: PnOverflowMode = clippedIds.length > 0 || maxBottom > effectiveOverlayRect.h
     ? mode === "fixed-side-panel" ? "side-panel" : mode === "compact" ? "compact" : "scroll"
     : "none";
 
@@ -359,12 +365,13 @@ function placeNodes(
   });
 
   return {
+    overlayRect: effectiveOverlayRect,
     nodes: placed,
     nodeRectsById: byId,
     overflow: {
       mode: overflowMode,
       clippedIds,
-      ...(overflowMode === "none" ? {} : { scrollRect: rect(0, 0, overlayRect.w, overlayRect.h) }),
+      ...(overflowMode === "none" ? {} : { scrollRect: rect(0, 0, effectiveOverlayRect.w, effectiveOverlayRect.h) }),
     },
   };
 }
@@ -466,18 +473,18 @@ export function layoutProgressiveNav(input: PnLayoutInput): PnLayoutOutput {
     const size = estimateSize(input, visibility.visibleNodeIds, mode);
     const overlayRect = candidateRect(input, mode, size);
     const placed = placeNodes(input, visibility.visibleNodeIds, visibility.pathIds, visibility.visibleReason, overlayRect, mode);
-    const candidateCanvasScore = canvasScore(overlayRect, placed.nodes, input.safeZones);
-    const candidateOverlapScore = weightedScore(overlayRect, placed.nodes, input.safeZones, input.viewport);
+    const candidateCanvasScore = canvasScore(placed.overlayRect, placed.nodes, input.safeZones);
+    const candidateOverlapScore = weightedScore(placed.overlayRect, placed.nodes, input.safeZones, input.viewport);
     const decision: PnPlacementDecision = {
       mode,
-      rect: overlayRect,
+      rect: placed.overlayRect,
       overlapScore: candidateOverlapScore,
       canvasNodeOverlapScore: candidateCanvasScore,
       trialOrder,
       rejected: [...rejected],
     };
     const output: PnLayoutOutput = {
-      overlayRect,
+      overlayRect: placed.overlayRect,
       placement: decision,
       visibleNodeIds: visibility.visibleNodeIds,
       pathIds: visibility.pathIds,
@@ -485,13 +492,13 @@ export function layoutProgressiveNav(input: PnLayoutInput): PnLayoutOutput {
       nodeRectsById: placed.nodeRectsById,
       edges: routeEdges(input, visibility.visibleNodeIds, visibility.pathIds, placed.nodeRectsById, mode),
       focusOrder: visibility.visibleNodeIds.filter((id) => id !== input.rootId),
-      overflow: explicitOverflow(placed.overflow, overlayRect, input.viewport, mode),
+      overflow: explicitOverflow(placed.overflow, placed.overlayRect, input.viewport, mode),
     };
     if (!best || candidateCanvasScore < best.placement.canvasNodeOverlapScore) {
       best = output;
     }
     if (candidateCanvasScore === 0 || trialOrder.length === 1) return output;
-    rejected.push({ mode, rect: overlayRect, overlapScore: candidateOverlapScore, canvasNodeOverlapScore: candidateCanvasScore });
+    rejected.push({ mode, rect: placed.overlayRect, overlapScore: candidateOverlapScore, canvasNodeOverlapScore: candidateCanvasScore });
   }
 
   if (!best) {

--- a/beta/tests/unit/pn_layout_contract.test.ts
+++ b/beta/tests/unit/pn_layout_contract.test.ts
@@ -12,6 +12,40 @@ export const pnNodes: PnNode[] = [
   { id: "board", label: "Board", hint: "file", parentId: "gui" },
 ];
 
+const stabilityNodes: PnNode[] = [
+  { id: "root", label: "Root", hint: "root" },
+  { id: "a", label: "A", hint: "level 1", parentId: "root" },
+  { id: "b", label: "B", hint: "level 2", parentId: "a" },
+  { id: "s", label: "Sibling", hint: "level 2", parentId: "a" },
+  { id: "c1", label: "C1", hint: "level 3", parentId: "b" },
+  { id: "c2", label: "C2", hint: "level 3", parentId: "b" },
+  { id: "c3", label: "C3", hint: "level 3", parentId: "b" },
+  { id: "c4", label: "C4", hint: "level 3", parentId: "b" },
+  { id: "c5", label: "C5", hint: "level 3", parentId: "b" },
+  { id: "c6", label: "C6", hint: "level 3", parentId: "b" },
+  { id: "c7", label: "C7", hint: "level 3", parentId: "b" },
+  { id: "c8", label: "C8", hint: "level 3", parentId: "b" },
+  { id: "d1", label: "D1", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d2", label: "D2", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d3", label: "D3", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d4", label: "D4", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d5", label: "D5", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d6", label: "D6", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d7", label: "D7", hint: "level 4", parentId: "c1", action: "command" },
+  { id: "d8", label: "D8", hint: "level 4", parentId: "c1", action: "command" },
+];
+
+function screenRect(result: ReturnType<typeof layoutProgressiveNav>, nodeId: string) {
+  const node = result.nodes.find((entry) => entry.id === nodeId);
+  if (!node) throw new Error(`missing node ${nodeId}`);
+  return {
+    x: result.overlayRect.x + node.rect.x,
+    y: result.overlayRect.y + node.rect.y,
+    w: node.rect.w,
+    h: node.rect.h,
+  };
+}
+
 function input(overrides: Partial<PnLayoutInput> = {}): PnLayoutInput {
   const metrics = Object.fromEntries(pnNodes.map((node) => [node.id, { w: node.id === "gui" ? 44 : 172, h: node.id === "gui" ? 44 : 47 }]));
   return {
@@ -28,6 +62,25 @@ function input(overrides: Partial<PnLayoutInput> = {}): PnLayoutInput {
 }
 
 describe("layoutProgressiveNav contract", () => {
+  test("keeps existing ancestor cards stationary when a selected child reveals descendants", () => {
+    const metrics = Object.fromEntries(stabilityNodes.map((node) => [node.id, { w: node.id === "root" ? 44 : 172, h: node.id === "root" ? 44 : 47 }]));
+    const common = {
+      nodes: stabilityNodes,
+      rootId: "root",
+      anchorRect: { x: 48, y: 340, w: 44, h: 44 },
+      viewport: { width: 1200, height: 720, zoom: 1 },
+      safeZones: [],
+      nodeMetrics: metrics,
+      options: { routeStyle: "orthogonal" as const },
+    };
+    const base = layoutProgressiveNav({ ...common, activeId: "b" });
+    const deeper = layoutProgressiveNav({ ...common, activeId: "c1" });
+
+    for (const id of ["a", "b", "c1"]) {
+      expect(screenRect(deeper, id)).toEqual(screenRect(base, id));
+    }
+  });
+
   test("returns visible path, focus order, placed rects, overflow state, and EdgePort route metadata", () => {
     const result = layoutProgressiveNav(input());
 


### PR DESCRIPTION
## What changed\n- rebase the Progressive Navigation overlay when descendants extend above its candidate area\n- preserve screen coordinates of already-rendered ancestor cards\n- add a regression test for expanding a child with a tall descendant list\n\n## Verification\n- ./beta/node_modules/.bin/vitest run beta/tests/unit/pn_layout_contract.test.ts beta/tests/unit/pn_layout_golden.test.ts\n- npm run build (beta)\n- M3E_PORT=14175 ./node_modules/.bin/playwright test tests/visual/workbench_progressive_nav.spec.js --config playwright.config.js (7 passed)