### PR TITLE
refactor(beta): harden table view projection

### DIFF
--- a/beta/src/browser/table_view.ts
+++ b/beta/src/browser/table_view.ts
@@ -1,0 +1,103 @@
+export interface TableViewChild {
+  id: string;
+  text: string;
+  details: string;
+  attributes: Readonly<Record<string, string>>;
+}
+
+export interface TableViewParent {
+  children: readonly string[];
+}
+
+export type TableViewNodeMap = Readonly<Record<string, TableViewChild | undefined>>;
+
+export interface TableViewModel {
+  children: readonly TableViewChild[];
+  attributeColumns: readonly string[];
+  includeDetails: boolean;
+}
+
+const TABLE_STATUS_CLASSES = new Set([
+  "placeholder",
+  "confirmed",
+  "contested",
+  "frozen",
+  "active",
+  "review",
+]);
+
+/** Resolve only the children named by the canonical parent-child edge list. */
+export function directTableViewChildren(
+  parent: TableViewParent,
+  nodes: TableViewNodeMap,
+): TableViewChild[] {
+  return parent.children
+    .map((childId) => Object.prototype.hasOwnProperty.call(nodes, childId) ? nodes[childId] : undefined)
+    .filter((child): child is TableViewChild => Boolean(child));
+}
+
+/** Build metadata for a table without copying or mutating canonical child data. */
+export function buildTableViewModel(children: readonly TableViewChild[]): TableViewModel {
+  const attributeKeys = new Set<string>();
+  for (const child of children) {
+    for (const key of Object.keys(child.attributes)) {
+      if (!key.startsWith("m3e:")) attributeKeys.add(key);
+    }
+  }
+
+  return {
+    children,
+    attributeColumns: Array.from(attributeKeys).sort(),
+    includeDetails: children.some((child) => Boolean(child.details)),
+  };
+}
+
+export function normalizeTableStatus(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const status = raw.trim().toLowerCase();
+  return TABLE_STATUS_CLASSES.has(status) ? status : null;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function childValue(child: TableViewChild, key: string): string {
+  return child.attributes[key] ?? "";
+}
+
+/** Render the table body as escaped HTML; the caller owns placement and sizing. */
+export function renderTableViewHtml(model: TableViewModel): string {
+  let html = '<table class="m3e-table-view" data-component-kind="tabular"><thead><tr><th>Name</th>';
+  for (const key of model.attributeColumns) {
+    html += `<th>${escapeHtml(key)}</th>`;
+  }
+  if (model.includeDetails) html += "<th>Details</th>";
+  html += "</tr></thead><tbody>";
+
+  const columnCount = model.attributeColumns.length + (model.includeDetails ? 1 : 0);
+  if (model.children.length === 0) {
+    html += `<tr class="m3e-table-empty-row"><td class="m3e-table-empty" colspan="${Math.max(1, columnCount + 1)}">No rows</td></tr>`;
+  } else {
+    for (const child of model.children) {
+      const childId = escapeHtml(child.id);
+      const status = normalizeTableStatus(child.attributes["m3e:status"]);
+      html += `<tr data-node-id="${childId}"${status ? ` class="status-${status}"` : ""}>`;
+      html += `<td class="m3e-table-name" data-node-id="${childId}">${escapeHtml(child.text || "(empty)")}</td>`;
+      for (const key of model.attributeColumns) {
+        html += `<td data-node-id="${childId}">${escapeHtml(childValue(child, key))}</td>`;
+      }
+      if (model.includeDetails) {
+        html += `<td data-node-id="${childId}">${escapeHtml(child.details)}</td>`;
+      }
+      html += "</tr>";
+    }
+  }
+
+  return `${html}</tbody></table>`;
+}

--- a/beta/src/browser/viewer.ts
+++ b/beta/src/browser/viewer.ts
@@ -29,6 +29,7 @@ import type { EdgeRouteStyle } from "../shared/edge_route";
 import { applyMarkdownLinkNodeInput, editInputForMarkdownLinkNode, isMarkdownLinkSubtype, localPathLinkToOpen, safeExternalLinkToOpen } from "../shared/markdown_link_node";
 import { resolveMarkdownFilePreviewTarget, type MarkdownFilePreviewTarget } from "../shared/markdown_file_preview";
 import { nearestEdgePortSideForGraphLinkEdit } from "./edge_adapters/graphlink_endpoint_edit";
+import { buildTableViewModel, directTableViewChildren, renderTableViewHtml } from "./table_view";
 import {
   type RenderEdge,
   type RenderGroupBoundary,
@@ -3243,13 +3244,6 @@ interface NodeStyleAttrs {
   band: string | null;
   confidence: number | null;
   status: string | null;
-}
-
-const VALID_STATUSES = new Set(["placeholder", "confirmed", "contested", "frozen", "active", "review"]);
-function sanitizeStatus(raw: string | undefined): string | null {
-  if (!raw || typeof raw !== "string") return null;
-  const s = raw.trim().toLowerCase();
-  return VALID_STATUSES.has(s) ? s : null;
 }
 
 /**
@@ -8084,55 +8078,17 @@ function render(): void {
   ): string {
     const parent = state.nodes[parentId];
     if (!parent) return "";
-
-    const childNodes = parent.children
-      .map((cid) => state.nodes[cid])
-      .filter((n): n is TreeNode => !!n);
-
-    const colSet = new Set<string>();
-    for (const child of childNodes) {
-      for (const key of Object.keys(child.attributes || {})) {
-        if (!key.startsWith("m3e:")) colSet.add(key);
-      }
-      if (child.details) colSet.add("_details");
-    }
-    const columns = Array.from(colSet).sort();
-
-    const esc = (s: string) => escapeXml(s);
+    const childNodes = directTableViewChildren(parent, state.nodes);
+    const tableModel = buildTableViewModel(childNodes);
 
     const densityClass = component.props.density === "compact"
       ? "m3e-component--density-compact"
       : "m3e-component--density-regular";
     const maxHeightClass = `m3e-component--max-${component.props.maxHeight}`;
 
-    let html = `<table class="m3e-table-view" data-component-kind="tabular"><thead><tr><th>Name</th>`;
-    for (const col of columns) {
-      html += `<th>${esc(col === "_details" ? "Details" : col)}</th>`;
-    }
-    html += `</tr></thead><tbody>`;
+    const html = renderTableViewHtml(tableModel);
 
-    if (childNodes.length === 0) {
-      html += `<tr class="m3e-table-empty-row"><td class="m3e-table-empty" colspan="${Math.max(1, columns.length + 1)}">No rows</td></tr>`;
-    } else {
-      for (const child of childNodes) {
-        const status = sanitizeStatus(child.attributes?.["m3e:status"]);
-        const statusClass = status ? ` class="status-${status}"` : "";
-        const childIdAttr = escapeXmlAttr(child.id);
-        html += `<tr data-node-id="${childIdAttr}"${statusClass}>`;
-        html += `<td class="m3e-table-name" data-node-id="${childIdAttr}">${esc(child.text || "(empty)")}</td>`;
-        for (const col of columns) {
-          if (col === "_details") {
-            html += `<td data-node-id="${childIdAttr}">${esc(child.details || "")}</td>`;
-          } else {
-            html += `<td data-node-id="${childIdAttr}">${esc(child.attributes?.[col] || "")}</td>`;
-          }
-        }
-        html += `</tr>`;
-      }
-    }
-    html += `</tbody></table>`;
-
-    const tableW = Math.max(columns.length * 150 + 200, 600);
+    const tableW = Math.max(tableModel.attributeColumns.length * 150 + (tableModel.includeDetails ? 150 : 0) + 200, 600);
     const maxHeightPx = component.props.maxHeight === "small" ? 360 : component.props.maxHeight === "large" ? 960 : 720;
     const rowHeight = component.props.density === "compact" ? 28 : 32;
     const tableH = Math.min((Math.max(1, childNodes.length) + 1) * rowHeight + 16, maxHeightPx);
@@ -8345,10 +8301,13 @@ function render(): void {
     maxX = Math.max(maxX, output.bounds.maxX);
     maxY = Math.max(maxY, output.bounds.maxY);
 
-    if (!scatterSurface && isFolderNode(node)) {
+    if (!scatterSurface && !nodeComponent && isFolderNode(node)) {
       nodes += renderFolderPreview(node, nodeStyles, p);
     }
 
+    // In tree surfaces the display root comes through this same path, so a
+    // root-owned table is valid. Rootless surfaces intentionally omit their
+    // hidden display root and therefore cannot anchor a projection there.
     if (nodeComponent) {
       nodes += renderNodeComponent(nodeComponent, nodeId, p);
     } else {

--- a/beta/tests/unit/table_view.test.ts
+++ b/beta/tests/unit/table_view.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTableViewModel,
+  directTableViewChildren,
+  normalizeTableStatus,
+  renderTableViewHtml,
+  type TableViewChild,
+} from "../../src/browser/table_view";
+
+function child(
+  id: string,
+  text: string,
+  attributes: Record<string, string> = {},
+  details = "",
+): TableViewChild {
+  return { id, text, details, attributes };
+}
+
+describe("table view projection", () => {
+  it("resolves direct children in canonical order and ignores missing or nested nodes", () => {
+    const first = child("first", "First");
+    const nested = child("nested", "Nested");
+    const result = directTableViewChildren(
+      { children: ["first", "missing"] },
+      { first, nested },
+    );
+
+    expect(result).toEqual([first]);
+    expect(result).not.toContain(nested);
+  });
+
+  it("derives deterministic union columns and excludes all m3e internal keys", () => {
+    const model = buildTableViewModel([
+      child("a", "A", { zeta: "z", "m3e:status": "active", alpha: "a" }),
+      child("b", "B", { beta: "b", alpha: "a", "m3e:view-type": "table" }),
+    ]);
+
+    expect(model.attributeColumns).toEqual(["alpha", "beta", "zeta"]);
+    expect(model.includeDetails).toBe(false);
+  });
+
+  it("includes one details column when any direct child has details", () => {
+    const model = buildTableViewModel([
+      child("a", "A", { owner: "one" }, "A detail"),
+      child("b", "B", { owner: "two" }),
+    ]);
+
+    const html = renderTableViewHtml(model);
+    expect(html).toContain("<th>owner</th><th>Details</th>");
+    expect(html).toContain(">A detail</td>");
+    expect(html).toContain("data-node-id=\"b\"");
+  });
+
+  it("escapes untrusted IDs, names, keys, values, and details", () => {
+    const html = renderTableViewHtml(buildTableViewModel([
+      child(
+        'row" onmouseover="bad',
+        "<script>alert(1)</script>",
+        { '<img src=x onerror="bad">': "& <b>unsafe</b>" },
+        "</td><script>bad()</script>",
+      ),
+    ]));
+
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("row&quot; onmouseover=&quot;bad");
+    expect(html).toContain("&amp; &lt;b&gt;unsafe&lt;/b&gt;");
+  });
+
+  it("uses only allowlisted normalized status classes", () => {
+    expect(normalizeTableStatus(" CONFIRMED ")).toBe("confirmed");
+    expect(normalizeTableStatus('active" onmouseover="bad')).toBeNull();
+
+    const html = renderTableViewHtml(buildTableViewModel([
+      child("safe", "Safe", { "m3e:status": " CONFIRMED " }),
+      child("unsafe", "Unsafe", { "m3e:status": 'active" onmouseover="bad' }),
+    ]));
+    expect(html).toContain('data-node-id="safe" class="status-confirmed"');
+    expect(html).toContain('data-node-id="unsafe">');
+    expect(html).not.toContain("status-active");
+  });
+});


### PR DESCRIPTION
## Summary
- extracts the existing tabular projection into a pure, testable helper
- preserves the registered `m3e:component` contract and legacy `m3e:view-type="table"` compatibility
- deterministically derives direct-child columns, excludes internal `m3e:` keys, and escapes untrusted values
- allowlists status classes and adds focused unit coverage

This ports the remaining intent of old PR #55 onto current `dev-beta`; it does not merge that stale branch.

## Verification
- `npm run build`
- `npx vitest run tests/unit/table_view.test.ts` (5/5)
- `M3E_PORT=14288 npx playwright test tests/visual/viewer.visual.spec.js --grep tabular` (3/3)