### PR TITLE
test(beta): fix flaky selection race and stale pen-tool selectors

### DIFF
--- a/beta/tests/visual/pen_annotations.spec.js
+++ b/beta/tests/visual/pen_annotations.spec.js
@@ -60,7 +60,8 @@ test("pen tool draws an SVG stroke and supports undo", async ({ page }) => {
   await launchViewer(page, map);
   await focusBoard(page);
 
-  await page.click("#pen-tool");
+  const penTool = page.getByTestId("workbench-left-rail").getByRole("button", { name: "Pen" });
+  await penTool.click();
   await expect(page.locator("#pen-tool")).toHaveAttribute("aria-pressed", "true");
 
   const boardBox = await page.locator("#board").boundingBox();
@@ -86,11 +87,13 @@ test("drawing toolbar controls pen style and date labels", async ({ page }) => {
   await launchViewer(page, map);
   await focusBoard(page);
 
-  await expect(page.locator("#draw-toolbar")).toBeVisible();
-  await page.click("#draw-pen");
+  const workbenchPanel = page.getByTestId("workbench-right-panel");
+  await expect(workbenchPanel.getByText("Annotation")).toBeVisible();
+  const workbenchPenTool = page.getByTestId("workbench-left-rail").getByRole("button", { name: "Pen" });
+  await workbenchPenTool.click();
   await expect(page.locator("#draw-pen")).toHaveClass(/is-active/);
-  await page.click('[data-pen-color="#e64980"]');
-  await page.locator("#pen-width").evaluate((el) => {
+  await workbenchPanel.getByRole("button", { name: "Stroke #e64980" }).click();
+  await workbenchPanel.getByRole("slider").evaluate((el) => {
     const input = /** @type {HTMLInputElement} */ (el);
     input.value = "4";
     input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -110,7 +113,7 @@ test("drawing toolbar controls pen style and date labels", async ({ page }) => {
   page.once("dialog", async (dialog) => {
     await dialog.accept("4/26");
   });
-  await page.click("#draw-date");
+  await page.getByTestId("workbench-left-rail").getByRole("button", { name: "Date label" }).click();
   await page.mouse.click(boardBox.x + 360, boardBox.y + 310);
   await waitForRender(page);
   await expect(page.locator("text.annotation-text-date")).toHaveText("4/26");

--- a/beta/tests/visual/shortcuts.spec.js
+++ b/beta/tests/visual/shortcuts.spec.js
@@ -157,8 +157,7 @@ test.describe("Shift+Arrow selection extension", () => {
     const before = await getSelectedCount(page);
 
     await pressKey(page, "Shift+ArrowDown");
-    const after = await getSelectedCount(page);
-    expect(after).toBeGreaterThan(before);
+    await expect.poll(() => getSelectedCount(page)).toBeGreaterThan(before);
   });
 
   test("Shift+ArrowDown extends further on consecutive presses from root", async ({ page }) => {
@@ -166,13 +165,12 @@ test.describe("Shift+Arrow selection extension", () => {
     await focusBoard(page);
 
     await pressKey(page, "Shift+ArrowDown");
+    await expect.poll(() => getSelectedCount(page)).toBeGreaterThanOrEqual(2);
     const afterOne = await getSelectedCount(page);
-    expect(afterOne).toBeGreaterThanOrEqual(2);
 
     await pressKey(page, "Shift+ArrowDown");
-    const afterTwo = await getSelectedCount(page);
     // Second press should keep or extend selection (layout-dependent).
-    expect(afterTwo).toBeGreaterThanOrEqual(afterOne);
+    await expect.poll(() => getSelectedCount(page)).toBeGreaterThanOrEqual(afterOne);
   });
 });
 


### PR DESCRIPTION
## Summary
- `Shift+ArrowDown` selection-extension tests read the selected-node count before `scheduleRender()` had flushed to the DOM — a render race, not a product bug. Switched to `expect.poll` so the assertions wait for the actual post-render count. Confirmed via source read that root + 1 child (2 nodes) is the correct outcome of a single press from root (`viewer.ts:15466-15484`, `layout_port.ts:452`).
- `pen_annotations.spec.js` was targeting `#pen-tool` / `#draw-pen`, legacy hidden-toolbar selectors (`pointer-events: none`) that sit underneath the current workbench UI (z-index 30) and were intercepting clicks. Real users go through the workbench left-rail / right-panel controls, which don't have this problem. Updated the spec to target the current workbench selectors.

System-clipboard-dependent tests (`Ctrl+C`/`Ctrl+V` across tabs/maps, `Ctrl+Alt+C`, `Ctrl+Alt+I`) were left untouched — suspected environment/permission dependency, out of scope here.

One pre-existing failure (`Ctrl+G groups multiple selected nodes under a new parent`) remains and is not addressed by this PR.

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint:deps` — 0 violations
- [x] `npx playwright test tests/visual/shortcuts.spec.js tests/visual/pen_annotations.spec.js` — target failures resolved (verified against a fresh `npm run build:browser`); one pre-existing, out-of-scope failure remains (`Ctrl+G` grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)