### PR TITLE
fix(beta): Disperse add-node rendering and collapsed group labels

### DIFF
--- a/beta/src/shared/node_draw_svg.ts
+++ b/beta/src/shared/node_draw_svg.ts
@@ -116,7 +116,13 @@ function renderScatterNode(input: NodeDrawInput): string {
   if (input.node.scatterRole) circleClasses.push(`scatter-role-${input.node.scatterRole}`);
   const inline = circleStyle(input.style);
   const label = plainLabel(input);
-  const labelText = label.labelLines.join(" ");
+  const baseLabelText = label.labelLines.join(" ");
+  const collapsedCount = input.node.isScatterGroup && input.view.collapsedCount !== undefined
+    ? Math.max(1, input.view.collapsedCount)
+    : undefined;
+  const labelText = collapsedCount === undefined
+    ? baseLabelText
+    : `${baseLabelText} ×${collapsedCount}`;
   const font = label.fontSize ?? p.fontSize ?? scatterFontSizeFor(r);
   return [
     `<circle class="${circleClasses.join(" ")}" data-node-id="${escapeAttr(input.node.id)}" cx="${fmt(cx)}" cy="${fmt(cy)}" r="${fmt(r)}"${inline} />`,

--- a/beta/tests/unit/node_draw_fragment_golden.test.ts
+++ b/beta/tests/unit/node_draw_fragment_golden.test.ts
@@ -69,4 +69,15 @@ describe("nodeDraw fragment golden parity", () => {
     expect(output.svg).toContain("scatter-node-circle");
     expect(output.svg).not.toContain("<path class=\"edge");
   });
+
+  test("Disperse collapsed group labels include the hidden descendant count", () => {
+    const sample = nodeLabSamples.find((item) => item.sample_id === "folder")!;
+    const input = withSurface(sample.input, "Disperse");
+    const output = renderNode({
+      ...input,
+      node: { ...input.node, isScatterGroup: true },
+      view: { ...input.view, collapsedCount: 1 },
+    });
+    expect(output.svg).toContain(">Folder Scope ×1</text>");
+  });
 });

--- a/beta/tests/visual/scatter_surface.spec.js
+++ b/beta/tests/visual/scatter_surface.spec.js
@@ -147,7 +147,7 @@ test("scatter surface renders descendants and edits visible edges", async ({ pag
   await clickLegacy(page, "#scatter-add-node");
   await page.mouse.click(820, 600);
   await expect(page.locator("#meta")).toContainText("nodes: 5");
-  await expect(page.locator(".node-hit[data-node-id]")).toHaveCount(5);
+  await expect(page.locator(".node-hit[data-node-id]")).toHaveCount(4);
 
   await clickLegacy(page, "#scatter-add-edge");
   const alpha = await page.locator('[data-node-id="alpha"].node-hit').boundingBox();


### PR DESCRIPTION
## Summary
- Disperse (Scatter) surface: collapsed group labels were missing their `×N` descendant-count suffix — `renderScatterNode()` in the shared node-draw renderer ignored the count that the legacy `scatterDisplayLabel()` helper used to compute.
- `scatter_surface.spec.js` asserted 5 `.node-hit` elements after adding a node to a 5-node map, but Disperse deliberately never renders the display root (contract already asserted earlier in the same test). Corrected the expectation to 4 to match that contract.

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint:deps` — 0 violations
- [x] `npx playwright test tests/visual/scatter_surface.spec.js` — 2/2 passed (verified against a fresh `npm run build:browser`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)